### PR TITLE
Improved 2D camera system

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,75 +1,82 @@
 # Rengine Architecture: Deep Technical Reference
 
-> This document is an **exhaustive, line-by-line technical deep-dive** into the Rengine game engine as it exists on the `re-write` branch. It covers every subsystem from boot to shutdown, every GPU pipeline, every data structure, and every interaction surface. A companion "kitchen-sink" game example at the end demonstrates how to exercise as many features as possible in a single coherent project.
+> This document is an **exhaustive, line-by-line technical deep-dive** into the Rengine game engine as it exists on the `master` branch. It covers every subsystem from boot to shutdown, every GPU pipeline, every data structure, and every interaction surface. A companion "kitchen-sink" game example at the end demonstrates how to exercise as many features as possible in a single coherent project.
 
 ---
 
 ## Table of Contents
 
-1. [Crate Layout](#1-crate-layout)
-2. [Public API Surface (`lib.rs`)](#2-public-api-surface-librs)
-3. [Entry Points and the Game Loop (`app.rs`)](#3-entry-points-and-the-game-loop-apprs)
-   - 3.1 [EngineConfig](#31-engineconfig)
-   - 3.2 [The Engine struct (2D)](#32-the-engine-struct-2d)
-   - 3.3 [`run::<G: Game>()` — the 2D trait-based entry point](#33-rung-game--the-2d-trait-based-entry-point)
-   - 3.4 [The RedrawRequested Frame Cycle](#34-the-redrawrequested-frame-cycle)
-   - 3.5 [`run_with_scenes()` — the scene-stack entry point](#35-run_with_scenes--the-scene-stack-entry-point)
-   - 3.6 [Engine3D and `run3d::<G: Game3D>()`](#36-engine3d-and-run3dg-game3d)
-   - 3.7 [Mouse Capture in 3D Mode](#37-mouse-capture-in-3d-mode)
-4. [The 2D Renderer (`renderer/`)](#4-the-2d-renderer-renderer)
-   - 4.1 [GPU Initialization](#41-gpu-initialization)
-   - 4.2 [The Sprite Pipeline (DrawParams)](#42-the-sprite-pipeline-drawparams)
-   - 4.3 [Texture Management (TextureId)](#43-texture-management-textureid)
-   - 4.4 [Frame Submission and Batched Rendering](#44-frame-submission-and-batched-rendering)
-   - 4.5 [Camera2D and Projection](#45-camera2d-and-projection)
-   - 4.6 [The sprite.wgsl Shader](#46-the-spritewgsl-shader)
-5. [The 3D Renderer (`renderer3d/`)](#5-the-3d-renderer-renderer3d)
-   - 5.1 [Renderer3D Initialization](#51-renderer3d-initialization)
-   - 5.2 [Frame3D and DrawCmd3D](#52-frame3d-and-drawcmd3d)
-   - 5.3 [Viewmodel3D Rendering](#53-viewmodel3d-rendering)
-   - 5.4 [The mesh3d.wgsl Shader](#54-the-mesh3dwgsl-shader)
-   - 5.5 [Mesh Primitives (cube_mesh, floor_quad, wall_quad)](#55-mesh-primitives-cube_mesh-floor_quad-wall_quad)
-6. [Canvas and Text Overlay (`canvas/`, `text.rs`)](#6-canvas-and-text-overlay-canvas-textrs)
-   - 6.1 [FontAtlas Construction](#61-fontatlas-construction)
-   - 6.2 [Canvas Drawing](#62-canvas-drawing)
-   - 6.3 [The canvas.wgsl Shader](#63-the-canvaswgsl-shader)
-   - 6.4 [The FPS Counter](#64-the-fps-counter)
-7. [Input System (`input/`)](#7-input-system-input)
-   - 7.1 [InputState — Keyboard State](#71-inputstate--keyboard-state)
-   - 7.2 [Mouse State](#72-mouse-state)
-   - 7.3 [GamepadSystem and GamepadState](#73-gamepadsystem-and-gamepadstate)
-8. [Asset Pipeline (`assets/`)](#8-asset-pipeline-assets)
-   - 8.1 [AssetPipeline (Internal)](#81-assetpipeline-internal)
-   - 8.2 [AssetManifest and AssetPack](#82-assetmanifest-and-assetpack)
-   - 8.3 [Texture Loading](#83-texture-loading)
-   - 8.4 [SpriteSheet and Animation](#84-spritesheet-and-animation)
-   - 8.5 [3D Mesh Loading (OBJ and glTF)](#85-3d-mesh-loading-obj-and-gltf)
-   - 8.6 [Audio Loading](#86-audio-loading)
-   - 8.7 [Hot Reload](#87-hot-reload)
-   - 8.8 [AssetError](#88-asseterror)
-9. [Audio System (`assets/audio.rs`)](#9-audio-system-assetsaudiors)
-   - 9.1 [AudioBus and Volume](#91-audiobus-and-volume)
-   - 9.2 [Music Playback](#92-music-playback)
-   - 9.3 [Headless Mode](#93-headless-mode)
-10. [Color and Pixel Art (`assets/color.rs`, `assets/pixelart.rs`)](#10-color-and-pixel-art)
-11. [Scene System (`scene/`)](#11-scene-system-scene)
-    - 11.1 [Scene Trait and SceneOp](#111-scene-trait-and-sceneop)
-    - 11.2 [Globals — Typed Key-Value Store](#112-globals--typed-key-value-store)
-    - 11.3 [Scene Stack Dispatch](#113-scene-stack-dispatch)
-    - 11.4 [2D Scene Data (Scene2D, SceneInstance2D, Prefabs, Instances)](#114-2d-scene-data-scene2d-sceneinstance2d-prefabs-instances)
-12. [World Systems (`world/`)](#12-world-systems-world)
-    - 12.1 [TileMap and TileDef](#121-tilemap-and-tiledef)
-    - 12.2 [aabb_overlap — AABB Physics](#122-aabb_overlap--aabb-physics)
-    - 12.3 [iso_to_screen / screen_to_iso — Isometric Helpers](#123-iso_to_screen--screen_to_iso--isometric-helpers)
-13. [Math Utilities (`math/`)](#13-math-utilities-math)
-    - 13.1 [Rect](#131-rect)
-    - 13.2 [TimeState](#132-timestate)
-14. [Rollback Netcode (`netcode/`, feature-gated)](#14-rollback-netcode-netcode-feature-gated)
-    - 14.1 [Architecture Overview (Rollbackable)](#141-architecture-overview-rollbackable)
-    - 14.2 [RollbackSession](#142-rollbacksession)
-    - 14.3 [UdpNonBlockingSocket — UDP Transport](#143-udpnonblockingsocket--udp-transport)
-15. [Complete Frame Lifecycle: Boot to Pixel](#15-complete-frame-lifecycle-boot-to-pixel)
-16. [Kitchen-Sink Game Example](#16-kitchen-sink-game-example)
+- [Rengine Architecture: Deep Technical Reference](#rengine-architecture-deep-technical-reference)
+  - [Table of Contents](#table-of-contents)
+  - [1. Crate Layout](#1-crate-layout)
+  - [2. Public API Surface (`lib.rs`)](#2-public-api-surface-librs)
+  - [3. Entry Points and the Game Loop (`app.rs`)](#3-entry-points-and-the-game-loop-apprs)
+    - [3.1 `EngineConfig`](#31-engineconfig)
+    - [3.2 The `Engine` struct (2D)](#32-the-engine-struct-2d)
+    - [3.3 `run::<G: Game>()` — the 2D trait-based entry point](#33-rung-game--the-2d-trait-based-entry-point)
+    - [3.4 The RedrawRequested Frame Cycle](#34-the-redrawrequested-frame-cycle)
+    - [3.5 `run_with_scenes()` — the scene-stack entry point](#35-run_with_scenes--the-scene-stack-entry-point)
+    - [3.6 `Engine3D` and `run3d::<G: Game3D>()`](#36-engine3d-and-run3dg-game3d)
+    - [3.7 Mouse Capture in 3D Mode](#37-mouse-capture-in-3d-mode)
+  - [4. The 2D Renderer (`renderer/`)](#4-the-2d-renderer-renderer)
+    - [4.1 GPU Initialization](#41-gpu-initialization)
+    - [4.2 The Sprite Pipeline (`DrawParams`)](#42-the-sprite-pipeline-drawparams)
+    - [4.3 Texture Management (`TextureId`)](#43-texture-management-textureid)
+    - [4.4 `Frame` Submission and Batched Rendering](#44-frame-submission-and-batched-rendering)
+    - [4.5 `Camera2D` and Projection](#45-camera2d-and-projection)
+    - [4.6 The sprite.wgsl Shader](#46-the-spritewgsl-shader)
+  - [5. The 3D Renderer (`renderer3d/`)](#5-the-3d-renderer-renderer3d)
+    - [5.1 `Renderer3D` Initialization](#51-renderer3d-initialization)
+    - [5.2 `Frame3D` and `DrawCmd3D`](#52-frame3d-and-drawcmd3d)
+    - [5.3 `Viewmodel3D` Rendering](#53-viewmodel3d-rendering)
+    - [5.4 The mesh3d.wgsl Shader](#54-the-mesh3dwgsl-shader)
+    - [5.5 Mesh Primitives (`cube_mesh`, `floor_quad`, `wall_quad`)](#55-mesh-primitives-cube_mesh-floor_quad-wall_quad)
+    - [`Camera3D`](#camera3d)
+  - [6. Canvas and Text Overlay (`canvas/`, `text.rs`)](#6-canvas-and-text-overlay-canvas-textrs)
+    - [6.1 `FontAtlas` Construction](#61-fontatlas-construction)
+    - [6.2 `Canvas` Drawing](#62-canvas-drawing)
+    - [6.3 The canvas.wgsl Shader](#63-the-canvaswgsl-shader)
+    - [6.4 The FPS Counter](#64-the-fps-counter)
+  - [7. Input System (`input/`)](#7-input-system-input)
+    - [7.1 `InputState` — Keyboard State](#71-inputstate--keyboard-state)
+    - [7.2 Mouse State](#72-mouse-state)
+    - [7.3 `GamepadSystem` and `GamepadState`](#73-gamepadsystem-and-gamepadstate)
+  - [8. Asset Pipeline (`assets/`)](#8-asset-pipeline-assets)
+    - [8.1 `AssetPipeline` (Internal)](#81-assetpipeline-internal)
+    - [8.2 `AssetManifest` and `AssetPack`](#82-assetmanifest-and-assetpack)
+    - [8.3 Texture Loading](#83-texture-loading)
+    - [8.4 `SpriteSheet` and `Animation`](#84-spritesheet-and-animation)
+    - [8.5 3D Mesh Loading (OBJ and glTF)](#85-3d-mesh-loading-obj-and-gltf)
+    - [8.6 Audio Loading](#86-audio-loading)
+    - [8.7 Hot Reload](#87-hot-reload)
+    - [8.8 `AssetError`](#88-asseterror)
+  - [9. Audio System (`assets/audio.rs`)](#9-audio-system-assetsaudiors)
+    - [9.1 `AudioBus` and Volume](#91-audiobus-and-volume)
+    - [9.2 Music Playback](#92-music-playback)
+    - [9.3 Headless Mode](#93-headless-mode)
+  - [10. Color and Pixel Art](#10-color-and-pixel-art)
+    - [`Color`](#color)
+    - [`PixelCanvas` (Procedural Texture Generation)](#pixelcanvas-procedural-texture-generation)
+  - [11. Scene System (`scene/`)](#11-scene-system-scene)
+    - [11.1 `Scene` Trait and `SceneOp`](#111-scene-trait-and-sceneop)
+    - [11.2 `Globals` — Typed Key-Value Store](#112-globals--typed-key-value-store)
+    - [11.3 Scene Stack Dispatch](#113-scene-stack-dispatch)
+    - [11.4 2D Scene Data (`Scene2D`, `SceneInstance2D`, Prefabs, Instances)](#114-2d-scene-data-scene2d-sceneinstance2d-prefabs-instances)
+  - [12. World Systems (`world/`)](#12-world-systems-world)
+    - [12.1 `TileMap` and `TileDef`](#121-tilemap-and-tiledef)
+    - [12.2 `aabb_overlap` — AABB Physics](#122-aabb_overlap--aabb-physics)
+    - [12.3 `iso_to_screen` / `screen_to_iso` — Isometric Helpers](#123-iso_to_screen--screen_to_iso--isometric-helpers)
+  - [13. Math Utilities (`math/`)](#13-math-utilities-math)
+    - [13.1 `Rect`](#131-rect)
+    - [13.2 `TimeState`](#132-timestate)
+  - [14. Rollback Netcode (`netcode/`, feature-gated)](#14-rollback-netcode-netcode-feature-gated)
+    - [14.1 Architecture Overview (`Rollbackable`)](#141-architecture-overview-rollbackable)
+    - [14.2 `RollbackSession`](#142-rollbacksession)
+    - [14.3 `UdpNonBlockingSocket` — UDP Transport](#143-udpnonblockingsocket--udp-transport)
+  - [15. Complete Frame Lifecycle: Boot to Pixel](#15-complete-frame-lifecycle-boot-to-pixel)
+  - [16. Kitchen-Sink Game Example](#16-kitchen-sink-game-example)
+    - [Features Exercised in This Example](#features-exercised-in-this-example)
+    - [What This Example Does NOT Cover (and How You Would)](#what-this-example-does-not-cover-and-how-you-would)
 
 ---
 
@@ -95,7 +102,7 @@ rengine/
 │       ├── assets/        # AssetPipeline, Color, audio, pixelart, spritesheet
 │       └── netcode/       # (feature "rollback") GGRS integration + UDP transport
 └── samples/
-    ├── features/          # feature-scenes, feature-sprites
+    ├── features/          # feature-scenes, feature-sprites, feature-camera
     └── games/             # game-platformer, game-topdown, game-iso, game-fps, game-fight, game-fps-mp
 ```
 
@@ -118,7 +125,7 @@ default = []
 rollback = ["dep:ggrs", "dep:bincode"]
 ```
 
-When `rollback` is enabled, the `netcode` module is compiled in, exposing [`RollbackSession`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L86), [`Rollbackable`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L73), [`OnlineConfig`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L39), [`SessionMode`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L45), and the [`fletcher64`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L290) checksum function.
+When `rollback` is enabled, the `netcode` module is compiled in, exposing [`RollbackSession`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L86), [`Rollbackable`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L73), [`OnlineConfig`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L39), [`SessionMode`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L45), and the [`fletcher64`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L290) checksum function.
 
 **Key dependencies:**
 | Dependency | Purpose |
@@ -140,7 +147,7 @@ When `rollback` is enabled, the `netcode` module is compiled in, exposing [`Roll
 
 ---
 
-## 2. Public API Surface ([`lib.rs`](https://github.com/justinwash/rengine/blob/re-write/engine/src/lib.rs))
+## 2. Public API Surface ([`lib.rs`](https://github.com/justinwash/rengine/blob/master/engine/src/lib.rs))
 
 `lib.rs` is purely re-exports. It defines zero logic — its entire job is to flatten the internal module tree into a single `rengine::*` namespace:
 
@@ -162,24 +169,24 @@ pub mod netcode;
 
 Then selective re-exports:
 
-- **Core runtime:** [`run`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L291), [`run_with_scenes`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L409), [`Engine`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L47), [`EngineConfig`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L22), [`Game`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L279)
-- **Rendering (2D):** [`Camera2D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/camera.rs#L4), [`DrawParams`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/sprite.rs#L6), [`Frame`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/mod.rs#L21), [`TextureId`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/texture.rs#L2)
-- **Rendering (3D):** [`Camera3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/camera.rs#L4), [`DrawCmd3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L29), [`Frame3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L57), [`MeshId`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mesh.rs#L5), [`Vertex3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mesh.rs#L10), [`Viewmodel3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L35), [`cube_mesh`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mesh.rs#L54), [`floor_quad`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mesh.rs#L107), [`wall_quad`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mesh.rs#L123)
-- **Input:** [`InputState`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L6), `KeyCode` (from winit), `GamepadButton` (from gilrs), [`GamepadState`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/gamepad.rs#L9), [`GamepadSystem`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/gamepad.rs#L58)
-- **Assets:** [`Color`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/color.rs#L2), [`Animation`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L56), [`AssetError`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L15), [`AssetManifest`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L158), [`AssetPack`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L174), [`AudioBus`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L14), [`AudioClip`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L25), [`AudioId`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L22), [`MeshAsset`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L137), [`SpriteSheet`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L5), [`SpriteSheetAssetDef`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L151), [`TextureAsset`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L119)
-- **Scene:** [`Globals`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L4), [`Prefab2D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L61)/[`Prefab2DDef`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L26), [`PrefabSprite2D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L50)/[`PrefabSprite2DDef`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L11), [`Scene`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L24), [`Scene2D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L98)/[`Scene2DDef`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L42), [`SceneInstance2D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L67)/[`SceneInstance2DDef`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L32), [`SceneOp`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L16), [`Scene3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L47), [`SceneOp3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L39)
-- **World:** [`tilemap`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs), [`aabb_overlap`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/physics.rs#L5), [`iso_to_screen`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/iso.rs#L4), [`screen_to_iso`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/iso.rs#L11), [`TileDef`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L16), [`TileMap`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L6)
-- **Canvas/Text:** [`screen_to_ndc`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L145), [`Canvas`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L42), [`CanvasVertex`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L6), [`FontAtlas`](https://github.com/justinwash/rengine/blob/re-write/engine/src/text.rs#L17)
-- **Pixel art:** [`pixelart`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs) (module-level re-export of [`PixelCanvas`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L3), [`darken`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L106), [`lighten`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L110))
-- **Math:** [`Rect`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L5), [`TimeState`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/time.rs#L4), `Vec2`, `Vec3` (from glam)
+- **Core runtime:** [`run`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L291), [`run_with_scenes`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L409), [`Engine`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L47), [`EngineConfig`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L22), [`Game`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L279)
+- **Rendering (2D):** [`Camera2D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/camera.rs#L4), [`DrawParams`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/sprite.rs#L6), [`Frame`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/mod.rs#L21), [`TextureId`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/texture.rs#L2)
+- **Rendering (3D):** [`Camera3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/camera.rs#L4), [`DrawCmd3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L29), [`Frame3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L57), [`MeshId`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mesh.rs#L5), [`Vertex3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mesh.rs#L10), [`Viewmodel3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L35), [`cube_mesh`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mesh.rs#L54), [`floor_quad`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mesh.rs#L107), [`wall_quad`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mesh.rs#L123)
+- **Input:** [`InputState`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L6), `KeyCode` (from winit), `GamepadButton` (from gilrs), [`GamepadState`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L9), [`GamepadSystem`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L58)
+- **Assets:** [`Color`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L2), [`Animation`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L56), [`AssetError`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L15), [`AssetManifest`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L158), [`AssetPack`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L174), [`AudioBus`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L14), [`AudioClip`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L25), [`AudioId`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L22), [`MeshAsset`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L137), [`SpriteSheet`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L5), [`SpriteSheetAssetDef`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L151), [`TextureAsset`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L119)
+- **Scene:** [`Globals`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L4), [`Prefab2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L61)/[`Prefab2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L26), [`PrefabSprite2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L50)/[`PrefabSprite2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L11), [`Scene`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L24), [`Scene2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L98)/[`Scene2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L42), [`SceneInstance2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L67)/[`SceneInstance2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L32), [`SceneOp`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L16), [`Scene3D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L47), [`SceneOp3D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L39)
+- **World:** [`tilemap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs), [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs#L5), [`iso_to_screen`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L4), [`screen_to_iso`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L11), [`TileDef`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L16), [`TileMap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L6)
+- **Canvas/Text:** [`screen_to_ndc`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L145), [`Canvas`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L42), [`CanvasVertex`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L6), [`FontAtlas`](https://github.com/justinwash/rengine/blob/master/engine/src/text.rs#L17)
+- **Pixel art:** [`pixelart`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs) (module-level re-export of [`PixelCanvas`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L3), [`darken`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L106), [`lighten`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L110))
+- **Math:** [`Rect`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L5), [`TimeState`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L4), `Vec2`, `Vec3` (from glam)
 
 The guiding design philosophy: **a game crate writes `use rengine::*;` and gets everything it needs.**
 
 ---
 
-## 3. Entry Points and the Game Loop ([`app.rs`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs))
+## 3. Entry Points and the Game Loop ([`app.rs`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs))
 
-### 3.1 [`EngineConfig`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L22)
+### 3.1 [`EngineConfig`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L22)
 
 ```rust
 pub struct EngineConfig {
@@ -196,12 +203,13 @@ pub struct EngineConfig {
 Default: 800×600, no vsync, not headless, hot reload on, FPS shown.
 
 The `headless` flag is critical for testing:
+
 - The engine still creates a wgpu surface and device (needed for texture/buffer creation).
 - The window is invisible (`with_visible(false)`).
 - Audio is muted (master volume set to 0).
 - The `run` function uses a tight `loop {}` instead of the platform event loop.
 
-### 3.2 The [`Engine`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L47) struct (2D)
+### 3.2 The [`Engine`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L47) struct (2D)
 
 ```rust
 pub struct Engine {
@@ -219,29 +227,29 @@ pub struct Engine {
 
 All fields are `pub(crate)` — the game only interacts through accessor methods:
 
-- [`engine.input()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L60) → `&InputState`
-- [`engine.time()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L63) / [`engine.dt()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L67) → `&TimeState` / `f32`
-- [`engine.window_size()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L70) → `(u32, u32)`
-- [`engine.gamepad(player)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L74) → `&GamepadState`
-- [`engine.gamepads_connected()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L78) → `usize`
-- [`engine.asset_root()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L82) / [`engine.set_asset_root()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L86)
-- [`engine.create_texture(w, h, &rgba)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L98) → `TextureId`
-- [`engine.create_color_texture(w, h, color)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L256) → `TextureId`
-- [`engine.white_texture()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L270) → `TextureId` (1×1 white pixel)
-- [`engine.font_atlas()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L274) → `&FontAtlas`
-- [`engine.load_texture(path)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L145) → `Result<TextureAsset, AssetError>`
-- [`engine.load_sprite_sheet(path, cell_w, cell_h)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L151) → `Result<SpriteSheet, AssetError>`
-- [`engine.load_audio(path)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L163) → `Result<AudioClip, AssetError>`
-- [`engine.load_asset_manifest(path)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L110) → `Result<AssetPack, AssetError>`
-- [`engine.load_bytes(path)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L102) / [`engine.load_text(path)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L106)
-- [`engine.load_scene2d(assets, path)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L218) → `Result<Scene2D, AssetError>`
-- Audio controls: [`play_sound`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L169), [`play_sound_on_bus`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L173), [`play_music`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L182), [`play_music_with_volume`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L186), [`stop_music`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L190), [`pause_music`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L194), [`resume_music`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L198), [`stop_audio_bus`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L202), [`set_master_volume`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L206), [`set_audio_bus_volume`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L210), [`audio_bus_volume`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L214)
-- [`engine.reload_assets_if_changed()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L227) — called every frame automatically
-- [`engine.hot_reload_enabled()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L90) / [`engine.set_hot_reload_enabled()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L94)
+- [`engine.input()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L60) → `&InputState`
+- [`engine.time()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L63) / [`engine.dt()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L67) → `&TimeState` / `f32`
+- [`engine.window_size()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L70) → `(u32, u32)`
+- [`engine.gamepad(player)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L74) → `&GamepadState`
+- [`engine.gamepads_connected()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L78) → `usize`
+- [`engine.asset_root()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L82) / [`engine.set_asset_root()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L86)
+- [`engine.create_texture(w, h, &rgba)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L98) → `TextureId`
+- [`engine.create_color_texture(w, h, color)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L256) → `TextureId`
+- [`engine.white_texture()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L270) → `TextureId` (1×1 white pixel)
+- [`engine.font_atlas()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L274) → `&FontAtlas`
+- [`engine.load_texture(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L145) → `Result<TextureAsset, AssetError>`
+- [`engine.load_sprite_sheet(path, cell_w, cell_h)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L151) → `Result<SpriteSheet, AssetError>`
+- [`engine.load_audio(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L163) → `Result<AudioClip, AssetError>`
+- [`engine.load_asset_manifest(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L110) → `Result<AssetPack, AssetError>`
+- [`engine.load_bytes(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L102) / [`engine.load_text(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L106)
+- [`engine.load_scene2d(assets, path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L218) → `Result<Scene2D, AssetError>`
+- Audio controls: [`play_sound`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L169), [`play_sound_on_bus`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L173), [`play_music`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L182), [`play_music_with_volume`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L186), [`stop_music`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L190), [`pause_music`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L194), [`resume_music`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L198), [`stop_audio_bus`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L202), [`set_master_volume`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L206), [`set_audio_bus_volume`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L210), [`audio_bus_volume`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L214)
+- [`engine.reload_assets_if_changed()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L227) — called every frame automatically
+- [`engine.hot_reload_enabled()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L90) / [`engine.set_hot_reload_enabled()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L94)
 
-### 3.3 [`run::<G: Game>()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L291) — the 2D trait-based entry point
+### 3.3 [`run::<G: Game>()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L291) — the 2D trait-based entry point
 
-This is the simplest way to run a 2D game. The type parameter `G` must implement the [`Game`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L279) trait:
+This is the simplest way to run a 2D game. The type parameter `G` must implement the [`Game`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L279) trait:
 
 ```rust
 pub trait Game: 'static + Sized {
@@ -287,28 +295,29 @@ On every `WindowEvent::RedrawRequested`:
 ├─ engine.reload_assets_if_changed() // Hot-reload textures, manifests, audio
 ├─ game.update(&engine)            // Run game logic (reads input, modifies game state)
 ├─ if game.should_exit() → exit
-├─ let mut frame = Frame::new()    // Create empty draw list
+├─ frame.begin()                   // Clear sprites + canvases; camera state persists
 ├─ game.render(&engine, &mut frame)// Game populates frame with DrawParams + canvases
 ├─ [if show_fps] draw FPS canvas overlay
 ├─ engine.renderer.render_frame(&frame) // Submit to GPU
 └─ engine.input.end_frame()        // Clear per-frame flags (pressed, released, mouse delta)
 ```
 
-The `Event::AboutToWait` handler calls `window.request_redraw()`, which ensures `RedrawRequested` fires every iteration of the event loop — this is what creates the "run as fast as possible" game loop.
+`Frame` is created once before the event loop so that `Camera2D` state (position, shake, rotation) persists across frames. `frame.begin()` clears only transient per-frame data (sprites, canvases).
 
 Other event handlers:
+
 - **`WindowEvent::Resized`** — Updates engine width/height, calls `renderer.resize()` to reconfigure the surface.
 - **`WindowEvent::KeyboardInput`** — Extracts `PhysicalKey::Code(key)` + `state` (pressed/released), passes to `input.handle_key_event()`.
 - **`WindowEvent::CloseRequested`** — Calls `target.exit()`.
 
-### 3.5 [`run_with_scenes()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L409) — the scene-stack entry point
+### 3.5 [`run_with_scenes()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L409) — the scene-stack entry point
 
 ```rust
 pub fn run_with_scenes<F>(config: EngineConfig, init: F)
 where F: FnOnce(&mut Engine, &mut Globals) -> Box<dyn Scene>
 ```
 
-This is the scene-aware alternative. Instead of a [`Game`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L279) trait, you provide a closure that returns the initial [`Scene`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L24). Key differences from `run()`:
+This is the scene-aware alternative. Instead of a [`Game`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L279) trait, you provide a closure that returns the initial [`Scene`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L24). Key differences from `run()`:
 
 1. A `Globals` is created (`Globals::new()`) — a typed key-value store shared across all scenes.
 2. A scene `stack: Vec<Box<dyn Scene>>` is maintained.
@@ -317,14 +326,15 @@ This is the scene-aware alternative. Instead of a [`Game`](https://github.com/ju
 5. **Per-frame:** The top scene's `update()` is called, returning a `SceneOp`. The `apply_scene_op()` function processes it (see §11.3).
 6. **Rendering:** All scenes in the stack are rendered bottom-to-top: `for scene in stack.iter() { scene.render(...) }`. This allows transparent overlays (e.g. a pause screen rendering on top of the game scene).
 
-### 3.6 [`Engine3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L591) and [`run3d::<G: Game3D>()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L778)
+### 3.6 [`Engine3D`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L591) and [`run3d::<G: Game3D>()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L778)
 
 `Engine3D` mirrors `Engine` but wraps a `Renderer3D` instead of `Renderer`, and adds `mouse_captured: bool`. It provides the same asset/audio/input API plus 3D-specific methods:
 
-- [`engine.load_obj_mesh(path)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L669) / [`engine.load_gltf_mesh(path)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L675) / [`engine.load_mesh(path)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L681) → `Result<MeshAsset, AssetError>`
-- [`engine.create_mesh(vertices, indices)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L764) → `MeshId`
+- [`engine.load_obj_mesh(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L669) / [`engine.load_gltf_mesh(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L675) / [`engine.load_mesh(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L681) → `Result<MeshAsset, AssetError>`
+- [`engine.create_mesh(vertices, indices)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L764) → `MeshId`
 
-[`Game3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L769) trait:
+[`Game3D`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L769) trait:
+
 ```rust
 pub trait Game3D: 'static + Sized {
     fn new(engine: &mut Engine3D) -> Self;
@@ -337,6 +347,7 @@ pub trait Game3D: 'static + Sized {
 ### 3.7 Mouse Capture in 3D Mode
 
 In `run3d()`, the engine immediately grabs the mouse:
+
 ```rust
 window.set_cursor_grab(CursorGrabMode::Confined)
     .or_else(|_| window.set_cursor_grab(CursorGrabMode::Locked));
@@ -348,7 +359,7 @@ The `DeviceEvent::MouseMotion` handler accumulates deltas into `input.mouse_delt
 
 ---
 
-## 4. The 2D Renderer ([`renderer/`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/))
+## 4. The 2D Renderer ([`renderer/`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/))
 
 ### 4.1 GPU Initialization
 
@@ -363,10 +374,12 @@ The `DeviceEvent::MouseMotion` handler accumulates deltas into `input.mouse_delt
 4. **`adapter.request_device()`** — Requests a logical device and command queue. No special features or limits are required.
 
 5. **Surface configuration:**
+
    ```rust
    let surface_format = caps.formats.iter().find(|f| f.is_srgb()).copied()
        .unwrap_or(caps.formats[0]);
    ```
+
    Prefers sRGB format for correct gamma. Configured with the chosen present mode.
 
 6. **Sprite shader** — `include_str!("sprite.wgsl")` compiles the WGSL sprite shader at Rust compile time.
@@ -391,11 +404,12 @@ The `DeviceEvent::MouseMotion` handler accumulates deltas into `input.mouse_delt
 
 15. **White texture** — A 1×1 white pixel texture created as `create_texture(1, 1, &[255, 255, 255, 255])`. Its `TextureId` is stored as `renderer.white_texture` and used when games want to draw solid-colored rectangles without loading a texture.
 
-### 4.2 The Sprite Pipeline ([`DrawParams`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/sprite.rs#L6))
+### 4.2 The Sprite Pipeline ([`DrawParams`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/sprite.rs#L6))
 
 The sprite pipeline is a standard 2D batcher:
 
 **Vertex layout (`Vertex`):**
+
 ```rust
 struct Vertex {
     position: [f32; 2],     // World-space position
@@ -406,7 +420,7 @@ struct Vertex {
 
 Stride: 32 bytes. Attributes at shader locations 0, 1, 2.
 
-### 4.3 Texture Management ([`TextureId`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/texture.rs#L2))
+### 4.3 Texture Management ([`TextureId`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/texture.rs#L2))
 
 Textures are stored in a `Vec<GpuTexture>`:
 
@@ -418,18 +432,19 @@ struct GpuTexture {
 }
 ```
 
-`TextureId(usize)` is an index into this vector. [`create_texture()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/mod.rs#L307):
+`TextureId(usize)` is an index into this vector. [`create_texture()`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/mod.rs#L307):
+
 - Asserts `pixels.len() == width × height × 4`
 - Creates an `Rgba8UnormSrgb` texture
 - Writes pixels via `queue.write_texture()`
 - Creates a view and bind group (texture + sampler)
 - Pushes to `self.textures` and returns `TextureId(len - 1)`
 
-[`replace_texture()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/mod.rs#L373) follows the same process but writes to an existing slot, enabling hot reload.
+[`replace_texture()`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/mod.rs#L373) follows the same process but writes to an existing slot, enabling hot reload.
 
-### 4.4 [`Frame`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/mod.rs#L21) Submission and Batched Rendering
+### 4.4 [`Frame`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/mod.rs#L21) Submission and Batched Rendering
 
-[`render_frame(&frame)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/mod.rs#L444) performs the actual GPU work:
+[`render_frame(&frame)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/mod.rs#L444) performs the actual GPU work:
 
 1. **Surface acquire** — `self.surface.get_current_texture()`. On `Lost` or `Outdated`, reconfigures and returns early.
 
@@ -438,12 +453,15 @@ struct GpuTexture {
 3. **Sort sprites** — `frame.sprites` is sorted by `(z_order, texture_id)`. This ensures correct draw order and minimizes texture bind switches.
 
 4. **Vertex generation** — For each sorted sprite, four vertices are generated:
+
    ```
    [bottom-left, bottom-right, top-right, top-left]
    ```
+
    with positions computed from `position`, `size`, `origin`, `rotation`. UV coordinates respect `flip_x`/`flip_y` by swapping U or V ranges.
 
    **Rotation math:** If `rotation != 0.0`, each corner is rotated around the sprite's position:
+
    ```rust
    let dx = cx - px;
    let dy = cy - py;
@@ -464,29 +482,47 @@ struct GpuTexture {
 
 9. **Submit** — `queue.submit(encoder.finish())` + `output.present()`.
 
-### 4.5 [`Camera2D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/camera.rs#L4) and Projection
+### 4.5 [`Camera2D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/camera.rs#L3) and Projection
 
 ```rust
 pub struct Camera2D {
-    pub position: Vec2,  // World-space center of the camera
-    pub zoom: f32,       // Zoom level (1.0 = default)
+    pub position: Vec2,
+    pub zoom: f32,
+    pub rotation: f32,
+    pub bounds: Option<CameraBounds>,
+    // private: follow_target, follow_speed, dead_zone,
+    //          shake_intensity, shake_duration, shake_elapsed, shake_offset, shake_seed
+}
+
+pub struct CameraBounds {
+    pub min: Vec2,
+    pub max: Vec2,
 }
 ```
 
-The [`projection`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/camera.rs#L18) is an orthographic matrix:
+**Smooth follow** — call `cam.follow(target, speed)` each frame. The camera lerps toward the target at the given speed, respecting a configurable dead zone set via `cam.set_dead_zone(half_size)`. Movement inside the dead zone does not move the camera.
+
+**Screen shake** — `cam.shake(intensity, duration)` starts a decaying random offset using a deterministic hash. The offset fades linearly to zero over the duration.
+
+**Bounds clamping** — when `bounds` is `Some`, the camera position is clamped after following.
+
+**`cam.update(dt)`** must be called each frame (typically at the start of `render`) to advance follow interpolation, bounds clamping, and shake.
+
+The [`projection`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/camera.rs#L92) builds an ortho × view matrix:
+
 ```rust
 fn projection(&self, viewport_width: f32, viewport_height: f32) -> Mat4 {
     let half_w = viewport_width / 2.0 / self.zoom;
     let half_h = viewport_height / 2.0 / self.zoom;
-    Mat4::orthographic_rh(
-        self.position.x - half_w, self.position.x + half_w,
-        self.position.y - half_h, self.position.y + half_h,
-        -1.0, 1.0,
-    )
+    let pos = self.position + self.shake_offset;
+    let ortho = Mat4::orthographic_rh(-half_w, half_w, -half_h, half_h, -1.0, 1.0);
+    let view = Mat4::from_rotation_z(-self.rotation)
+        * Mat4::from_translation(Vec3::new(-pos.x, -pos.y, 0.0));
+    ortho * view
 }
 ```
 
-At zoom 1.0, one world unit equals one screen pixel. The camera is centered on `position`. Increasing zoom narrows the view. The orthographic projection uses right-handed coordinates with Y-up: `position.y` increases upward on screen.
+At zoom 1.0, one world unit equals one screen pixel. The camera is centered on `position`. Increasing zoom narrows the view. Rotation is in radians (counter-clockwise). The shader receives the combined matrix unchanged — no shader modifications were needed.
 
 ### 4.6 The sprite.wgsl Shader
 
@@ -511,15 +547,16 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 ```
 
 The vertex shader transforms 2D world positions by the orthographic projection. The fragment shader samples the texture and multiplies by the vertex color tint. This enables:
+
 - **Textured sprites** — When using a real texture with white tint
 - **Color tinting** — When using a white texture with a colored tint
 - **Semi-transparent overlays** — By setting `color.a < 1.0`
 
 ---
 
-## 5. The 3D Renderer ([`renderer3d/`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/))
+## 5. The 3D Renderer ([`renderer3d/`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/))
 
-### 5.1 [`Renderer3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L119) Initialization
+### 5.1 [`Renderer3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L119) Initialization
 
 Similar to the 2D renderer but with key differences:
 
@@ -538,7 +575,7 @@ Similar to the 2D renderer but with key differences:
 - **Blend mode:** `REPLACE` (opaque rendering).
 - **Vertex/index buffers:** Pre-allocated for 200,000 vertices and 400,000 indices.
 
-### 5.2 [`Frame3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L57) and [`DrawCmd3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L29)
+### 5.2 [`Frame3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L57) and [`DrawCmd3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L29)
 
 ```rust
 pub struct Frame3D {
@@ -558,6 +595,7 @@ pub struct Frame3D {
 ```
 
 `DrawCmd3D` is a position + mesh reference:
+
 ```rust
 pub struct DrawCmd3D {
     pub mesh: MeshId,
@@ -566,9 +604,10 @@ pub struct DrawCmd3D {
 ```
 
 The frame is populated via:
-- [`frame.draw_mesh(mesh_id, position)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L92) — World-space mesh
-- [`frame.draw_viewmodel_mesh(mesh_id, position)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L96) — Camera-relative viewmodel mesh
-- [`frame.draw_raw(vertices, indices)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L100) — Inline geometry (no MeshId needed)
+
+- [`frame.draw_mesh(mesh_id, position)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L92) — World-space mesh
+- [`frame.draw_viewmodel_mesh(mesh_id, position)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L96) — Camera-relative viewmodel mesh
+- [`frame.draw_raw(vertices, indices)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L100) — Inline geometry (no MeshId needed)
 
 **Rendering flow:**
 
@@ -580,11 +619,12 @@ The frame is populated via:
 6. If viewmodel draws exist: a second render pass with the viewmodel camera's VP matrix and depth cleared to 1.0 (viewmodel always renders on top).
 7. Canvas overlay pass.
 
-### 5.3 [`Viewmodel3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L35) Rendering
+### 5.3 [`Viewmodel3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L35) Rendering
 
 The `Viewmodel3D` has its own `Camera3D` with tight near/far planes (0.01–16.0) and narrow FOV (50°). This prevents viewmodel geometry from clipping into walls.
 
 `build_viewmodel_geometry()` transforms each mesh vertex from camera-local space to world space using the inverse of the viewmodel camera's view matrix:
+
 ```rust
 let camera_from_view = camera.view_matrix().inverse();
 let world_position = camera_from_view.transform_point3(local_position);
@@ -620,12 +660,13 @@ struct Uniforms {
 ```
 
 This is a simple **Lambertian diffuse** lighting model:
+
 - `N · L` gives the cosine of the angle between the surface normal and light direction.
 - The diffuse term scales the light color by this factor and the light intensity.
 - Ambient is added unconditionally.
 - The final color is the vertex color multiplied by (diffuse + ambient).
 
-### 5.5 Mesh Primitives ([`cube_mesh`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mesh.rs#L54), [`floor_quad`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mesh.rs#L107), [`wall_quad`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mesh.rs#L123))
+### 5.5 Mesh Primitives ([`cube_mesh`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mesh.rs#L54), [`floor_quad`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mesh.rs#L107), [`wall_quad`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mesh.rs#L123))
 
 Three procedural mesh generators are provided:
 
@@ -635,7 +676,7 @@ Three procedural mesh generators are provided:
 
 - **`wall_quad(p0, p1, height, color)`** — A vertical quad between two floor-level points, extruded upward by `height`. Normal is computed as the 2D perpendicular of the base edge.
 
-### [`Camera3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/camera.rs#L4)
+### [`Camera3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/camera.rs#L4)
 
 ```rust
 pub struct Camera3D {
@@ -648,30 +689,30 @@ pub struct Camera3D {
 }
 ```
 
-- [`forward()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/camera.rs#L31) — Computes the unit direction vector from yaw + pitch using spherical coordinates.
-- [`right()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/camera.rs#L41) — Cross product of forward and world up.
-- [`view_matrix()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/camera.rs#L46) — `Mat4::look_at_rh(position, position + forward(), Y)`.
-- [`projection_matrix()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/camera.rs#L52) — `Mat4::perspective_rh(fov_y, aspect, z_near, z_far)`.
-- [`mouse_look(dx, dy, sensitivity)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/camera.rs#L62) — Adds to yaw/pitch from mouse deltas, clamps pitch to ±89°.
+- [`forward()`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/camera.rs#L31) — Computes the unit direction vector from yaw + pitch using spherical coordinates.
+- [`right()`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/camera.rs#L41) — Cross product of forward and world up.
+- [`view_matrix()`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/camera.rs#L46) — `Mat4::look_at_rh(position, position + forward(), Y)`.
+- [`projection_matrix()`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/camera.rs#L52) — `Mat4::perspective_rh(fov_y, aspect, z_near, z_far)`.
+- [`mouse_look(dx, dy, sensitivity)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/camera.rs#L62) — Adds to yaw/pitch from mouse deltas, clamps pitch to ±89°.
 
 ---
 
-## 6. Canvas and Text Overlay ([`canvas/`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/), [`text.rs`](https://github.com/justinwash/rengine/blob/re-write/engine/src/text.rs))
+## 6. Canvas and Text Overlay ([`canvas/`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/), [`text.rs`](https://github.com/justinwash/rengine/blob/master/engine/src/text.rs))
 
-### 6.1 [`FontAtlas`](https://github.com/justinwash/rengine/blob/re-write/engine/src/text.rs#L17) Construction
+### 6.1 [`FontAtlas`](https://github.com/justinwash/rengine/blob/master/engine/src/text.rs#L17) Construction
 
 The engine embeds `assets/font.ttf` at compile time via `include_bytes!()`. At initialization:
 
 1. Parse the font with `fontdue::Font::from_bytes()`.
 2. Allocate a 512×512 single-channel (`R8Unorm`) pixel buffer.
-3. Write a 2×2 white pixel block at the top-left corner (used for solid rectangles) → [`white_uv = [1.0/512.0, 1.0/512.0]`](https://github.com/justinwash/rengine/blob/re-write/engine/src/text.rs#L25).
+3. Write a 2×2 white pixel block at the top-left corner (used for solid rectangles) → [`white_uv = [1.0/512.0, 1.0/512.0]`](https://github.com/justinwash/rengine/blob/master/engine/src/text.rs#L25).
 4. Rasterize ASCII characters 32–126 at 48px using fontdue.
 5. Pack glyphs into the atlas using a simple left-to-right, top-to-bottom bin packer with 1px padding.
 6. For each glyph, store UV coordinates, pixel dimensions, x/y offsets, and advance width in a `[Option<GlyphEntry>; 128]` array.
 7. Upload the atlas to a GPU texture.
 8. Create a bind group with the texture + a linear-filtering sampler.
 
-### 6.2 [`Canvas`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L42) Drawing
+### 6.2 [`Canvas`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L42) Drawing
 
 `Canvas` is an immediate-mode 2D drawing API that operates in **screen space** (pixel coordinates, origin top-left):
 
@@ -682,16 +723,19 @@ pub struct Canvas {
 ```
 
 Methods:
-- **[`canvas.rect(x, y, w, h, color, screen_size)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L55)** — Draws a solid rectangle. Converts screen coordinates to NDC via `screen_to_ndc()`, uses the `white_uv` from the font atlas so the fragment shader returns a solid color.
-- **[`canvas.text(x, y, text, size, color, screen_size, atlas)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L84)** — Renders text by emitting two triangles per visible glyph. Scales glyphs by `size / FONT_SIZE`. Each quad's UV maps to the glyph's region in the font atlas.
-- **[`canvas.shape(triangles)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L51)** — Accepts raw `CanvasVertex` triangles for custom shapes.
+
+- **[`canvas.rect(x, y, w, h, color, screen_size)`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L55)** — Draws a solid rectangle. Converts screen coordinates to NDC via `screen_to_ndc()`, uses the `white_uv` from the font atlas so the fragment shader returns a solid color.
+- **[`canvas.text(x, y, text, size, color, screen_size, atlas)`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L84)** — Renders text by emitting two triangles per visible glyph. Scales glyphs by `size / FONT_SIZE`. Each quad's UV maps to the glyph's region in the font atlas.
+- **[`canvas.shape(triangles)`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L51)** — Accepts raw `CanvasVertex` triangles for custom shapes.
 
 **NDC conversion:**
+
 ```rust
 pub fn screen_to_ndc(x: f32, y: f32, screen_size: (u32, u32)) -> [f32; 2] {
     [(x / sw) * 2.0 - 1.0, 1.0 - (y / sh) * 2.0]
 }
 ```
+
 Maps screen-space (0,0 = top-left) to NDC (-1,-1 = bottom-left, +1,+1 = top-right).
 
 ### 6.3 The canvas.wgsl Shader
@@ -719,9 +763,9 @@ When `EngineConfig::show_fps` is true, the engine creates a dedicated canvas, dr
 
 ---
 
-## 7. Input System ([`input/`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/))
+## 7. Input System ([`input/`](https://github.com/justinwash/rengine/blob/master/engine/src/input/))
 
-### 7.1 [`InputState`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L6) — Keyboard State
+### 7.1 [`InputState`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L6) — Keyboard State
 
 ```rust
 pub struct InputState {
@@ -736,29 +780,32 @@ pub struct InputState {
 ```
 
 **Three-state key model:**
-- [`is_key_down(key)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L30) — True every frame the key is held.
-- [`is_key_pressed(key)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L35) — True only the first frame of a press (edge trigger).
-- [`is_key_released(key)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L40) — True only the frame the key is released.
 
-[`handle_key_event()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L70) logic:
+- [`is_key_down(key)`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L30) — True every frame the key is held.
+- [`is_key_pressed(key)`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L35) — True only the first frame of a press (edge trigger).
+- [`is_key_released(key)`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L40) — True only the frame the key is released.
+
+[`handle_key_event()`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L70) logic:
+
 - On `Pressed`: insert into `keys_down`. If it was newly inserted (not already held), also insert into `keys_pressed`.
 - On `Released`: remove from `keys_down`, insert into `keys_released`.
 
-[`end_frame()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L107) clears `keys_pressed`, `keys_released`, `mouse_delta`, and `mouse_buttons_pressed/released`. This ensures "pressed" and "released" are one-frame events.
+[`end_frame()`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L107) clears `keys_pressed`, `keys_released`, `mouse_delta`, and `mouse_buttons_pressed/released`. This ensures "pressed" and "released" are one-frame events.
 
 ### 7.2 Mouse State
 
-Mouse motion is accumulated via [`handle_mouse_motion(dx, dy)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L84):
+Mouse motion is accumulated via [`handle_mouse_motion(dx, dy)`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L84):
+
 ```rust
 self.mouse_delta.0 += dx;
 self.mouse_delta.1 += dy;
 ```
 
-Multiple motion events per frame are summed. The game reads [`input.mouse_delta()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L45) and the total is reset at [`end_frame()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L107).
+Multiple motion events per frame are summed. The game reads [`input.mouse_delta()`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L45) and the total is reset at [`end_frame()`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L107).
 
 Mouse buttons use the same pressed/down/released model as keys, mapped by index: 0=Left, 1=Right, 2=Middle.
 
-### 7.3 [`GamepadSystem`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/gamepad.rs#L58) and [`GamepadState`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/gamepad.rs#L9)
+### 7.3 [`GamepadSystem`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L58) and [`GamepadState`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L9)
 
 Built on **gilrs**. Supports up to `MAX_PLAYERS = 4` gamepads.
 
@@ -773,6 +820,7 @@ pub struct GamepadSystem {
 **Auto-assignment:** When a gamepad connects, it's assigned to the first empty slot. When it disconnects, its slot is cleared.
 
 **Per-frame update:**
+
 1. Clear `buttons_pressed` and `buttons_released` for all slots.
 2. Drain gilrs events: handle `Connected`, `Disconnected`, `ButtonPressed`, `ButtonReleased`.
 3. Read analog axes: `left_stick_x/y` from `Axis::LeftStickX/Y`.
@@ -780,15 +828,16 @@ pub struct GamepadSystem {
 5. **Dead zone:** Values below 0.15 are clamped to 0.
 
 `GamepadState` provides:
-- [`is_button_down(button)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/gamepad.rs#L37), [`is_button_pressed(button)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/gamepad.rs#L42), [`is_button_released(button)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/gamepad.rs#L47)
+
+- [`is_button_down(button)`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L37), [`is_button_pressed(button)`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L42), [`is_button_released(button)`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L47)
 - `left_stick_x`, `left_stick_y` (public fields)
-- [`is_connected()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/gamepad.rs#L52)
+- [`is_connected()`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L52)
 
 ---
 
-## 8. Asset Pipeline ([`assets/`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/))
+## 8. Asset Pipeline ([`assets/`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/))
 
-### 8.1 [`AssetPipeline`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L247) (Internal)
+### 8.1 [`AssetPipeline`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L247) (Internal)
 
 The `AssetPipeline` is the internal caching layer:
 
@@ -811,18 +860,18 @@ struct AssetPipeline {
 
 **Caching:** All `load_*` methods check the cache first. This means calling `load_texture("player.png")` twice returns the same `TextureId` without re-uploading.
 
-### 8.2 [`AssetManifest`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L158) and [`AssetPack`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L174)
+### 8.2 [`AssetManifest`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L158) and [`AssetPack`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L174)
 
 An `AssetManifest` is a JSON file declaring assets by alias:
 
 ```json
 {
-    "textures": { "player": "sprites/player.png", "tiles": "sprites/tiles.png" },
-    "sprite_sheets": { "walk": { "path": "sprites/walk.png", "cell_width": 32, "cell_height": 32 } },
-    "audio": { "jump": "audio/jump.wav", "music": "audio/bgm.ogg" },
-    "meshes": { "level": "meshes/level.obj" },
-    "bytes": { "config": "data/config.bin" },
-    "text": { "dialogue": "data/dialogue.json" }
+  "textures": { "player": "sprites/player.png", "tiles": "sprites/tiles.png" },
+  "sprite_sheets": { "walk": { "path": "sprites/walk.png", "cell_width": 32, "cell_height": 32 } },
+  "audio": { "jump": "audio/jump.wav", "music": "audio/bgm.ogg" },
+  "meshes": { "level": "meshes/level.obj" },
+  "bytes": { "config": "data/config.bin" },
+  "text": { "dialogue": "data/dialogue.json" }
 }
 ```
 
@@ -839,18 +888,19 @@ pub struct AssetPack {
 }
 ```
 
-The `AssetPack` provides typed accessors by alias: [`pack.texture("player")`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L192), [`pack.sprite_sheet("walk")`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L196), [`pack.audio("jump")`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L204), etc. It also provides [`texture_id(alias)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L208) which checks both textures and sprite sheets.
+The `AssetPack` provides typed accessors by alias: [`pack.texture("player")`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L192), [`pack.sprite_sheet("walk")`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L196), [`pack.audio("jump")`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L204), etc. It also provides [`texture_id(alias)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L208) which checks both textures and sprite sheets.
 
 ### 8.3 Texture Loading
 
 `load_texture()` flow:
+
 1. Resolve path → check cache → miss: read file from disk.
 2. Decode with `image::load_from_memory()` → convert to RGBA8.
 3. Call the `create_texture` callback (which calls `renderer.create_texture()`).
 4. Store the `TextureAsset { id, width, height, path }` in the cache.
 5. Record the file's modification timestamp for hot reload.
 
-### 8.4 [`SpriteSheet`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L5) and [`Animation`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L56)
+### 8.4 [`SpriteSheet`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L5) and [`Animation`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L56)
 
 ```rust
 pub struct SpriteSheet {
@@ -862,13 +912,14 @@ pub struct SpriteSheet {
 }
 ```
 
-- [`columns()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L35) → `texture_width / cell_width`
-- [`rows()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L40) → `texture_height / cell_height`
-- [`uv_rect(col, row)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L45) → `[u, v, w, h]` in 0..1 range for the specified cell
+- [`columns()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L35) → `texture_width / cell_width`
+- [`rows()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L40) → `texture_height / cell_height`
+- [`uv_rect(col, row)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L45) → `[u, v, w, h]` in 0..1 range for the specified cell
 
 Loading validates that the texture dimensions are evenly divisible by cell dimensions.
 
 **Animation:**
+
 ```rust
 pub struct Animation {
     pub frames: Vec<(u32, u32)>,  // (col, row) pairs
@@ -878,12 +929,13 @@ pub struct Animation {
 }
 ```
 
-- [`Animation::new(frames, fps)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L68) — Creates an animation with `frame_time = 1.0 / fps`.
-- [`update(dt)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L78) — Advances the timer; when `elapsed >= frame_time`, cycles to the next frame (wrapping). Returns the current `(col, row)`.
-- [`current_frame()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L88) — Returns current without advancing.
-- [`reset()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L93) — Resets to frame 0.
+- [`Animation::new(frames, fps)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L68) — Creates an animation with `frame_time = 1.0 / fps`.
+- [`update(dt)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L78) — Advances the timer; when `elapsed >= frame_time`, cycles to the next frame (wrapping). Returns the current `(col, row)`.
+- [`current_frame()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L88) — Returns current without advancing.
+- [`reset()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L93) — Resets to frame 0.
 
 Usage pattern:
+
 ```rust
 let (col, row) = animation.update(engine.dt());
 let uv = sprite_sheet.uv_rect(col, row);
@@ -893,16 +945,19 @@ frame.draw_sprite(DrawParams::new(sprite_sheet.texture, pos, size).with_uv_rect(
 ### 8.5 3D Mesh Loading (OBJ and glTF)
 
 `load_mesh()` dispatches based on file extension:
+
 - `.obj` → `read_obj_mesh()` using `tobj` with triangulation and single-indexing
 - `.gltf` / `.glb` → `read_gltf_mesh()` using the `gltf` crate
 
 After loading, two post-processing steps run:
+
 1. **`fix_winding_from_normals()`** — For each triangle, checks if the geometric normal (from cross product) agrees with the average vertex normal. If they disagree, swaps two indices to flip the winding. This corrects meshes where the face winding doesn't match the authored normals.
 2. **`compute_flat_normals()`** — If all vertex normals are zero (unset), computes flat-shading normals from face geometry.
 
 ### 8.6 Audio Loading
 
 `Engine::load_audio()`:
+
 1. Resolves the path.
 2. Loads raw bytes via the asset pipeline.
 3. Registers the clip with the audio system: `audio.register_clip(path, bytes)`.
@@ -915,13 +970,14 @@ Audio data is stored as raw bytes and decoded on-demand at playback time using `
 When `hot_reload_enabled` is true, `engine.reload_assets_if_changed()` is called every frame:
 
 **For 2D Engine:**
+
 1. **Textures:** Iterates all loaded textures, checks file modification time against stored timestamp. If newer, re-reads the image, calls `renderer.replace_texture()` to update the GPU texture in-place (same `TextureId`), and updates sprite sheet dimensions.
 2. **Manifests:** Checks modification times and invalidates stale manifests from the cache (does not automatically re-load, just forces a re-parse on next access).
 3. **Audio:** Checks modification times and replaces raw bytes in the clip store.
 
 **For 3D Engine:** Same as above but for meshes instead of textures (re-runs winding correction and normal computation).
 
-### 8.8 [`AssetError`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L15)
+### 8.8 [`AssetError`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L15)
 
 A comprehensive error enum covering all asset failure modes:
 
@@ -943,9 +999,9 @@ All variants carry the relevant path for context in error messages.
 
 ---
 
-## 9. Audio System ([`assets/audio.rs`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs))
+## 9. Audio System ([`assets/audio.rs`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs))
 
-### 9.1 [`AudioBus`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L14) and Volume
+### 9.1 [`AudioBus`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L14) and Volume
 
 Four buses: `Music`, `Effects`, `Ui`, `Ambient`. Each has an independent volume multiplier. The final volume for any sound is:
 
@@ -953,9 +1009,10 @@ Four buses: `Music`, `Effects`, `Ui`, `Ambient`. Each has an independent volume 
 final_volume = master_volume × bus_volume × clip_volume
 ```
 
-`AudioSystem` uses `RefCell`-based interior mutability for the active sinks and music sink, allowing [`play()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L106) to be called from `&self` contexts.
+`AudioSystem` uses `RefCell`-based interior mutability for the active sinks and music sink, allowing [`play()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L106) to be called from `&self` contexts.
 
-[`play_on_bus(bus, clip, volume)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L110):
+[`play_on_bus(bus, clip, volume)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L110):
+
 1. Clean up finished sinks.
 2. Create a new `rodio::Sink`.
 3. Set volume to `final_volume`.
@@ -964,26 +1021,28 @@ final_volume = master_volume × bus_volume × clip_volume
 
 ### 9.2 Music Playback
 
-[`play_music_with_volume(clip, volume)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L137):
+[`play_music_with_volume(clip, volume)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L137):
+
 1. Stops any existing music.
 2. Creates a new sink.
 3. Decodes the clip and appends it with `.repeat_infinite()` for looping.
 4. Stores in `music_sink`.
 
-[`pause_music()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L164) / [`resume_music()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L170) call `.pause()` / `.play()` on the music sink.
+[`pause_music()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L164) / [`resume_music()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L170) call `.pause()` / `.play()` on the music sink.
 
 ### 9.3 Headless Mode
 
 When `headless` is true:
+
 - Master volume is set to 0.
-- [`play_on_bus()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L110) still decodes the clip (exercises the decode path for testing) but if no audio handle is available, returns early after decoding.
-- [`set_master_volume()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L191) forces 0 if `silent` is true.
+- [`play_on_bus()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L110) still decodes the clip (exercises the decode path for testing) but if no audio handle is available, returns early after decoding.
+- [`set_master_volume()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L191) forces 0 if `silent` is true.
 
 ---
 
 ## 10. Color and Pixel Art
 
-### [`Color`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/color.rs#L2)
+### [`Color`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L2)
 
 ```rust
 pub struct Color { pub r: f32, pub g: f32, pub b: f32, pub a: f32 }
@@ -991,11 +1050,11 @@ pub struct Color { pub r: f32, pub g: f32, pub b: f32, pub a: f32 }
 
 Constants: `WHITE`, `BLACK`, `RED`, `ORANGE`, `YELLOW`, `GREEN`, `BLUE`, `INDIGO`, `VIOLET`.
 
-Constructors: [`new(r,g,b,a)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/color.rs#L65), [`rgb(r,g,b)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/color.rs#L69), [`from_rgba8(r,g,b,a)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/color.rs#L73).
+Constructors: [`new(r,g,b,a)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L65), [`rgb(r,g,b)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L69), [`from_rgba8(r,g,b,a)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L73).
 
-Conversions: [`to_array() → [f32; 4]`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/color.rs#L82), [`to_wgpu() → wgpu::Color`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/color.rs#L86).
+Conversions: [`to_array() → [f32; 4]`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L82), [`to_wgpu() → wgpu::Color`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L86).
 
-### [`PixelCanvas`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L3) (Procedural Texture Generation)
+### [`PixelCanvas`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L3) (Procedural Texture Generation)
 
 `assets::pixelart::PixelCanvas` is a CPU-side pixel buffer for procedural texture creation:
 
@@ -1003,9 +1062,10 @@ Conversions: [`to_array() → [f32; 4]`](https://github.com/justinwash/rengine/b
 pub struct PixelCanvas { pub width: u32, pub height: u32, pixels: Vec<[u8; 4]> }
 ```
 
-Methods: [`fill(color)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L18), [`set(x, y, color)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L23), [`fill_rect(x, y, w, h, color)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L29), [`fill_circle(cx, cy, radius, color)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L42), [`fill_diamond(color)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L58), [`stroke_diamond(color, thickness)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L73), [`into_bytes() → Vec<u8>`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L89).
+Methods: [`fill(color)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L18), [`set(x, y, color)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L23), [`fill_rect(x, y, w, h, color)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L29), [`fill_circle(cx, cy, radius, color)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L42), [`fill_diamond(color)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L58), [`stroke_diamond(color, thickness)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L73), [`into_bytes() → Vec<u8>`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L89).
 
 Usage pattern:
+
 ```rust
 let mut canvas = pixelart::PixelCanvas::new(16, 16);
 canvas.fill(Color::BLUE);
@@ -1014,13 +1074,13 @@ let pixels = canvas.into_bytes();
 let tex = engine.create_texture(16, 16, &pixels);
 ```
 
-[`darken(color, factor)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L106) and [`lighten(color, factor)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L110) are color utility functions.
+[`darken(color, factor)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L106) and [`lighten(color, factor)`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L110) are color utility functions.
 
 ---
 
-## 11. Scene System ([`scene/`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/))
+## 11. Scene System ([`scene/`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/))
 
-### 11.1 [`Scene`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L24) Trait and [`SceneOp`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L16)
+### 11.1 [`Scene`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L24) Trait and [`SceneOp`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L16)
 
 ```rust
 pub trait Scene: 'static {
@@ -1034,6 +1094,7 @@ pub trait Scene: 'static {
 ```
 
 `SceneOp` is the return value from `update()`:
+
 ```rust
 pub enum SceneOp {
     Continue,                   // Do nothing
@@ -1045,6 +1106,7 @@ pub enum SceneOp {
 ```
 
 Lifecycle:
+
 - **`on_enter`** — Called when the scene is first activated (pushed or switched to). `&mut Engine` allows loading assets.
 - **`update`** — Called every frame for the top scene only. Returns `SceneOp`.
 - **`render`** — Called for **all** scenes in the stack, bottom to top.
@@ -1052,7 +1114,7 @@ Lifecycle:
 - **`on_resume`** — Called when the scene above is popped. `&mut Engine` for potential re-loading.
 - **`on_exit`** — Called when the scene is removed from the stack.
 
-### 11.2 [`Globals`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L4) — Typed Key-Value Store
+### 11.2 [`Globals`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L4) — Typed Key-Value Store
 
 ```rust
 pub struct Globals {
@@ -1060,7 +1122,7 @@ pub struct Globals {
 }
 ```
 
-Methods: [`set<T>(value)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L21), [`get<T>() → Option<&T>`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L25), [`get_mut<T>() → Option<&mut T>`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L29), [`remove<T>() → Option<T>`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L33), [`contains<T>() → bool`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L39).
+Methods: [`set<T>(value)`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L21), [`get<T>() → Option<&T>`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L25), [`get_mut<T>() → Option<&mut T>`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L29), [`remove<T>() → Option<T>`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L33), [`contains<T>() → bool`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L39).
 
 This uses `TypeId` as keys and `Any` for type-erased storage. Each type `T` can have exactly one value stored. This is a common pattern for cross-scene shared state (scores, player data, settings).
 
@@ -1081,47 +1143,45 @@ fn apply_scene_op(stack, op, engine, globals) {
 ```
 
 **Critical rendering detail:** All scenes render, not just the top:
+
 ```rust
 for scene in stack.iter() {
     scene.render(&engine, &globals, &mut frame);
 }
 ```
+
 This means a pause overlay scene pushed on top of a game scene will render the game first (with its clear color), then the overlay draws on top (e.g. a semi-transparent dark rectangle + "PAUSED" text).
 
-### 11.4 2D Scene Data ([`Scene2D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L98), [`SceneInstance2D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L67), Prefabs, Instances)
+### 11.4 2D Scene Data ([`Scene2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L98), [`SceneInstance2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L67), Prefabs, Instances)
 
 Rengine supports data-driven 2D scenes via JSON:
 
 **Scene2DDef (JSON format):**
+
 ```json
 {
-    "prefabs": [
-        {
-            "name": "tree",
-            "sprites": [
-                { "asset": "tree_texture", "offset": [0, 0], "size": [32, 48] }
-            ]
-        }
-    ],
-    "instances": [
-        { "prefab": "tree", "position": [100, 200], "scale": [1.5, 1.5],
-          "properties": { "type": "oak" } }
-    ]
+  "prefabs": [
+    {
+      "name": "tree",
+      "sprites": [{ "asset": "tree_texture", "offset": [0, 0], "size": [32, 48] }]
+    }
+  ],
+  "instances": [{ "prefab": "tree", "position": [100, 200], "scale": [1.5, 1.5], "properties": { "type": "oak" } }]
 }
 ```
 
-[`Scene2D::load_from_path(path, assets)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L103) parses this JSON, resolves texture aliases against an `AssetPack`, and produces `SceneInstance2D` objects that can be queried and drawn:
+[`Scene2D::load_from_path(path, assets)`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L103) parses this JSON, resolves texture aliases against an `AssetPack`, and produces `SceneInstance2D` objects that can be queried and drawn:
 
-- [`scene.instances()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L144) → slice of all instances
-- [`scene.by_prefab("tree")`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L148) → iterator of instances using that prefab
-- [`scene.draw(frame)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L154) — draws all instances
-- Each instance has [`property("type")`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L76) for custom key-value metadata
+- [`scene.instances()`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L144) → slice of all instances
+- [`scene.by_prefab("tree")`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L148) → iterator of instances using that prefab
+- [`scene.draw(frame)`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L154) — draws all instances
+- Each instance has [`property("type")`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L76) for custom key-value metadata
 
 ---
 
-## 12. World Systems ([`world/`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/))
+## 12. World Systems ([`world/`](https://github.com/justinwash/rengine/blob/master/engine/src/world/))
 
-### 12.1 [`TileMap`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L6) and [`TileDef`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L16)
+### 12.1 [`TileMap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L6) and [`TileDef`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L16)
 
 ```rust
 pub struct TileMap {
@@ -1132,6 +1192,7 @@ pub struct TileMap {
 ```
 
 **Tile definitions:**
+
 ```rust
 pub struct TileDef {
     pub texture: TextureId,
@@ -1141,26 +1202,28 @@ pub struct TileDef {
 ```
 
 API:
-- [`tilemap.add_tile(def)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L59) → `usize` (tile ID)
-- [`tilemap.set(col, row, Some(tile_id))`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L66) / [`tilemap.get(col, row)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L73)
-- [`tilemap.cell_position(col, row)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L82) → `Vec2`
-- [`tilemap.world_width()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L87) / [`world_height()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L92)
-- **[`tilemap.collide_rect(rect)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L97)** → `Option<Vec2>` — Checks a `Rect` against all occupied tiles within range, accumulates AABB minimum translation vectors. Returns the total push-back vector to resolve overlap.
-- **[`tilemap.draw(frame)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L141)** — Frustum-culled tile rendering: only draws tiles visible within a hardcoded 600×400 half-extent around the camera. Each visible tile emits a `DrawParams` with the tile's texture, color, and UV rect.
 
-### 12.2 [`aabb_overlap`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/physics.rs#L5) — AABB Physics
+- [`tilemap.add_tile(def)`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L59) → `usize` (tile ID)
+- [`tilemap.set(col, row, Some(tile_id))`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L66) / [`tilemap.get(col, row)`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L73)
+- [`tilemap.cell_position(col, row)`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L82) → `Vec2`
+- [`tilemap.world_width()`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L87) / [`world_height()`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L92)
+- **[`tilemap.collide_rect(rect)`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L97)** → `Option<Vec2>` — Checks a `Rect` against all occupied tiles within range, accumulates AABB minimum translation vectors. Returns the total push-back vector to resolve overlap.
+- **[`tilemap.draw(frame)`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L141)** — Frustum-culled tile rendering: only draws tiles visible within a hardcoded 600×400 half-extent around the camera. Each visible tile emits a `DrawParams` with the tile's texture, color, and UV rect.
+
+### 12.2 [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs#L5) — AABB Physics
 
 ```rust
 pub fn aabb_overlap(a: &Rect, b: &Rect) -> Option<Vec2>
 ```
 
 Computes the **Minimum Translation Vector (MTV)** for two overlapping AABBs. Returns `None` if they don't overlap. The MTV is along the axis of least penetration:
+
 - Computes overlap on both X and Y axes.
 - Returns the smaller overlap as the push direction, with sign determined by the relative center positions.
 
 This is used by `TileMap::collide_rect()` for tilemap collision.
 
-### 12.3 [`iso_to_screen`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/iso.rs#L4) / [`screen_to_iso`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/iso.rs#L11) — Isometric Helpers
+### 12.3 [`iso_to_screen`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L4) / [`screen_to_iso`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L11) — Isometric Helpers
 
 ```rust
 pub fn iso_to_screen(col: i32, row: i32, tile_width: f32, tile_height: f32) -> Vec2
@@ -1171,19 +1234,19 @@ Standard diamond-shaped isometric projection. `iso_to_screen` converts grid coor
 
 ---
 
-## 13. Math Utilities ([`math/`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/))
+## 13. Math Utilities ([`math/`](https://github.com/justinwash/rengine/blob/master/engine/src/math/))
 
-### 13.1 [`Rect`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L5)
+### 13.1 [`Rect`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L5)
 
 ```rust
 pub struct Rect { pub x: f32, pub y: f32, pub width: f32, pub height: f32 }
 ```
 
-Methods: [`new()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L13), [`from_pos_size()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L22), [`left()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L31), [`right()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L35), [`bottom()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L39), [`top()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L43), [`center()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L47), [`contains_point()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L51), [`overlaps()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L58).
+Methods: [`new()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L13), [`from_pos_size()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L22), [`left()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L31), [`right()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L35), [`bottom()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L39), [`top()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L43), [`center()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L47), [`contains_point()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L51), [`overlaps()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L58).
 
-Note: [`bottom()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L39) returns `y` and [`top()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L43) returns `y + height`, so Y increases upward (matching the world coordinate system).
+Note: [`bottom()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L39) returns `y` and [`top()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L43) returns `y + height`, so Y increases upward (matching the world coordinate system).
 
-### 13.2 [`TimeState`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/time.rs#L4)
+### 13.2 [`TimeState`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L4)
 
 ```rust
 pub struct TimeState {
@@ -1195,21 +1258,22 @@ pub struct TimeState {
 }
 ```
 
-- [`dt()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/time.rs#L25) — Seconds since last frame (capped at 0.1 to prevent spiral-of-death).
-- [`total_time()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/time.rs#L30) — Seconds since engine start.
-- [`frame_count()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/time.rs#L34) — Total frames processed.
-- [`fps()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/time.rs#L38) — `1.0 / dt`.
-- [`tick()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/time.rs#L46) — Called once per frame by the engine; updates all fields.
+- [`dt()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L25) — Seconds since last frame (capped at 0.1 to prevent spiral-of-death).
+- [`total_time()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L30) — Seconds since engine start.
+- [`frame_count()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L34) — Total frames processed.
+- [`fps()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L38) — `1.0 / dt`.
+- [`tick()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L46) — Called once per frame by the engine; updates all fields.
 
 ---
 
-## 14. Rollback Netcode ([`netcode/`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/), feature-gated)
+## 14. Rollback Netcode ([`netcode/`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/), feature-gated)
 
-### 14.1 Architecture Overview ([`Rollbackable`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L73))
+### 14.1 Architecture Overview ([`Rollbackable`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L73))
 
 Rengine integrates **GGRS** (Good Game Rollback SDK) for deterministic rollback netcode. This is feature-gated behind `rollback`.
 
 The key trait is:
+
 ```rust
 pub trait Rollbackable {
     type Input: InputT;
@@ -1221,7 +1285,7 @@ pub trait Rollbackable {
 
 `InputT` requires: `Copy + Clone + PartialEq + Default + Pod + Zeroable + Serialize + DeserializeOwned + 'static`.
 
-### 14.2 [`RollbackSession`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L86)
+### 14.2 [`RollbackSession`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L86)
 
 ```rust
 pub struct RollbackSession<I: InputT> {
@@ -1238,11 +1302,13 @@ pub struct RollbackSession<I: InputT> {
 ```
 
 **Session modes:**
+
 - **`Local`** — No rollback; directly advances the simulation.
 - **`SyncTest { check_distance }`** — Runs all players locally and uses GGRS sync testing to validate determinism.
-- **`Online(`[`OnlineConfig`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L39)`)`** — Real P2P rollback over UDP.
+- **`Online(`[`OnlineConfig`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L39)`)`** — Real P2P rollback over UDP.
 
-**[`update(dt, inputs, sim)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L186)** — The central tick function:
+**[`update(dt, inputs, sim)`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L186)** — The central tick function:
+
 1. Accumulates `dt` into the fixed-timestep accumulator.
 2. If not enough time has passed, just polls remote clients (P2P) and returns `false`.
 3. Otherwise, subtracts `fixed_dt` from accumulator and processes one tick.
@@ -1251,13 +1317,15 @@ pub struct RollbackSession<I: InputT> {
 6. Returns `true` if a tick was processed.
 
 **GGRS request handling:**
-- `SaveGameState` — Calls `sim.save()`, computes [`fletcher64`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L290) checksum, stores in GGRS cell.
+
+- `SaveGameState` — Calls `sim.save()`, computes [`fletcher64`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L290) checksum, stores in GGRS cell.
 - `LoadGameState` — Calls `sim.load()` with the stored state.
 - `AdvanceFrame` — Calls `sim.advance()` with the GGRS-provided inputs.
 
-### 14.3 [`UdpNonBlockingSocket`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/transport.rs#L5) — UDP Transport
+### 14.3 [`UdpNonBlockingSocket`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/transport.rs#L5) — UDP Transport
 
 `UdpNonBlockingSocket` implements `ggrs::NonBlockingSocket<String>`:
+
 - Binds a non-blocking UDP socket.
 - `send_to()` serializes GGRS messages with bincode and sends via UDP.
 - `receive_all_messages()` drains all pending UDP packets, deserializes them.
@@ -1971,61 +2039,61 @@ fn main() {
 
 ### Features Exercised in This Example
 
-| Feature | Where Used |
-|---|---|
-| [`EngineConfig`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L22) (all fields) | `main()` — title, width, height, vsync, headless, hot_reload, show_fps |
-| [`run_with_scenes()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L409) | `main()` — scene-stack entry point |
-| [`Scene`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L24) trait (all hooks) | `TitleScene`, `GameScene`, `PauseOverlay` — on_enter, update, render, on_pause, on_resume, on_exit |
-| [`SceneOp::Switch`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L16) | Title → Game, Game → Title |
-| [`SceneOp::Push`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L16) / `Pop` | Game → PauseOverlay, PauseOverlay → Game |
-| [`SceneOp::Quit`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/mod.rs#L16) | Escape from title |
-| [`Globals`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L4) typed store | `TransitionCounter`, `PlayerStats` — [`set`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L21), [`get`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L25), [`get_mut`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L29), [`contains`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/globals.rs#L39) |
-| [`pixelart::PixelCanvas`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L3) | Player, coin, ground, sky textures — [`fill`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L18), [`fill_rect`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L29), [`set`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L23), [`darken`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L106), [`lighten`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pixelart.rs#L110) |
-| [`Engine::create_texture()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L98) | Procedural texture upload |
-| [`SpriteSheet`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L5) | Coin animation sprite sheet (4 frames) |
-| [`Animation`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L56) | `coin_anim` — [`new`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L68), [`update`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L78), [`current_frame`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/spritesheet.rs#L88) |
-| [`TileMap`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L6) | Level geometry — [`new`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L48), [`add_tile`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L59), [`set`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L66), [`collide_rect`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L97), [`draw`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L141) |
-| [`TileDef::solid()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L24) | Ground tile |
-| [`TileMap::collide_rect()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/tilemap.rs#L97) | Player vs tilemap collision |
-| [`Rect`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/rect.rs#L5) | Player collision box |
-| [`DrawParams`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/sprite.rs#L6) builder | position, size, color, uv_rect, flip_x, rotation, origin, z_order |
-| [`Frame::draw_sprite()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/mod.rs#L39) | Player, coins, background |
-| [`Frame::canvas()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/mod.rs#L58) | HUD text, pause overlay |
-| [`Canvas::rect()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L55) | HUD background, pause darkening |
-| [`Canvas::text()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L84) | Score, controls, stats |
-| [`Camera2D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer/camera.rs#L4) | position, zoom — smooth follow with lerp |
-| [`InputState`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L6) | [`is_key_down`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L30), [`is_key_pressed`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L35) for movement/jump/menu |
-| [`GamepadState`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/gamepad.rs#L9) | Left stick for movement, South for jump, Start for unpause |
-| [`TimeState`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/time.rs#L4) | [`dt()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/time.rs#L25) for physics, [`total_time`](https://github.com/justinwash/rengine/blob/re-write/engine/src/math/time.rs#L30) tracking |
-| [`Color`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/color.rs#L2) constants + constructors | WHITE, BLACK, YELLOW, GREEN, ORANGE, [`rgb()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/color.rs#L69), [`new()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/color.rs#L65) |
-| [`FontAtlas`](https://github.com/justinwash/rengine/blob/re-write/engine/src/text.rs#L17) | Passed to canvas.text() calls |
-| [`screen_to_ndc`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L145) (implicit) | Used by Canvas internally |
-| [`aabb_overlap`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/physics.rs#L5) (implicit) | Used by TileMap::collide_rect internally |
-| `Vec2` | All positions, velocities, sizes |
-| Hot reload | Enabled via config — textures would auto-reload if files change |
-| FPS overlay | Enabled via config — rendered by engine after game render |
-| Bottom-to-top stack rendering | GameScene renders world, PauseOverlay renders on top |
+| Feature                                                                                                               | Where Used                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`EngineConfig`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L22) (all fields)              | `main()` — title, width, height, vsync, headless, hot_reload, show_fps                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| [`run_with_scenes()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L409)                     | `main()` — scene-stack entry point                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| [`Scene`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L24) trait (all hooks)          | `TitleScene`, `GameScene`, `PauseOverlay` — on_enter, update, render, on_pause, on_resume, on_exit                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| [`SceneOp::Switch`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L16)                  | Title → Game, Game → Title                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| [`SceneOp::Push`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L16) / `Pop`            | Game → PauseOverlay, PauseOverlay → Game                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| [`SceneOp::Quit`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L16)                    | Escape from title                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| [`Globals`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L4) typed store           | `TransitionCounter`, `PlayerStats` — [`set`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L21), [`get`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L25), [`get_mut`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L29), [`contains`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L39)                                                                                                                |
+| [`pixelart::PixelCanvas`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L3)       | Player, coin, ground, sky textures — [`fill`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L18), [`fill_rect`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L29), [`set`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L23), [`darken`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L106), [`lighten`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L110) |
+| [`Engine::create_texture()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L98)               | Procedural texture upload                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| [`SpriteSheet`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L5)              | Coin animation sprite sheet (4 frames)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| [`Animation`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L56)               | `coin_anim` — [`new`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L68), [`update`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L78), [`current_frame`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L88)                                                                                                                                                                                                                  |
+| [`TileMap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L6)                       | Level geometry — [`new`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L48), [`add_tile`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L59), [`set`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L66), [`collide_rect`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L97), [`draw`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L141)                               |
+| [`TileDef::solid()`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L24)             | Ground tile                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| [`TileMap::collide_rect()`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L97)      | Player vs tilemap collision                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| [`Rect`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L5)                              | Player collision box                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| [`DrawParams`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/sprite.rs#L6) builder          | position, size, color, uv_rect, flip_x, rotation, origin, z_order                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| [`Frame::draw_sprite()`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/mod.rs#L39)          | Player, coins, background                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| [`Frame::canvas()`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/mod.rs#L58)               | HUD text, pause overlay                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| [`Canvas::rect()`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L55)                  | HUD background, pause darkening                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| [`Canvas::text()`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L84)                  | Score, controls, stats                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| [`Camera2D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer/camera.rs#L4)                    | position, zoom — smooth follow with lerp                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| [`InputState`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L6)                   | [`is_key_down`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L30), [`is_key_pressed`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L35) for movement/jump/menu                                                                                                                                                                                                                                                                                                              |
+| [`GamepadState`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L9)                  | Left stick for movement, South for jump, Start for unpause                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| [`TimeState`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L4)                         | [`dt()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L25) for physics, [`total_time`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L30) tracking                                                                                                                                                                                                                                                                                                                                     |
+| [`Color`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L2) constants + constructors | WHITE, BLACK, YELLOW, GREEN, ORANGE, [`rgb()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L69), [`new()`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L65)                                                                                                                                                                                                                                                                                                                   |
+| [`FontAtlas`](https://github.com/justinwash/rengine/blob/master/engine/src/text.rs#L17)                             | Passed to canvas.text() calls                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| [`screen_to_ndc`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L145) (implicit)       | Used by Canvas internally                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs#L5) (implicit)       | Used by TileMap::collide_rect internally                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `Vec2`                                                                                                                | All positions, velocities, sizes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Hot reload                                                                                                            | Enabled via config — textures would auto-reload if files change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| FPS overlay                                                                                                           | Enabled via config — rendered by engine after game render                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Bottom-to-top stack rendering                                                                                         | GameScene renders world, PauseOverlay renders on top                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 
 ### What This Example Does NOT Cover (and How You Would)
 
-| Feature | How to Use |
-|---|---|
-| [`run::<G: Game>()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L291) | Implement [`Game`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L279) trait directly instead of using scenes |
-| [`AssetManifest`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L158) / [`AssetPack`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/pipeline.rs#L174) | Create a `manifest.json` file, call [`engine.load_asset_manifest("manifest.json")`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L110) |
-| [`Scene2D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/scene/data2d.rs#L98) / Prefabs | Create a scene JSON with prefabs + instances, call [`engine.load_scene2d(assets, "level.json")`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L218) |
-| File-based textures | [`engine.load_texture("player.png")`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L145) instead of procedural generation |
-| [`AudioClip`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L25) / [`play_sound`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L169) | `let clip = engine.load_audio("jump.wav"); engine.play_sound(&clip);` |
-| [`play_music`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L182) / [`stop_music`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L190) | `engine.play_music(&bgm); engine.pause_music(); engine.resume_music();` |
-| [`AudioBus`](https://github.com/justinwash/rengine/blob/re-write/engine/src/assets/audio.rs#L14) / volume | [`engine.play_sound_on_bus(AudioBus::Effects, &clip, 0.5)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L173) |
-| [`set_master_volume`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L206) | `engine.set_master_volume(0.8)` |
-| 3D rendering | Use [`run3d::<G: Game3D>()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L778) with [`Frame3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L57), [`Camera3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/camera.rs#L4), [`DrawCmd3D`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mod.rs#L29), [`cube_mesh()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/renderer3d/mesh.rs#L54), etc. |
-| Rollback netcode | Enable `rollback` feature, implement [`Rollbackable`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L73), create [`RollbackSession`](https://github.com/justinwash/rengine/blob/re-write/engine/src/netcode/mod.rs#L86) |
-| [`iso_to_screen`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/iso.rs#L4) / [`screen_to_iso`](https://github.com/justinwash/rengine/blob/re-write/engine/src/world/iso.rs#L11) | Use in an isometric game for tile placement |
-| [`Canvas::shape()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L51) | Pass raw [`CanvasVertex`](https://github.com/justinwash/rengine/blob/re-write/engine/src/canvas/mod.rs#L6) triangles for custom shapes |
-| [`create_color_texture`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L256) | `engine.create_color_texture(32, 32, Color::RED)` for solid-color textures |
-| [`white_texture()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/app.rs#L270) | `engine.white_texture()` for drawing solid rectangles without a texture file |
-| Mouse input | [`engine.input().mouse_delta()`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L45), [`is_mouse_down(0)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L50), [`is_mouse_pressed(1)`](https://github.com/justinwash/rengine/blob/re-write/engine/src/input/keyboard.rs#L55) |
+| Feature                                                                                                                                                                                                           | How to Use                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`run::<G: Game>()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L291)                                                                                                                  | Implement [`Game`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L279) trait directly instead of using scenes                                                                                                                                                                                                                                                                                                                                                                                                    |
+| [`AssetManifest`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L158) / [`AssetPack`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L174) | Create a `manifest.json` file, call [`engine.load_asset_manifest("manifest.json")`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L110)                                                                                                                                                                                                                                                                                                                                                                          |
+| [`Scene2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L98) / Prefabs                                                                                                         | Create a scene JSON with prefabs + instances, call [`engine.load_scene2d(assets, "level.json")`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L218)                                                                                                                                                                                                                                                                                                                                                             |
+| File-based textures                                                                                                                                                                                               | [`engine.load_texture("player.png")`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L145) instead of procedural generation                                                                                                                                                                                                                                                                                                                                                                                       |
+| [`AudioClip`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L25) / [`play_sound`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L169)                    | `let clip = engine.load_audio("jump.wav"); engine.play_sound(&clip);`                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| [`play_music`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L182) / [`stop_music`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L190)                           | `engine.play_music(&bgm); engine.pause_music(); engine.resume_music();`                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| [`AudioBus`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L14) / volume                                                                                                         | [`engine.play_sound_on_bus(AudioBus::Effects, &clip, 0.5)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L173)                                                                                                                                                                                                                                                                                                                                                                                                  |
+| [`set_master_volume`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L206)                                                                                                                 | `engine.set_master_volume(0.8)`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| 3D rendering                                                                                                                                                                                                      | Use [`run3d::<G: Game3D>()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L778) with [`Frame3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L57), [`Camera3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/camera.rs#L4), [`DrawCmd3D`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L29), [`cube_mesh()`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mesh.rs#L54), etc. |
+| Rollback netcode                                                                                                                                                                                                  | Enable `rollback` feature, implement [`Rollbackable`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L73), create [`RollbackSession`](https://github.com/justinwash/rengine/blob/master/engine/src/netcode/mod.rs#L86)                                                                                                                                                                                                                                                                                  |
+| [`iso_to_screen`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L4) / [`screen_to_iso`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L11)            | Use in an isometric game for tile placement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| [`Canvas::shape()`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L51)                                                                                                             | Pass raw [`CanvasVertex`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L6) triangles for custom shapes                                                                                                                                                                                                                                                                                                                                                                                                   |
+| [`create_color_texture`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L256)                                                                                                              | `engine.create_color_texture(32, 32, Color::RED)` for solid-color textures                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| [`white_texture()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L270)                                                                                                                   | `engine.white_texture()` for drawing solid rectangles without a texture file                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| Mouse input                                                                                                                                                                                                       | [`engine.input().mouse_delta()`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L45), [`is_mouse_down(0)`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L50), [`is_mouse_pressed(1)`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L55)                                                                                                                                                                                        |
 
 ---
 
-*This document was generated from the `re-write` branch of the Rengine repository. All line references, struct definitions, and API signatures are current as of that branch.*
+_This document was generated from the `master` branch of the Rengine repository. All line references, struct definitions, and API signatures are current as of that branch._

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rengine-feature-camera"
+version = "0.1.0"
+dependencies = [
+ "rengine",
+]
+
+[[package]]
 name = "rengine-feature-scenes"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["engine", "samples/games/game-platformer", "samples/games/game-topdown", "samples/games/game-iso", "samples/games/game-fps", "samples/games/game-fight", "samples/games/game-fps-mp", "samples/features/feature-scenes", "samples/features/feature-sprites"]
+members = ["engine", "samples/games/game-platformer", "samples/games/game-topdown", "samples/games/game-iso", "samples/games/game-fps", "samples/games/game-fight", "samples/games/game-fps-mp", "samples/features/feature-scenes", "samples/features/feature-sprites", "samples/features/feature-camera"]
 resolver = "2"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,6 +46,8 @@ Recently completed or partially completed:
 - Completed: `show_fps` config toggle on `EngineConfig` — FPS overlay is now opt-in (defaults to true for backward compat)
 - Completed: feature samples convention — `samples/features/feature-<name>/` directory for engine feature demos, separate from game samples
 - Completed: `feature-scenes` sample — demonstrates Switch, Push/Pop, pause overlay with transparency, Globals-based persistent counters, and all lifecycle hooks
+- Completed: improved 2D camera — rotation, smooth follow with configurable speed, dead zones, screen shake with decay, camera bounds clamping via `CameraBounds`, projection refactored to ortho × view matrix
+- Completed: `feature-camera` sample — demonstrates follow, dead zone, bounds, shake, and rotation toggle
 - Partial: broader asset pipeline coverage still needs validation tooling, dependency tracking, and additional import formats beyond OBJ and glTF
 - Partial: 3D transforms still only support position-based translation; rotation and scale per draw are not yet supported (caused the recurring door visibility issue)
 
@@ -73,11 +75,10 @@ These are the features that most directly increase the engine’s usefulness for
 6. Serializable resources
    Data-driven definitions for entities, items, attacks, animation clips, tile sets, dialogue, and configuration.
 
-7. Better 2D transforms
-   Add rotation, scale, origin or pivot, per-sprite layering, and explicit draw order.
-
-8. Improved 2D camera system
-   Zoom, rotation, smoothing, shake, dead zones, camera bounds, and parallax.
+7. Better 2D transforms [done]
+   Add rotation, scale, and origin support.
+8. Improved 2D camera system [done]
+   Rotation, smooth follow with dead zones, screen shake (intensity + duration with decay), camera bounds clamping. Projection uses view matrix (translate + rotate) applied to centered orthographic.
 
 9. Audio playback [mostly done]
    Music, sound effects, looping, pause or resume, bus routing, master and per-bus volume control, and headless silent mode are implemented. Still missing: fades, crossfades, and spatial audio.

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -323,6 +323,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
     };
 
     let mut game = G::new(&mut engine);
+    let mut frame = Frame::new();
 
     if headless {
         loop {
@@ -373,7 +374,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                         return;
                     }
 
-                    let mut frame = Frame::new();
+                    frame.begin();
                     game.render(&engine, &mut frame);
 
                     if show_fps {
@@ -449,6 +450,7 @@ where
     let mut initial = init(&mut engine, &mut globals);
     initial.on_enter(&mut engine, &mut globals);
     stack.push(initial);
+    let mut frame = Frame::new();
 
     if headless {
         loop {
@@ -515,7 +517,7 @@ where
                         return;
                     }
 
-                    let mut frame = Frame::new();
+                    frame.begin();
                     for scene in stack.iter() {
                         scene.render(&engine, &globals, &mut frame);
                     }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -23,7 +23,7 @@ pub use assets::Color;
 pub use input::InputState;
 pub use math::Rect;
 pub use math::TimeState;
-pub use renderer::{Camera2D, DrawParams, Frame, TextureId};
+pub use renderer::{Camera2D, CameraBounds, DrawParams, Frame, TextureId};
 
 pub use world::tilemap;
 pub use world::{aabb_overlap, iso_to_screen, screen_to_iso, TileDef, TileMap};

--- a/engine/src/renderer/camera.rs
+++ b/engine/src/renderer/camera.rs
@@ -1,9 +1,26 @@
 use glam::{Mat4, Vec2};
 
-
 pub struct Camera2D {
     pub position: Vec2,
     pub zoom: f32,
+    pub rotation: f32,
+
+    pub bounds: Option<CameraBounds>,
+
+    follow_target: Option<Vec2>,
+    follow_speed: f32,
+    dead_zone: Vec2,
+
+    shake_intensity: f32,
+    shake_duration: f32,
+    shake_elapsed: f32,
+    shake_offset: Vec2,
+    shake_seed: u32,
+}
+
+pub struct CameraBounds {
+    pub min: Vec2,
+    pub max: Vec2,
 }
 
 impl Camera2D {
@@ -11,22 +28,84 @@ impl Camera2D {
         Self {
             position: Vec2::ZERO,
             zoom: 1.0,
+            rotation: 0.0,
+            bounds: None,
+            follow_target: None,
+            follow_speed: 5.0,
+            dead_zone: Vec2::ZERO,
+            shake_intensity: 0.0,
+            shake_duration: 0.0,
+            shake_elapsed: 0.0,
+            shake_offset: Vec2::ZERO,
+            shake_seed: 0,
         }
     }
 
+    pub fn follow(&mut self, target: Vec2, speed: f32) {
+        self.follow_target = Some(target);
+        self.follow_speed = speed;
+    }
+
+    pub fn set_dead_zone(&mut self, half_size: Vec2) {
+        self.dead_zone = half_size.abs();
+    }
+
+    pub fn shake(&mut self, intensity: f32, duration: f32) {
+        self.shake_intensity = intensity;
+        self.shake_duration = duration;
+        self.shake_elapsed = 0.0;
+        self.shake_seed = self.shake_seed.wrapping_add(1);
+    }
+
+    pub fn update(&mut self, dt: f32) {
+        if let Some(target) = self.follow_target {
+            let diff = target - self.position;
+            let clamped = Vec2::new(
+                if diff.x.abs() > self.dead_zone.x {
+                    diff.x - diff.x.signum() * self.dead_zone.x
+                } else {
+                    0.0
+                },
+                if diff.y.abs() > self.dead_zone.y {
+                    diff.y - diff.y.signum() * self.dead_zone.y
+                } else {
+                    0.0
+                },
+            );
+            let t = (self.follow_speed * dt).clamp(0.0, 1.0);
+            self.position += clamped * t;
+        }
+
+        if let Some(ref b) = self.bounds {
+            self.position = self.position.clamp(b.min, b.max);
+        }
+
+        if self.shake_elapsed < self.shake_duration {
+            self.shake_elapsed += dt;
+            let t = 1.0 - (self.shake_elapsed / self.shake_duration).min(1.0);
+            let s = self
+                .shake_seed
+                .wrapping_add((self.shake_elapsed * 1000.0) as u32);
+            let hash_x = ((s.wrapping_mul(2654435761)) >> 16) as f32 / 32768.0 - 1.0;
+            let hash_y = ((s.wrapping_mul(2246822519)) >> 16) as f32 / 32768.0 - 1.0;
+            self.shake_offset = Vec2::new(hash_x, hash_y) * self.shake_intensity * t;
+        } else {
+            self.shake_offset = Vec2::ZERO;
+        }
+    }
 
     pub fn projection(&self, viewport_width: f32, viewport_height: f32) -> Mat4 {
         let half_w = viewport_width / 2.0 / self.zoom;
         let half_h = viewport_height / 2.0 / self.zoom;
 
-        Mat4::orthographic_rh(
-            self.position.x - half_w,
-            self.position.x + half_w,
-            self.position.y - half_h,
-            self.position.y + half_h,
-            -1.0,
-            1.0,
-        )
+        let pos = self.position + self.shake_offset;
+
+        let ortho = Mat4::orthographic_rh(-half_w, half_w, -half_h, half_h, -1.0, 1.0);
+
+        let view = Mat4::from_rotation_z(-self.rotation)
+            * Mat4::from_translation(glam::Vec3::new(-pos.x, -pos.y, 0.0));
+
+        ortho * view
     }
 }
 

--- a/engine/src/renderer/mod.rs
+++ b/engine/src/renderer/mod.rs
@@ -2,7 +2,7 @@ pub mod camera;
 pub mod sprite;
 pub mod texture;
 
-pub use camera::Camera2D;
+pub use camera::{Camera2D, CameraBounds};
 pub use sprite::DrawParams;
 pub use texture::TextureId;
 
@@ -53,6 +53,12 @@ impl Frame {
     ) {
         self.sprites
             .push(DrawParams::new(texture, position, size).with_color(color));
+    }
+
+    pub fn begin(&mut self) {
+        self.sprites.clear();
+        self.canvases.clear();
+        self.clear_color = Color::BLACK;
     }
 
     pub fn canvas(&mut self, index: usize) -> &mut Canvas {

--- a/samples/features/feature-camera/Cargo.toml
+++ b/samples/features/feature-camera/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rengine-feature-camera"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "rengine-feature-camera"
+path = "src/main.rs"
+
+[dependencies]
+rengine = { path = "../../../engine" }

--- a/samples/features/feature-camera/src/main.rs
+++ b/samples/features/feature-camera/src/main.rs
@@ -1,0 +1,179 @@
+use rengine::*;
+
+const WORLD_SIZE: f32 = 800.0;
+const PLAYER_SPEED: f32 = 200.0;
+const PLAYER_SIZE: f32 = 24.0;
+
+struct CameraDemo {
+    white: TextureId,
+    checker: TextureId,
+    player_pos: Vec2,
+    rotation_mode: bool,
+    pending_shake: bool,
+}
+
+impl Game for CameraDemo {
+    fn new(engine: &mut Engine) -> Self {
+        let white = engine.create_color_texture(1, 1, Color::WHITE);
+
+        let grid_size: u32 = 16;
+        let mut pixels = Vec::with_capacity((grid_size * grid_size * 4) as usize);
+        for row in 0..grid_size {
+            for col in 0..grid_size {
+                let on_edge = row == 0 || col == 0;
+                if on_edge {
+                    pixels.extend_from_slice(&[100, 100, 110, 255]);
+                } else {
+                    pixels.extend_from_slice(&[50, 50, 58, 255]);
+                }
+            }
+        }
+        let checker = engine.create_texture(grid_size, grid_size, &pixels);
+
+        Self {
+            white,
+            checker,
+            player_pos: Vec2::ZERO,
+            rotation_mode: false,
+            pending_shake: false,
+        }
+    }
+
+    fn update(&mut self, engine: &Engine) {
+        let input = engine.input();
+        let dt = engine.dt();
+
+        let mut dir = Vec2::ZERO;
+        if input.is_key_down(KeyCode::KeyW) || input.is_key_down(KeyCode::ArrowUp) {
+            dir.y += 1.0;
+        }
+        if input.is_key_down(KeyCode::KeyS) || input.is_key_down(KeyCode::ArrowDown) {
+            dir.y -= 1.0;
+        }
+        if input.is_key_down(KeyCode::KeyA) || input.is_key_down(KeyCode::ArrowLeft) {
+            dir.x -= 1.0;
+        }
+        if input.is_key_down(KeyCode::KeyD) || input.is_key_down(KeyCode::ArrowRight) {
+            dir.x += 1.0;
+        }
+        if dir != Vec2::ZERO {
+            self.player_pos += dir.normalize() * PLAYER_SPEED * dt;
+        }
+
+        let half = WORLD_SIZE / 2.0;
+        self.player_pos = self
+            .player_pos
+            .clamp(Vec2::new(-half, -half), Vec2::new(half, half));
+
+        if input.is_key_pressed(KeyCode::KeyR) {
+            self.rotation_mode = !self.rotation_mode;
+        }
+
+        if input.is_key_pressed(KeyCode::Space) {
+            self.pending_shake = true;
+        }
+    }
+
+    fn render(&mut self, engine: &Engine, frame: &mut Frame) {
+        frame.clear_color = Color::new(0.08, 0.08, 0.12, 1.0);
+
+        let cam = &mut frame.camera;
+        cam.follow(self.player_pos, 2.0);
+        cam.set_dead_zone(Vec2::new(80.0, 50.0));
+        cam.bounds = Some(CameraBounds {
+            min: Vec2::new(-WORLD_SIZE / 2.0, -WORLD_SIZE / 2.0),
+            max: Vec2::new(WORLD_SIZE / 2.0, WORLD_SIZE / 2.0),
+        });
+
+        if self.pending_shake {
+            self.pending_shake = false;
+            cam.shake(25.0, 0.5);
+        }
+
+        if self.rotation_mode {
+            cam.rotation += engine.dt() * 1.5;
+        }
+
+        cam.update(engine.dt());
+
+        let white = self.white;
+        let checker = self.checker;
+
+        let half = WORLD_SIZE / 2.0;
+        let tile = 64.0;
+        let mut y = -half;
+        while y < half {
+            let mut x = -half;
+            while x < half {
+                frame.draw_sprite(DrawParams::new(
+                    checker,
+                    Vec2::new(x, y),
+                    Vec2::new(tile, tile),
+                ));
+                x += tile;
+            }
+            y += tile;
+        }
+
+        let boundary_color = Color::new(0.6, 0.2, 0.2, 1.0);
+        let thick = 4.0;
+        frame.draw_sprite(
+            DrawParams::new(white, Vec2::new(-half, -half), Vec2::new(WORLD_SIZE, thick))
+                .with_color(boundary_color),
+        );
+        frame.draw_sprite(
+            DrawParams::new(
+                white,
+                Vec2::new(-half, half - thick),
+                Vec2::new(WORLD_SIZE, thick),
+            )
+            .with_color(boundary_color),
+        );
+        frame.draw_sprite(
+            DrawParams::new(white, Vec2::new(-half, -half), Vec2::new(thick, WORLD_SIZE))
+                .with_color(boundary_color),
+        );
+        frame.draw_sprite(
+            DrawParams::new(
+                white,
+                Vec2::new(half - thick, -half),
+                Vec2::new(thick, WORLD_SIZE),
+            )
+            .with_color(boundary_color),
+        );
+
+        let hs = PLAYER_SIZE / 2.0;
+        frame.draw_sprite(
+            DrawParams::new(
+                white,
+                Vec2::new(self.player_pos.x - hs, self.player_pos.y - hs),
+                Vec2::new(PLAYER_SIZE, PLAYER_SIZE),
+            )
+            .with_color(Color::new(0.2, 0.8, 1.0, 1.0))
+            .with_z_order(10),
+        );
+
+        let (sw, sh) = engine.window_size();
+        let canvas = frame.canvas(0);
+        canvas.text(
+            8.0,
+            8.0,
+            "WASD:Move  Space:Shake  R:Rotation  |  Follow + DeadZone + Bounds + Shake",
+            11.0,
+            Color::WHITE,
+            (sw, sh),
+            engine.font_atlas(),
+        );
+    }
+}
+
+fn main() {
+    rengine::run::<CameraDemo>(EngineConfig {
+        title: "Feature: Camera".into(),
+        width: 800,
+        height: 600,
+        show_fps: false,
+        ..Default::default()
+    })
+    .unwrap();
+}

--- a/samples/features/feature-camera/src/main.rs
+++ b/samples/features/feature-camera/src/main.rs
@@ -158,7 +158,7 @@ impl Game for CameraDemo {
         canvas.text(
             8.0,
             8.0,
-            "WASD:Move  Space:Shake  R:Rotation  |  Follow + DeadZone + Bounds + Shake",
+            "WASD:Move  Space:Shake  R:Rotation",
             11.0,
             Color::WHITE,
             (sw, sh),


### PR DESCRIPTION
Adds rotation, smooth follow with dead zones, screen shake (intensity + duration with decay), and camera bounds clamping to Camera2D. Projection refactored to ortho × view matrix — no shader changes needed.

**New on Camera2D:**
- `rotation: f32` — world rotation in radians
- `bounds: Option<CameraBounds>` — clamp position to world region
- `follow(target, speed)` — smooth lerp toward a target each frame
- `set_dead_zone(half_size)` — ignore small target movements
- `shake(intensity, duration)` — decaying random offset
- `update(dt)` — must be called each frame to advance follow/shake/bounds

**Feature sample:** `feature-camera` — WASD movement, follow + dead zone + bounds, Space for shake, R to toggle rotation.

ROADMAP.md and ARCHITECTURE.md updated.