### PR TITLE
Feature sample: Canvas drawing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rengine-feature-canvas"
+version = "0.1.0"
+dependencies = [
+ "rengine",
+]
+
+[[package]]
 name = "rengine-feature-input"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["engine", "samples/games/game-platformer", "samples/games/game-topdown", "samples/games/game-iso", "samples/games/game-fps", "samples/games/game-fight", "samples/games/game-fps-mp", "samples/features/feature-scenes", "samples/features/feature-sprites", "samples/features/feature-camera", "samples/features/feature-input"]
+members = ["engine", "samples/games/game-platformer", "samples/games/game-topdown", "samples/games/game-iso", "samples/games/game-fps", "samples/games/game-fight", "samples/games/game-fps-mp", "samples/features/feature-scenes", "samples/features/feature-sprites", "samples/features/feature-camera", "samples/features/feature-input", "samples/features/feature-canvas"]
 resolver = "2"

--- a/samples/features/feature-canvas/Cargo.toml
+++ b/samples/features/feature-canvas/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rengine-feature-canvas"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "rengine-feature-canvas"
+path = "src/main.rs"
+
+[dependencies]
+rengine = { path = "../../../engine" }

--- a/samples/features/feature-canvas/src/main.rs
+++ b/samples/features/feature-canvas/src/main.rs
@@ -1,0 +1,116 @@
+use rengine::*;
+
+struct CanvasDemo {
+    time: f32,
+}
+
+impl Game for CanvasDemo {
+    fn new(_engine: &mut Engine) -> Self {
+        Self {
+            time: 0.0,
+        }
+    }
+
+    fn update(&mut self, engine: &Engine) {
+        self.time += engine.dt();
+    }
+
+    fn render(&mut self, engine: &Engine, frame: &mut Frame) {
+        frame.clear_color = Color::new(0.08, 0.08, 0.12, 1.0);
+        let screen = engine.window_size();
+        let atlas = engine.font_atlas();
+
+        let hud = frame.canvas(0);
+
+        hud.rect(20.0, 20.0, 200.0, 120.0, Color::new(0.15, 0.15, 0.22, 0.9), screen);
+        hud.text(30.0, 30.0, "Canvas Demo", 20.0, Color::WHITE, screen, atlas);
+        hud.text(30.0, 56.0, "Rectangles, text,", 14.0, Color::new(0.7, 0.7, 0.7, 1.0), screen, atlas);
+        hud.text(30.0, 74.0, "and custom shapes", 14.0, Color::new(0.7, 0.7, 0.7, 1.0), screen, atlas);
+
+        let colors = [Color::RED, Color::ORANGE, Color::YELLOW, Color::GREEN, Color::BLUE, Color::INDIGO, Color::VIOLET];
+        for (i, color) in colors.iter().enumerate() {
+            let x = 260.0 + i as f32 * 50.0;
+            hud.rect(x, 30.0, 40.0, 40.0, *color, screen);
+        }
+        hud.text(260.0, 80.0, "Color palette", 14.0, Color::new(0.7, 0.7, 0.7, 1.0), screen, atlas);
+
+        let bar_w = 300.0;
+        let bar_h = 24.0;
+        let bar_x = 260.0;
+        let bar_y = 110.0;
+        hud.rect(bar_x, bar_y, bar_w, bar_h, Color::new(0.2, 0.2, 0.2, 1.0), screen);
+        let fill = ((self.time * 0.3).sin() * 0.5 + 0.5) * bar_w;
+        hud.rect(bar_x, bar_y, fill, bar_h, Color::new(0.3, 0.8, 0.4, 1.0), screen);
+        hud.text(bar_x + 8.0, bar_y + 4.0, "Animated bar", 14.0, Color::WHITE, screen, atlas);
+
+        let shapes = frame.canvas(1);
+        let sw = screen.0 as f32;
+        let sh = screen.1 as f32;
+
+        let cx = sw * 0.35;
+        let cy = sh * 0.6;
+        let r = 60.0;
+        let segments = 24;
+        for i in 0..segments {
+            let a0 = i as f32 / segments as f32 * std::f32::consts::TAU;
+            let a1 = (i + 1) as f32 / segments as f32 * std::f32::consts::TAU;
+            let t = i as f32 / segments as f32;
+            let color = Color::new(t, 1.0 - t, 0.5 + t * 0.5, 0.8);
+            let c = color.to_array();
+
+            let p0 = screen_to_ndc(cx, cy, screen);
+            let p1 = screen_to_ndc(cx + a0.cos() * r, cy + a0.sin() * r, screen);
+            let p2 = screen_to_ndc(cx + a1.cos() * r, cy + a1.sin() * r, screen);
+
+            let uv = [0.0, 0.0];
+            shapes.shape(&[
+                CanvasVertex { position: p0, color: c, uv },
+                CanvasVertex { position: p1, color: c, uv },
+                CanvasVertex { position: p2, color: c, uv },
+            ]);
+        }
+
+        let label = frame.canvas(2);
+        label.text(cx - 70.0, cy + r + 10.0, "Custom triangle fan", 14.0, Color::WHITE, screen, atlas);
+
+        let dx = sw * 0.65;
+        let dy = sh * 0.55;
+        let spin = self.time * 1.5;
+        let size = 90.0;
+        let corners: [(f32, f32); 4] = [
+            (dx + spin.cos() * size, dy + spin.sin() * size),
+            (dx + (spin + 1.57).cos() * size, dy + (spin + 1.57).sin() * size),
+            (dx + (spin + 3.14).cos() * size, dy + (spin + 3.14).sin() * size),
+            (dx + (spin + 4.71).cos() * size, dy + (spin + 4.71).sin() * size),
+        ];
+
+        let quad_color = Color::new(0.2, 0.5, 1.0, 0.7).to_array();
+        let uv = [0.0, 0.0];
+        let verts: Vec<CanvasVertex> = corners.iter().map(|&(x, y)| {
+            let p = screen_to_ndc(x, y, screen);
+            CanvasVertex { position: p, color: quad_color, uv }
+        }).collect();
+
+        let shapes2 = frame.canvas(1);
+        shapes2.shape(&[verts[0], verts[1], verts[2], verts[0], verts[2], verts[3]]);
+
+        let label2 = frame.canvas(2);
+        label2.text(dx - 60.0, dy + size + 20.0, "Spinning quad", 14.0, Color::WHITE, screen, atlas);
+
+        let stats = frame.canvas(3);
+        let fps_text = format!("dt: {:.1}ms", engine.dt() * 1000.0);
+        let time_text = format!("time: {:.1}s", self.time);
+        stats.rect(20.0, sh - 60.0, 160.0, 50.0, Color::new(0.1, 0.1, 0.15, 0.85), screen);
+        stats.text(30.0, sh - 52.0, &fps_text, 14.0, Color::YELLOW, screen, atlas);
+        stats.text(30.0, sh - 34.0, &time_text, 14.0, Color::new(0.6, 0.8, 1.0, 1.0), screen, atlas);
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    rengine::run::<CanvasDemo>(EngineConfig {
+        title: "Feature: Canvas Drawing".into(),
+        width: 800,
+        height: 600,
+        ..Default::default()
+    })
+}


### PR DESCRIPTION
Demonstrates the Canvas API for screen-space HUD/debug drawing:

- `Canvas::rect()` for filled rectangles
- `Canvas::text()` with `FontAtlas` for text rendering
- `Canvas::shape()` with custom `CanvasVertex` triangles
- `screen_to_ndc()` coordinate conversion
- Multiple canvas layers (indices 0-3)
- Animated progress bar, color palette, spinning quad, rainbow triangle fan