### PR TITLE
Asset pipeline: dependency tracking, validation, and cache management

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -595,23 +595,18 @@ pub struct Frame3D {
 }
 ```
 
-`DrawCmd3D` holds a mesh reference with full TRS (translation, rotation, scale) transform:
+`DrawCmd3D` is a position + mesh reference:
 
 ```rust
 pub struct DrawCmd3D {
     pub mesh: MeshId,
     pub position: Vec3,
-    pub rotation: Quat,
-    pub scale: Vec3,
 }
 ```
 
-Create via `DrawCmd3D::new(mesh, position)` (defaults to identity rotation and unit scale), then chain builder methods: `.with_rotation(quat)`, `.with_scale(vec3)`, `.with_uniform_scale(f32)`. The `transform_matrix()` method computes `Mat4::from_scale_rotation_translation(scale, rotation, position)`.
-
 The frame is populated via:
 
-- [`frame.draw_mesh(mesh_id, position)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L92) — World-space mesh (identity rotation, unit scale)
-- [`frame.draw_mesh_transformed(cmd)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs) — World-space mesh with full TRS
+- [`frame.draw_mesh(mesh_id, position)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L92) — World-space mesh
 - [`frame.draw_viewmodel_mesh(mesh_id, position)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L96) — Camera-relative viewmodel mesh
 - [`frame.draw_raw(vertices, indices)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L100) — Inline geometry (no MeshId needed)
 
@@ -619,7 +614,7 @@ The frame is populated via:
 
 1. Compute view-projection from `frame.camera`.
 2. Upload uniforms (VP matrix + lighting).
-3. **Build geometry:** `build_draw_geometry()` iterates all `DrawCmd3D`s, computes a full TRS `Mat4` per draw, applies it to vertex positions CPU-side, and uses `Mat3::from_quat` for correct normal rotation. All vertices/indices are concatenated. Raw vertices/indices are appended after.
+3. **Build geometry:** `build_draw_geometry()` iterates all `DrawCmd3D`s, copies each mesh's vertices with position offset applied CPU-side, and concatenates all indices with base offsets. Raw vertices/indices are appended after.
 4. Upload concatenated vertices + indices to GPU buffers.
 5. Render pass with clear + depth attachment.
 6. If viewmodel draws exist: a second render pass with the viewmodel camera's VP matrix and depth cleared to 1.0 (viewmodel always renders on top).
@@ -629,14 +624,12 @@ The frame is populated via:
 
 The `Viewmodel3D` has its own `Camera3D` with tight near/far planes (0.01–16.0) and narrow FOV (50°). This prevents viewmodel geometry from clipping into walls.
 
-`build_viewmodel_geometry()` applies the per-draw TRS transform in local space, then transforms from camera-local space to world space using the inverse of the viewmodel camera's view matrix:
+`build_viewmodel_geometry()` transforms each mesh vertex from camera-local space to world space using the inverse of the viewmodel camera's view matrix:
 
 ```rust
-let local_transform = cmd.transform_matrix(); // TRS
 let camera_from_view = camera.view_matrix().inverse();
-let world_position = camera_from_view.transform_point3(local_transform.transform_point3(v));
-let normal_rot = Mat3::from_quat(cmd.rotation);
-let world_normal = camera_from_view.transform_vector3(normal_rot * normal).normalize_or_zero();
+let world_position = camera_from_view.transform_point3(local_position);
+let world_normal = camera_from_view.transform_vector3(normal).normalize_or_zero();
 ```
 
 The viewmodel pass clears depth but **loads** the existing color (preserving the world render), then renders the viewmodel geometry on top.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -595,18 +595,23 @@ pub struct Frame3D {
 }
 ```
 
-`DrawCmd3D` is a position + mesh reference:
+`DrawCmd3D` holds a mesh reference with full TRS (translation, rotation, scale) transform:
 
 ```rust
 pub struct DrawCmd3D {
     pub mesh: MeshId,
     pub position: Vec3,
+    pub rotation: Quat,
+    pub scale: Vec3,
 }
 ```
 
+Create via `DrawCmd3D::new(mesh, position)` (defaults to identity rotation and unit scale), then chain builder methods: `.with_rotation(quat)`, `.with_scale(vec3)`, `.with_uniform_scale(f32)`. The `transform_matrix()` method computes `Mat4::from_scale_rotation_translation(scale, rotation, position)`.
+
 The frame is populated via:
 
-- [`frame.draw_mesh(mesh_id, position)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L92) — World-space mesh
+- [`frame.draw_mesh(mesh_id, position)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L92) — World-space mesh (identity rotation, unit scale)
+- [`frame.draw_mesh_transformed(cmd)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs) — World-space mesh with full TRS
 - [`frame.draw_viewmodel_mesh(mesh_id, position)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L96) — Camera-relative viewmodel mesh
 - [`frame.draw_raw(vertices, indices)`](https://github.com/justinwash/rengine/blob/master/engine/src/renderer3d/mod.rs#L100) — Inline geometry (no MeshId needed)
 
@@ -614,7 +619,7 @@ The frame is populated via:
 
 1. Compute view-projection from `frame.camera`.
 2. Upload uniforms (VP matrix + lighting).
-3. **Build geometry:** `build_draw_geometry()` iterates all `DrawCmd3D`s, copies each mesh's vertices with position offset applied CPU-side, and concatenates all indices with base offsets. Raw vertices/indices are appended after.
+3. **Build geometry:** `build_draw_geometry()` iterates all `DrawCmd3D`s, computes a full TRS `Mat4` per draw, applies it to vertex positions CPU-side, and uses `Mat3::from_quat` for correct normal rotation. All vertices/indices are concatenated. Raw vertices/indices are appended after.
 4. Upload concatenated vertices + indices to GPU buffers.
 5. Render pass with clear + depth attachment.
 6. If viewmodel draws exist: a second render pass with the viewmodel camera's VP matrix and depth cleared to 1.0 (viewmodel always renders on top).
@@ -624,12 +629,14 @@ The frame is populated via:
 
 The `Viewmodel3D` has its own `Camera3D` with tight near/far planes (0.01–16.0) and narrow FOV (50°). This prevents viewmodel geometry from clipping into walls.
 
-`build_viewmodel_geometry()` transforms each mesh vertex from camera-local space to world space using the inverse of the viewmodel camera's view matrix:
+`build_viewmodel_geometry()` applies the per-draw TRS transform in local space, then transforms from camera-local space to world space using the inverse of the viewmodel camera's view matrix:
 
 ```rust
+let local_transform = cmd.transform_matrix(); // TRS
 let camera_from_view = camera.view_matrix().inverse();
-let world_position = camera_from_view.transform_point3(local_position);
-let world_normal = camera_from_view.transform_vector3(normal).normalize_or_zero();
+let world_position = camera_from_view.transform_point3(local_transform.transform_point3(v));
+let normal_rot = Mat3::from_quat(cmd.rotation);
+let world_normal = camera_from_view.transform_vector3(normal_rot * normal).normalize_or_zero();
 ```
 
 The viewmodel pass clears depth but **loads** the existing color (preserving the world render), then renders the viewmodel geometry on top.
@@ -915,12 +922,19 @@ struct AssetPipeline {
     texture_timestamps: HashMap<PathBuf, SystemTime>,
     mesh_timestamps: HashMap<PathBuf, SystemTime>,
     manifest_timestamps: HashMap<PathBuf, SystemTime>,
+    manifest_deps: HashMap<PathBuf, Vec<PathBuf>>,
 }
 ```
 
 **Path resolution:** `resolve_path()` joins relative paths with `self.root` and canonicalizes. Absolute paths are used as-is.
 
 **Caching:** All `load_*` methods check the cache first. This means calling `load_texture("player.png")` twice returns the same `TextureId` without re-uploading.
+
+**Dependency tracking:** When `load_asset_manifest()` is called, the engine records every file path loaded by that manifest in `manifest_deps`. Query with `engine.manifest_dependencies("assets.json")`.
+
+**Manifest validation:** `engine.validate_manifest("assets.json")` parses the manifest JSON and checks that every referenced file exists on disk. Returns `Vec<AssetError>` with all problems found rather than failing on the first. Useful for build-time or startup validation.
+
+**Cache management:** `engine.loaded_asset_summary()` returns an `AssetSummary` with counts and paths. Use `unload_texture()`, `unload_mesh()`, or `unload_data()` to evict cached assets.
 
 ### 8.2 [`AssetManifest`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L158) and [`AssetPack`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L174)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,7 +51,7 @@ Recently completed or partially completed:
 - Completed: input action mapping — `ActionMap` with named digital actions and analog axes, `Binding` enum for Key/MouseButton/GamepadButton, `AxisMapping` with positive/negative bindings and optional gamepad stick axis, convenience methods on `Engine` and `Engine3D`
 - Completed: `feature-input` sample — demonstrates action binding setup, axis-driven movement, pressed/down/released queries with visual feedback
 - Completed: asset pipeline validation and dependency tracking — `validate_manifest()` for pre-load checks, `manifest_dependencies()` for tracking which files each manifest loaded, `loaded_asset_summary()` for debugging, `unload_texture/mesh/data()` for cache eviction
-- Completed: full 3D transforms — per-draw rotation (`Quat`) and scale (`Vec3`) via `DrawCmd3D` builder pattern, TRS matrix applied to positions, `Mat3::from_quat` for correct normal transforms
+- Partial: 3D transforms still only support position-based translation; rotation and scale per draw are not yet supported (caused the recurring door visibility issue)
 
 ---
 
@@ -184,8 +184,8 @@ These features make 2D development substantially more practical.
 
 The 3D renderer exists, but these features are required before it becomes practical for general development.
 
-39. Full 3D transforms [done]
-    Per-draw rotation (Quat) and scale (Vec3) via DrawCmd3D builder pattern. TRS matrix applied to vertex positions, Mat3::from_quat for normal transforms. Backward compatible — existing draw_mesh(mesh, pos) calls unchanged.
+39. Full 3D transforms [not started — needed]
+    Per-draw rotation and scale in addition to position. Lack of rotation caused sample door meshes to be invisible when oriented wrong for the scene.
 
 40. Transform hierarchies
     Parent-child spatial relationships for weapons, bones, cameras, and grouped props.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,8 +50,8 @@ Recently completed or partially completed:
 - Completed: `feature-camera` sample — demonstrates follow, dead zone, bounds, shake, and rotation toggle
 - Completed: input action mapping — `ActionMap` with named digital actions and analog axes, `Binding` enum for Key/MouseButton/GamepadButton, `AxisMapping` with positive/negative bindings and optional gamepad stick axis, convenience methods on `Engine` and `Engine3D`
 - Completed: `feature-input` sample — demonstrates action binding setup, axis-driven movement, pressed/down/released queries with visual feedback
-- Partial: broader asset pipeline coverage still needs validation tooling, dependency tracking, and additional import formats beyond OBJ and glTF
-- Partial: 3D transforms still only support position-based translation; rotation and scale per draw are not yet supported (caused the recurring door visibility issue)
+- Completed: asset pipeline validation and dependency tracking — `validate_manifest()` for pre-load checks, `manifest_dependencies()` for tracking which files each manifest loaded, `loaded_asset_summary()` for debugging, `unload_texture/mesh/data()` for cache eviction
+- Completed: full 3D transforms — per-draw rotation (`Quat`) and scale (`Vec3`) via `DrawCmd3D` builder pattern, TRS matrix applied to positions, `Mat3::from_quat` for correct normal transforms
 
 ---
 
@@ -184,8 +184,8 @@ These features make 2D development substantially more practical.
 
 The 3D renderer exists, but these features are required before it becomes practical for general development.
 
-39. Full 3D transforms [not started — needed]
-    Per-draw rotation and scale in addition to position. Lack of rotation caused sample door meshes to be invisible when oriented wrong for the scene.
+39. Full 3D transforms [done]
+    Per-draw rotation (Quat) and scale (Vec3) via DrawCmd3D builder pattern. TRS matrix applied to vertex positions, Mat3::from_quat for normal transforms. Backward compatible — existing draw_mesh(mesh, pos) calls unchanged.
 
 40. Transform hierarchies
     Parent-child spatial relationships for weapons, bones, cameras, and grouped props.

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -316,7 +316,17 @@ impl Engine {
     }
 
     pub fn validate_manifest<P: AsRef<Path>>(&self, path: P) -> Vec<AssetError> {
-        self.assets.validate_manifest(path)
+        let path = path.as_ref();
+        let mut errors = self.assets.validate_manifest(path);
+        if let Ok(manifest) = self.assets.peek_manifest(path) {
+            if !manifest.meshes.is_empty() {
+                errors.push(AssetError::manifest_message(
+                    &self.assets.resolve_path(path),
+                    "2D Engine manifest cannot contain mesh entries; use Engine3D instead",
+                ));
+            }
+        }
+        errors
     }
 
     pub fn loaded_asset_summary(&self) -> crate::assets::AssetSummary {
@@ -889,7 +899,17 @@ impl Engine3D {
     }
 
     pub fn validate_manifest<P: AsRef<Path>>(&self, path: P) -> Vec<AssetError> {
-        self.assets.validate_manifest(path)
+        let path = path.as_ref();
+        let mut errors = self.assets.validate_manifest(path);
+        if let Ok(manifest) = self.assets.peek_manifest(path) {
+            if !manifest.textures.is_empty() || !manifest.sprite_sheets.is_empty() {
+                errors.push(AssetError::manifest_message(
+                    &self.assets.resolve_path(path),
+                    "3D Engine manifest does not support textures or sprite_sheets",
+                ));
+            }
+        }
+        errors
     }
 
     pub fn loaded_asset_summary(&self) -> crate::assets::AssetSummary {

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -160,25 +160,37 @@ impl Engine {
         &mut self,
         path: P,
     ) -> Result<AssetPack, AssetError> {
-        let manifest = self.assets.load_manifest(path)?;
+        let manifest_path = self.assets.resolve_path(path.as_ref());
+        let manifest = self.assets.load_manifest(&manifest_path)?;
         let mut pack = AssetPack::default();
+        let mut deps = Vec::new();
 
         for (alias, rel_path) in manifest.bytes {
+            let resolved = self.assets.resolve_path(Path::new(&rel_path));
+            deps.push(resolved);
             pack.insert_bytes(alias, self.assets.load_bytes(rel_path)?);
         }
         for (alias, rel_path) in manifest.text {
+            let resolved = self.assets.resolve_path(Path::new(&rel_path));
+            deps.push(resolved);
             pack.insert_text(alias, self.assets.load_text(rel_path)?);
         }
         for (alias, rel_path) in manifest.textures {
+            let resolved = self.assets.resolve_path(Path::new(&rel_path));
+            deps.push(resolved);
             pack.insert_texture(alias, self.load_texture(rel_path)?);
         }
         for (alias, sheet) in manifest.sprite_sheets {
+            let resolved = self.assets.resolve_path(Path::new(&sheet.path));
+            deps.push(resolved);
             pack.insert_sprite_sheet(
                 alias,
                 self.load_sprite_sheet(sheet.path, sheet.cell_width, sheet.cell_height)?,
             );
         }
         for (alias, rel_path) in manifest.audio {
+            let resolved = self.assets.resolve_path(Path::new(&rel_path));
+            deps.push(resolved);
             pack.insert_audio(alias, self.load_audio(rel_path)?);
         }
         if !manifest.meshes.is_empty() {
@@ -188,6 +200,7 @@ impl Engine {
             ));
         }
 
+        self.assets.record_manifest_deps(manifest_path, deps);
         Ok(pack)
     }
 
@@ -300,6 +313,28 @@ impl Engine {
                 Err(error) => log::warn!("Audio reload failed: {error}"),
             }
         }
+    }
+
+    pub fn validate_manifest<P: AsRef<Path>>(&self, path: P) -> Vec<AssetError> {
+        self.assets.validate_manifest(path)
+    }
+
+    pub fn loaded_asset_summary(&self) -> crate::assets::AssetSummary {
+        self.assets.loaded_asset_summary()
+    }
+
+    pub fn manifest_dependencies<P: AsRef<Path>>(&self, path: P) -> Option<Vec<PathBuf>> {
+        self.assets
+            .manifest_dependencies(path)
+            .map(|deps| deps.to_vec())
+    }
+
+    pub fn unload_texture<P: AsRef<Path>>(&mut self, path: P) {
+        self.assets.unload_texture(path);
+    }
+
+    pub fn unload_data<P: AsRef<Path>>(&mut self, path: P) {
+        self.assets.unload_data(path);
     }
 
     pub fn create_color_texture(&mut self, width: u32, height: u32, color: Color) -> TextureId {
@@ -722,19 +757,29 @@ impl Engine3D {
         &mut self,
         path: P,
     ) -> Result<AssetPack, AssetError> {
-        let manifest = self.assets.load_manifest(path)?;
+        let manifest_path = self.assets.resolve_path(path.as_ref());
+        let manifest = self.assets.load_manifest(&manifest_path)?;
         let mut pack = AssetPack::default();
+        let mut deps = Vec::new();
 
         for (alias, rel_path) in manifest.bytes {
+            let resolved = self.assets.resolve_path(Path::new(&rel_path));
+            deps.push(resolved);
             pack.insert_bytes(alias, self.assets.load_bytes(rel_path)?);
         }
         for (alias, rel_path) in manifest.text {
+            let resolved = self.assets.resolve_path(Path::new(&rel_path));
+            deps.push(resolved);
             pack.insert_text(alias, self.assets.load_text(rel_path)?);
         }
         for (alias, rel_path) in manifest.audio {
+            let resolved = self.assets.resolve_path(Path::new(&rel_path));
+            deps.push(resolved);
             pack.insert_audio(alias, self.load_audio(rel_path)?);
         }
         for (alias, rel_path) in manifest.meshes {
+            let resolved = self.assets.resolve_path(Path::new(&rel_path));
+            deps.push(resolved);
             pack.insert_mesh(alias, self.load_mesh(rel_path)?);
         }
         if !manifest.textures.is_empty() || !manifest.sprite_sheets.is_empty() {
@@ -744,6 +789,7 @@ impl Engine3D {
             ));
         }
 
+        self.assets.record_manifest_deps(manifest_path, deps);
         Ok(pack)
     }
 
@@ -840,6 +886,28 @@ impl Engine3D {
                 Err(error) => log::warn!("Audio reload failed: {error}"),
             }
         }
+    }
+
+    pub fn validate_manifest<P: AsRef<Path>>(&self, path: P) -> Vec<AssetError> {
+        self.assets.validate_manifest(path)
+    }
+
+    pub fn loaded_asset_summary(&self) -> crate::assets::AssetSummary {
+        self.assets.loaded_asset_summary()
+    }
+
+    pub fn manifest_dependencies<P: AsRef<Path>>(&self, path: P) -> Option<Vec<PathBuf>> {
+        self.assets
+            .manifest_dependencies(path)
+            .map(|deps| deps.to_vec())
+    }
+
+    pub fn unload_mesh<P: AsRef<Path>>(&mut self, path: P) {
+        self.assets.unload_mesh(path);
+    }
+
+    pub fn unload_data<P: AsRef<Path>>(&mut self, path: P) {
+        self.assets.unload_data(path);
     }
 
     pub fn create_mesh(&mut self, vertices: Vec<Vertex3D>, indices: Vec<u32>) -> MeshId {

--- a/engine/src/assets/mod.rs
+++ b/engine/src/assets/mod.rs
@@ -9,6 +9,7 @@ pub use audio::{AudioBus, AudioClip, AudioId};
 pub use color::Color;
 pub(crate) use pipeline::AssetPipeline;
 pub use pipeline::{
-    AssetError, AssetManifest, AssetPack, MeshAsset, SpriteSheetAssetDef, TextureAsset,
+    AssetError, AssetManifest, AssetPack, AssetSummary, MeshAsset, SpriteSheetAssetDef,
+    TextureAsset,
 };
 pub use spritesheet::{Animation, SpriteSheet};

--- a/engine/src/assets/pipeline.rs
+++ b/engine/src/assets/pipeline.rs
@@ -13,14 +13,38 @@ use crate::renderer3d::{MeshId, Vertex3D};
 
 #[derive(Debug)]
 pub enum AssetError {
-    Io { path: PathBuf, source: std::io::Error },
-    Utf8 { path: PathBuf, source: std::string::FromUtf8Error },
-    Json { path: PathBuf, source: serde_json::Error },
-    Image { path: PathBuf, source: image::ImageError },
-    Mesh { path: PathBuf, message: String },
-    Manifest { path: PathBuf, message: String },
-    Scene { path: PathBuf, message: String },
-    Audio { path: PathBuf, message: String },
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Utf8 {
+        path: PathBuf,
+        source: std::string::FromUtf8Error,
+    },
+    Json {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    Image {
+        path: PathBuf,
+        source: image::ImageError,
+    },
+    Mesh {
+        path: PathBuf,
+        message: String,
+    },
+    Manifest {
+        path: PathBuf,
+        message: String,
+    },
+    Scene {
+        path: PathBuf,
+        message: String,
+    },
+    Audio {
+        path: PathBuf,
+        message: String,
+    },
     InvalidSpriteSheet {
         path: PathBuf,
         texture_width: u32,
@@ -63,7 +87,11 @@ impl fmt::Display for AssetError {
                 write!(f, "asset '{}' is not valid UTF-8: {source}", path.display())
             }
             Self::Json { path, source } => {
-                write!(f, "asset '{}' contains invalid JSON: {source}", path.display())
+                write!(
+                    f,
+                    "asset '{}' contains invalid JSON: {source}",
+                    path.display()
+                )
             }
             Self::Image { path, source } => {
                 write!(f, "failed to decode image '{}': {source}", path.display())
@@ -78,7 +106,11 @@ impl fmt::Display for AssetError {
                 write!(f, "failed to load scene '{}': {message}", path.display())
             }
             Self::Audio { path, message } => {
-                write!(f, "failed to use audio asset '{}': {message}", path.display())
+                write!(
+                    f,
+                    "failed to use audio asset '{}': {message}",
+                    path.display()
+                )
             }
             Self::InvalidSpriteSheet {
                 path,
@@ -347,10 +379,11 @@ impl AssetPipeline {
             path: resolved.clone(),
             source,
         })?;
-        let manifest: AssetManifest = serde_json::from_str(&text).map_err(|source| AssetError::Json {
-            path: resolved.clone(),
-            source,
-        })?;
+        let manifest: AssetManifest =
+            serde_json::from_str(&text).map_err(|source| AssetError::Json {
+                path: resolved.clone(),
+                source,
+            })?;
         if let Ok(modified) = file_modified_time(&resolved) {
             self.manifest_timestamps.insert(resolved.clone(), modified);
         }
@@ -358,7 +391,11 @@ impl AssetPipeline {
         Ok(manifest)
     }
 
-    pub fn load_texture<P, F>(&mut self, path: P, create_texture: F) -> Result<TextureAsset, AssetError>
+    pub fn load_texture<P, F>(
+        &mut self,
+        path: P,
+        create_texture: F,
+    ) -> Result<TextureAsset, AssetError>
     where
         P: AsRef<Path>,
         F: FnOnce(u32, u32, &[u8]) -> TextureId,
@@ -458,7 +495,10 @@ impl AssetPipeline {
 
         let (mut vertices, mut indices) = read_mesh(&resolved)?;
         fix_winding_from_normals(&vertices, &mut indices);
-        if vertices.iter().all(|vertex| vertex.normal == [0.0, 0.0, 0.0]) {
+        if vertices
+            .iter()
+            .all(|vertex| vertex.normal == [0.0, 0.0, 0.0])
+        {
             compute_flat_normals(&mut vertices, &indices);
         }
 
@@ -478,7 +518,10 @@ impl AssetPipeline {
         Ok(asset)
     }
 
-    pub fn reload_changed_textures<F>(&mut self, mut replace_texture: F) -> Vec<Result<PathBuf, AssetError>>
+    pub fn reload_changed_textures<F>(
+        &mut self,
+        mut replace_texture: F,
+    ) -> Vec<Result<PathBuf, AssetError>>
     where
         F: FnMut(TextureId, u32, u32, &[u8]),
     {
@@ -520,7 +563,10 @@ impl AssetPipeline {
         results
     }
 
-    pub fn reload_changed_meshes<F>(&mut self, mut replace_mesh: F) -> Vec<Result<PathBuf, AssetError>>
+    pub fn reload_changed_meshes<F>(
+        &mut self,
+        mut replace_mesh: F,
+    ) -> Vec<Result<PathBuf, AssetError>>
     where
         F: FnMut(MeshId, Vec<Vertex3D>, Vec<u32>),
     {
@@ -547,7 +593,10 @@ impl AssetPipeline {
             match read_mesh(&path) {
                 Ok((mut vertices, mut indices)) => {
                     fix_winding_from_normals(&vertices, &mut indices);
-                    if vertices.iter().all(|vertex| vertex.normal == [0.0, 0.0, 0.0]) {
+                    if vertices
+                        .iter()
+                        .all(|vertex| vertex.normal == [0.0, 0.0, 0.0])
+                    {
                         compute_flat_normals(&mut vertices, &indices);
                     }
                     let vertex_count = vertices.len();
@@ -651,10 +700,7 @@ impl AssetPipeline {
             if !file_path.exists() {
                 errors.push(AssetError::Io {
                     path: file_path,
-                    source: std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        "file not found",
-                    ),
+                    source: std::io::Error::new(std::io::ErrorKind::NotFound, "file not found"),
                 });
             }
         }
@@ -664,10 +710,7 @@ impl AssetPipeline {
             if !file_path.exists() {
                 errors.push(AssetError::Io {
                     path: file_path.clone(),
-                    source: std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        "file not found",
-                    ),
+                    source: std::io::Error::new(std::io::ErrorKind::NotFound, "file not found"),
                 });
             }
             if sheet_def.cell_width == 0 || sheet_def.cell_height == 0 {

--- a/engine/src/assets/pipeline.rs
+++ b/engine/src/assets/pipeline.rs
@@ -210,8 +210,11 @@ pub struct AssetSummary {
     pub sprite_sheet_count: usize,
     pub mesh_count: usize,
     pub manifest_count: usize,
+    pub bytes_paths: Vec<PathBuf>,
+    pub text_paths: Vec<PathBuf>,
     pub texture_paths: Vec<PathBuf>,
     pub mesh_paths: Vec<PathBuf>,
+    pub manifest_paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -639,9 +642,11 @@ impl AssetPipeline {
         invalidated
     }
 
-    /// Validate that all files referenced by a manifest exist on disk.
-    /// Returns a list of errors for missing or unreadable files.
-    /// Call this before `load_manifest` to catch problems early.
+    /// Validate that the manifest can be read and parsed, and that all files
+    /// referenced by the manifest exist on disk.
+    /// Returns a list of errors for a missing or unreadable manifest, invalid
+    /// manifest JSON, or missing referenced files.
+    /// Call this before `load_manifest` to catch these problems early.
     pub fn validate_manifest<P: AsRef<Path>>(&self, path: P) -> Vec<AssetError> {
         let resolved = self.resolve_path(path.as_ref());
         let text = match fs::read_to_string(&resolved) {
@@ -712,8 +717,7 @@ impl AssetPipeline {
                     path: file_path.clone(),
                     source: std::io::Error::new(std::io::ErrorKind::NotFound, "file not found"),
                 });
-            }
-            if sheet_def.cell_width == 0 || sheet_def.cell_height == 0 {
+            } else if sheet_def.cell_width == 0 || sheet_def.cell_height == 0 {
                 errors.push(AssetError::InvalidSpriteSheet {
                     path: file_path,
                     texture_width: 0,
@@ -721,14 +725,41 @@ impl AssetPipeline {
                     cell_width: sheet_def.cell_width,
                     cell_height: sheet_def.cell_height,
                 });
+            } else if let Ok((w, h, _)) = self.read_image_rgba(&file_path) {
+                if w % sheet_def.cell_width != 0 || h % sheet_def.cell_height != 0 {
+                    errors.push(AssetError::InvalidSpriteSheet {
+                        path: file_path,
+                        texture_width: w,
+                        texture_height: h,
+                        cell_width: sheet_def.cell_width,
+                        cell_height: sheet_def.cell_height,
+                    });
+                }
             }
         }
 
         errors
     }
 
-    /// Record that a manifest loaded the given file paths.
-    pub(crate) fn record_manifest_deps(&mut self, manifest_path: PathBuf, deps: Vec<PathBuf>) {
+    /// Parse a manifest from disk without caching it. Used by engine-level
+    /// validation to check engine-specific constraints.
+    pub(crate) fn peek_manifest<P: AsRef<Path>>(&self, path: P) -> Result<AssetManifest, AssetError> {
+        let resolved = self.resolve_path(path.as_ref());
+        let text = fs::read_to_string(&resolved).map_err(|source| AssetError::Io {
+            path: resolved.clone(),
+            source,
+        })?;
+        serde_json::from_str(&text).map_err(|source| AssetError::Json {
+            path: resolved,
+            source,
+        })
+    }
+
+    /// Record the manifest itself and the file paths it loaded (deduplicated).
+    pub(crate) fn record_manifest_deps(&mut self, manifest_path: PathBuf, mut deps: Vec<PathBuf>) {
+        deps.push(manifest_path.clone());
+        deps.sort();
+        deps.dedup();
         self.manifest_deps.insert(manifest_path, deps);
     }
 
@@ -747,16 +778,20 @@ impl AssetPipeline {
             sprite_sheet_count: self.sprite_sheets.len(),
             mesh_count: self.meshes.len(),
             manifest_count: self.manifests.len(),
+            bytes_paths: self.bytes.keys().cloned().collect(),
+            text_paths: self.text.keys().cloned().collect(),
             texture_paths: self.textures.keys().cloned().collect(),
             mesh_paths: self.meshes.keys().cloned().collect(),
+            manifest_paths: self.manifests.keys().cloned().collect(),
         }
     }
 
-    /// Evict a cached texture so the next load reads from disk.
+    /// Evict a cached texture and any sprite sheets using it.
     pub fn unload_texture<P: AsRef<Path>>(&mut self, path: P) {
         let resolved = self.resolve_path(path.as_ref());
         self.textures.remove(&resolved);
         self.texture_timestamps.remove(&resolved);
+        self.sprite_sheets.retain(|key, _| key.path != resolved);
     }
 
     /// Evict a cached mesh so the next load reads from disk.

--- a/engine/src/assets/pipeline.rs
+++ b/engine/src/assets/pipeline.rs
@@ -213,6 +213,7 @@ pub struct AssetSummary {
     pub bytes_paths: Vec<PathBuf>,
     pub text_paths: Vec<PathBuf>,
     pub texture_paths: Vec<PathBuf>,
+    pub sprite_sheet_paths: Vec<PathBuf>,
     pub mesh_paths: Vec<PathBuf>,
     pub manifest_paths: Vec<PathBuf>,
 }
@@ -725,15 +726,22 @@ impl AssetPipeline {
                     cell_width: sheet_def.cell_width,
                     cell_height: sheet_def.cell_height,
                 });
-            } else if let Ok((w, h, _)) = self.read_image_rgba(&file_path) {
-                if w % sheet_def.cell_width != 0 || h % sheet_def.cell_height != 0 {
-                    errors.push(AssetError::InvalidSpriteSheet {
-                        path: file_path,
-                        texture_width: w,
-                        texture_height: h,
-                        cell_width: sheet_def.cell_width,
-                        cell_height: sheet_def.cell_height,
-                    });
+            } else {
+                match self.read_image_rgba(&file_path) {
+                    Ok((w, h, _)) => {
+                        if w % sheet_def.cell_width != 0 || h % sheet_def.cell_height != 0 {
+                            errors.push(AssetError::InvalidSpriteSheet {
+                                path: file_path,
+                                texture_width: w,
+                                texture_height: h,
+                                cell_width: sheet_def.cell_width,
+                                cell_height: sheet_def.cell_height,
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        errors.push(e);
+                    }
                 }
             }
         }
@@ -743,7 +751,10 @@ impl AssetPipeline {
 
     /// Parse a manifest from disk without caching it. Used by engine-level
     /// validation to check engine-specific constraints.
-    pub(crate) fn peek_manifest<P: AsRef<Path>>(&self, path: P) -> Result<AssetManifest, AssetError> {
+    pub(crate) fn peek_manifest<P: AsRef<Path>>(
+        &self,
+        path: P,
+    ) -> Result<AssetManifest, AssetError> {
         let resolved = self.resolve_path(path.as_ref());
         let text = fs::read_to_string(&resolved).map_err(|source| AssetError::Io {
             path: resolved.clone(),
@@ -781,6 +792,7 @@ impl AssetPipeline {
             bytes_paths: self.bytes.keys().cloned().collect(),
             text_paths: self.text.keys().cloned().collect(),
             texture_paths: self.textures.keys().cloned().collect(),
+            sprite_sheet_paths: self.sprite_sheets.keys().map(|k| k.path.clone()).collect(),
             mesh_paths: self.meshes.keys().cloned().collect(),
             manifest_paths: self.manifests.keys().cloned().collect(),
         }

--- a/engine/src/assets/pipeline.rs
+++ b/engine/src/assets/pipeline.rs
@@ -170,6 +170,18 @@ pub struct AssetManifest {
     pub audio: HashMap<String, String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct AssetSummary {
+    pub bytes_count: usize,
+    pub text_count: usize,
+    pub texture_count: usize,
+    pub sprite_sheet_count: usize,
+    pub mesh_count: usize,
+    pub manifest_count: usize,
+    pub texture_paths: Vec<PathBuf>,
+    pub mesh_paths: Vec<PathBuf>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct AssetPack {
     bytes: HashMap<String, Arc<[u8]>>,
@@ -255,6 +267,8 @@ pub(crate) struct AssetPipeline {
     texture_timestamps: HashMap<PathBuf, SystemTime>,
     mesh_timestamps: HashMap<PathBuf, SystemTime>,
     manifest_timestamps: HashMap<PathBuf, SystemTime>,
+    /// Maps a manifest path to the set of file paths it loaded.
+    manifest_deps: HashMap<PathBuf, Vec<PathBuf>>,
 }
 
 impl AssetPipeline {
@@ -270,6 +284,7 @@ impl AssetPipeline {
             texture_timestamps: HashMap::new(),
             mesh_timestamps: HashMap::new(),
             manifest_timestamps: HashMap::new(),
+            manifest_deps: HashMap::new(),
         }
     }
 
@@ -573,6 +588,146 @@ impl AssetPipeline {
         }
 
         invalidated
+    }
+
+    /// Validate that all files referenced by a manifest exist on disk.
+    /// Returns a list of errors for missing or unreadable files.
+    /// Call this before `load_manifest` to catch problems early.
+    pub fn validate_manifest<P: AsRef<Path>>(&self, path: P) -> Vec<AssetError> {
+        let resolved = self.resolve_path(path.as_ref());
+        let text = match fs::read_to_string(&resolved) {
+            Ok(t) => t,
+            Err(source) => {
+                return vec![AssetError::Io {
+                    path: resolved,
+                    source,
+                }];
+            }
+        };
+        let manifest: AssetManifest = match serde_json::from_str(&text) {
+            Ok(m) => m,
+            Err(source) => {
+                return vec![AssetError::Json {
+                    path: resolved,
+                    source,
+                }];
+            }
+        };
+
+        let mut errors = Vec::new();
+
+        let all_paths: Vec<(&str, &str)> = manifest
+            .bytes
+            .iter()
+            .map(|(alias, p)| (alias.as_str(), p.as_str()))
+            .chain(
+                manifest
+                    .text
+                    .iter()
+                    .map(|(alias, p)| (alias.as_str(), p.as_str())),
+            )
+            .chain(
+                manifest
+                    .textures
+                    .iter()
+                    .map(|(alias, p)| (alias.as_str(), p.as_str())),
+            )
+            .chain(
+                manifest
+                    .meshes
+                    .iter()
+                    .map(|(alias, p)| (alias.as_str(), p.as_str())),
+            )
+            .chain(
+                manifest
+                    .audio
+                    .iter()
+                    .map(|(alias, p)| (alias.as_str(), p.as_str())),
+            )
+            .collect();
+
+        for (_alias, rel_path) in &all_paths {
+            let file_path = self.resolve_path(Path::new(rel_path));
+            if !file_path.exists() {
+                errors.push(AssetError::Io {
+                    path: file_path,
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "file not found",
+                    ),
+                });
+            }
+        }
+
+        for (_alias, sheet_def) in &manifest.sprite_sheets {
+            let file_path = self.resolve_path(Path::new(&sheet_def.path));
+            if !file_path.exists() {
+                errors.push(AssetError::Io {
+                    path: file_path.clone(),
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "file not found",
+                    ),
+                });
+            }
+            if sheet_def.cell_width == 0 || sheet_def.cell_height == 0 {
+                errors.push(AssetError::InvalidSpriteSheet {
+                    path: file_path,
+                    texture_width: 0,
+                    texture_height: 0,
+                    cell_width: sheet_def.cell_width,
+                    cell_height: sheet_def.cell_height,
+                });
+            }
+        }
+
+        errors
+    }
+
+    /// Record that a manifest loaded the given file paths.
+    pub(crate) fn record_manifest_deps(&mut self, manifest_path: PathBuf, deps: Vec<PathBuf>) {
+        self.manifest_deps.insert(manifest_path, deps);
+    }
+
+    /// Get the file paths that a manifest loaded.
+    pub fn manifest_dependencies<P: AsRef<Path>>(&self, path: P) -> Option<&[PathBuf]> {
+        let resolved = self.resolve_path(path.as_ref());
+        self.manifest_deps.get(&resolved).map(|v| v.as_slice())
+    }
+
+    /// Returns a summary of all cached assets for debugging.
+    pub fn loaded_asset_summary(&self) -> AssetSummary {
+        AssetSummary {
+            bytes_count: self.bytes.len(),
+            text_count: self.text.len(),
+            texture_count: self.textures.len(),
+            sprite_sheet_count: self.sprite_sheets.len(),
+            mesh_count: self.meshes.len(),
+            manifest_count: self.manifests.len(),
+            texture_paths: self.textures.keys().cloned().collect(),
+            mesh_paths: self.meshes.keys().cloned().collect(),
+        }
+    }
+
+    /// Evict a cached texture so the next load reads from disk.
+    pub fn unload_texture<P: AsRef<Path>>(&mut self, path: P) {
+        let resolved = self.resolve_path(path.as_ref());
+        self.textures.remove(&resolved);
+        self.texture_timestamps.remove(&resolved);
+    }
+
+    /// Evict a cached mesh so the next load reads from disk.
+    pub fn unload_mesh<P: AsRef<Path>>(&mut self, path: P) {
+        let resolved = self.resolve_path(path.as_ref());
+        self.meshes.remove(&resolved);
+        self.mesh_timestamps.remove(&resolved);
+    }
+
+    /// Evict all cached bytes and text entries.
+    pub fn unload_data<P: AsRef<Path>>(&mut self, path: P) {
+        let resolved = self.resolve_path(path.as_ref());
+        self.bytes.remove(&resolved);
+        self.text.remove(&resolved);
     }
 
     fn read_image_rgba(&self, path: &Path) -> Result<(u32, u32, Vec<u8>), AssetError> {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -31,8 +31,8 @@ pub use world::{aabb_overlap, iso_to_screen, screen_to_iso, TileDef, TileMap};
 
 pub use assets::pixelart;
 pub use assets::{
-    Animation, AssetError, AssetManifest, AssetPack, AudioBus, AudioClip, AudioId, MeshAsset,
-    SpriteSheet, SpriteSheetAssetDef, TextureAsset,
+    Animation, AssetError, AssetManifest, AssetPack, AssetSummary, AudioBus, AudioClip, AudioId,
+    MeshAsset, SpriteSheet, SpriteSheetAssetDef, TextureAsset,
 };
 
 pub use canvas::{screen_to_ndc, Canvas, CanvasVertex};

--- a/engine/src/renderer3d/mod.rs
+++ b/engine/src/renderer3d/mod.rs
@@ -386,7 +386,8 @@ impl Renderer3D {
         self.queue
             .write_buffer(&self.uniform_buffer, 0, bytemuck::cast_slice(&[uniforms]));
 
-        let (all_verts, all_idxs) = self.build_draw_geometry(&frame.draws, &frame.raw_verts, &frame.raw_idxs);
+        let (all_verts, all_idxs) =
+            self.build_draw_geometry(&frame.draws, &frame.raw_verts, &frame.raw_idxs);
         let num_indices = all_idxs.len() as u32;
 
         let mut encoder = self
@@ -455,8 +456,11 @@ impl Renderer3D {
             let (vm_verts, vm_idxs) =
                 self.build_viewmodel_geometry(&frame.viewmodel.camera, &frame.viewmodel.draws);
             if !vm_idxs.is_empty() {
-                self.queue
-                    .write_buffer(&self.uniform_buffer, 0, bytemuck::cast_slice(&[vm_uniforms]));
+                self.queue.write_buffer(
+                    &self.uniform_buffer,
+                    0,
+                    bytemuck::cast_slice(&[vm_uniforms]),
+                );
                 self.queue
                     .write_buffer(&self.vertex_buffer, 0, bytemuck::cast_slice(&vm_verts));
                 self.queue
@@ -552,7 +556,11 @@ impl Renderer3D {
         (verts, idxs)
     }
 
-    fn build_viewmodel_geometry(&self, camera: &Camera3D, draws: &[DrawCmd3D]) -> (Vec<V3>, Vec<u32>) {
+    fn build_viewmodel_geometry(
+        &self,
+        camera: &Camera3D,
+        draws: &[DrawCmd3D],
+    ) -> (Vec<V3>, Vec<u32>) {
         let mut verts = Vec::new();
         let mut idxs = Vec::new();
         let camera_from_view = camera.view_matrix().inverse();


### PR DESCRIPTION
## Summary
Completes the remaining asset pipeline tooling from roadmap item #2.

## Changes

### Dependency tracking
- `Engine` and `Engine3D` `load_asset_manifest()` now record which file paths each manifest loaded
- New `manifest_dependencies(path)` method returns the tracked deps for a given manifest

### Manifest validation
- New `validate_manifest(path)` method on both `Engine` and `Engine3D`
- Reads the manifest JSON, checks every referenced file exists on disk
- Reports **all** errors (missing files, invalid sprite sheet dims) rather than failing on first
- Can be called before `load_asset_manifest` to catch problems early

### Cache management
- New `loaded_asset_summary()` returns an `AssetSummary` with counts and paths of all cached assets
- New `unload_texture()`, `unload_mesh()`, `unload_data()` methods to evict cached assets
- Evicted assets are re-read from disk on next load

### Public types
- `AssetSummary` struct exported from `rengine`

## Backward compatible
All existing samples compile unchanged.