### PR TITLE
Add serializable resources, fixed update, and collision layers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -176,7 +176,7 @@ Then selective re-exports:
 - **Input:** [`InputState`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L6), `KeyCode` (from winit), `GamepadButton` (from gilrs), [`GamepadState`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L9), [`GamepadSystem`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L58), [`ActionMap`](https://github.com/justinwash/rengine/blob/master/engine/src/input/action.rs), [`Binding`](https://github.com/justinwash/rengine/blob/master/engine/src/input/action.rs), [`AxisMapping`](https://github.com/justinwash/rengine/blob/master/engine/src/input/action.rs), [`GamepadAxis`](https://github.com/justinwash/rengine/blob/master/engine/src/input/action.rs)
 - **Assets:** [`Color`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L2), [`Animation`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L56), [`AssetError`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L15), [`AssetManifest`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L158), [`AssetPack`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L174), [`AudioBus`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L14), [`AudioClip`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L25), [`AudioId`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L22), [`MeshAsset`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L137), [`SpriteSheet`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L5), [`SpriteSheetAssetDef`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L151), [`TextureAsset`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L119)
 - **Scene:** [`Globals`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L4), [`Prefab2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L61)/[`Prefab2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L26), [`PrefabSprite2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L50)/[`PrefabSprite2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L11), [`Scene`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L24), [`Scene2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L98)/[`Scene2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L42), [`SceneInstance2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L67)/[`SceneInstance2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L32), [`SceneOp`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L16), [`Scene3D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L47), [`SceneOp3D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L39)
-- **World:** [`tilemap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs), [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs#L5), [`iso_to_screen`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L4), [`screen_to_iso`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L11), [`TileDef`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L16), [`TileMap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L6)
+- **World:** [`tilemap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs), [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs), [`aabb_overlap_layered`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs), [`CollisionLayer`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs), [`iso_to_screen`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L4), [`screen_to_iso`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L11), [`TileDef`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L16), [`TileMap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L6)
 - **Canvas/Text:** [`screen_to_ndc`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L145), [`Canvas`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L42), [`CanvasVertex`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L6), [`FontAtlas`](https://github.com/justinwash/rengine/blob/master/engine/src/text.rs#L17)
 - **Pixel art:** [`pixelart`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs) (module-level re-export of [`PixelCanvas`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L3), [`darken`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L106), [`lighten`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L110))
 - **Math:** [`Rect`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L5), [`TimeState`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L4), `Vec2`, `Vec3` (from glam)
@@ -198,10 +198,11 @@ pub struct EngineConfig {
     pub headless: bool,     // Skip window creation visibility + mute audio
     pub hot_reload: bool,   // File-watching for assets at runtime
     pub show_fps: bool,     // Render FPS counter overlay on canvas
+    pub fixed_dt: f32,      // Fixed-timestep interval (default 1/60)
 }
 ```
 
-Default: 800×600, no vsync, not headless, hot reload on, FPS shown.
+Default: 800×600, no vsync, not headless, hot reload on, FPS shown, fixed_dt 1/60.
 
 The `headless` flag is critical for testing:
 
@@ -243,6 +244,8 @@ All fields are `pub(crate)` — the game only interacts through accessor methods
 - [`engine.load_audio(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L163) → `Result<AudioClip, AssetError>`
 - [`engine.load_asset_manifest(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L110) → `Result<AssetPack, AssetError>`
 - [`engine.load_bytes(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L102) / [`engine.load_text(path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L106)
+- [`engine.load_resource::<T>(path)`] → `Result<T, AssetError>` — Load a JSON file and deserialize into any `Deserialize + DeserializeOwned` type.
+- [`engine.load_resource_list::<T>(path)`] → `Result<Vec<T>, AssetError>` — Load a JSON array and deserialize into a `Vec<T>`.
 - [`engine.load_scene2d(assets, path)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L218) → `Result<Scene2D, AssetError>`
 - Audio controls: [`play_sound`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L169), [`play_sound_on_bus`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L173), [`play_music`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L182), [`play_music_with_volume`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L186), [`stop_music`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L190), [`pause_music`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L194), [`resume_music`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L198), [`stop_audio_bus`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L202), [`set_master_volume`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L206), [`set_audio_bus_volume`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L210), [`audio_bus_volume`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L214)
 - [`engine.reload_assets_if_changed()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L227) — called every frame automatically
@@ -256,9 +259,15 @@ This is the simplest way to run a 2D game. The type parameter `G` must implement
 pub trait Game: 'static + Sized {
     fn new(engine: &mut Engine) -> Self;     // Constructor — load assets, init state
     fn update(&mut self, engine: &Engine);   // Logic tick — receives immutable engine
+    fn fixed_update(&mut self, _engine: &Engine) {} // Fixed-timestep tick (default empty)
     fn render(&mut self, engine: &Engine, frame: &mut Frame);  // Populate frame for rendering
     fn should_exit(&self) -> bool { false }  // Return true to exit the game loop
 }
+```
+
+`fixed_update()` is called N times per frame (where N depends on the accumulated time vs `EngineConfig::fixed_dt`) **before** the variable-rate `update()`. The same pattern exists on `Game3D`, `Scene`, and `Scene3D`.
+
+```rust
 ```
 
 **Line-by-line boot sequence in `run()`:**
@@ -291,10 +300,12 @@ pub trait Game: 'static + Sized {
 On every `WindowEvent::RedrawRequested`:
 
 ```
-┌─ engine.time.tick()              // Measure delta-time
+┌─ engine.time.tick()              // Measure delta-time, accumulate for fixed step
 ├─ engine.gamepads.update()        // Poll gilrs for gamepad events
 ├─ engine.reload_assets_if_changed() // Hot-reload textures, manifests, audio
-├─ game.update(&engine)            // Run game logic (reads input, modifies game state)
+├─ while engine.time.consume_fixed_step():
+│   └─ game.fixed_update(&engine)  // Fixed-timestep logic (physics, netcode)
+├─ game.update(&engine)            // Variable-rate logic (reads input, modifies game state)
 ├─ if game.should_exit() → exit
 ├─ frame.begin()                   // Clear sprites + canvases; camera state persists
 ├─ game.render(&engine, &mut frame)// Game populates frame with DrawParams + canvases
@@ -1279,7 +1290,7 @@ API:
 - **[`tilemap.collide_rect(rect)`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L97)** → `Option<Vec2>` — Checks a `Rect` against all occupied tiles within range, accumulates AABB minimum translation vectors. Returns the total push-back vector to resolve overlap.
 - **[`tilemap.draw(frame)`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L141)** — Frustum-culled tile rendering: only draws tiles visible within a hardcoded 600×400 half-extent around the camera. Each visible tile emits a `DrawParams` with the tile's texture, color, and UV rect.
 
-### 12.2 [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs#L5) — AABB Physics
+### 12.2 [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs) — AABB Physics
 
 ```rust
 pub fn aabb_overlap(a: &Rect, b: &Rect) -> Option<Vec2>
@@ -1291,6 +1302,23 @@ Computes the **Minimum Translation Vector (MTV)** for two overlapping AABBs. Ret
 - Returns the smaller overlap as the push direction, with sign determined by the relative center positions.
 
 This is used by `TileMap::collide_rect()` for tilemap collision.
+
+#### Collision Layers
+
+```rust
+pub struct CollisionLayer {
+    pub layer: u32,  // which groups this body belongs to
+    pub mask: u32,   // which groups this body collides with
+}
+```
+
+Bitmask-based collision filtering. Two bodies interact when `a.layer & b.mask != 0 && b.layer & a.mask != 0`. Named constants: `WORLD`, `PLAYER`, `ENEMY`, `PROJECTILE`, `TRIGGER`, `UI`. `CollisionLayer::default()` sets all bits so existing code is unaffected.
+
+```rust
+pub fn aabb_overlap_layered(a: &Rect, a_layer: &CollisionLayer, b: &Rect, b_layer: &CollisionLayer) -> Option<Vec2>
+```
+
+Checks layer compatibility via `interacts_with()` before delegating to `aabb_overlap()`. Returns `None` if layers don't interact or AABBs don't overlap.
 
 ### 12.3 [`iso_to_screen`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L4) / [`screen_to_iso`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L11) — Isometric Helpers
 
@@ -1324,6 +1352,8 @@ pub struct TimeState {
     dt: f32,
     total_time: f32,
     frame_count: u64,
+    fixed_dt: f32,       // Fixed-timestep interval (default 1/60)
+    accumulator: f32,    // Accumulated time for fixed steps
 }
 ```
 
@@ -1331,7 +1361,9 @@ pub struct TimeState {
 - [`total_time()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L30) — Seconds since engine start.
 - [`frame_count()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L34) — Total frames processed.
 - [`fps()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L38) — `1.0 / dt`.
-- [`tick()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L46) — Called once per frame by the engine; updates all fields.
+- [`tick()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L46) — Called once per frame by the engine; updates all fields and adds `dt` to `accumulator`.
+- [`fixed_dt()`] — Returns the configured fixed-timestep interval.
+- [`consume_fixed_step()`] — Returns `true` and subtracts `fixed_dt` from `accumulator` if enough time has accumulated. Called in a `while` loop before `update()` to drive `fixed_update()` N times per frame.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,9 @@ Recently completed or partially completed:
 - Completed: input action mapping — `ActionMap` with named digital actions and analog axes, `Binding` enum for Key/MouseButton/GamepadButton, `AxisMapping` with positive/negative bindings and optional gamepad stick axis, convenience methods on `Engine` and `Engine3D`
 - Completed: `feature-input` sample — demonstrates action binding setup, axis-driven movement, pressed/down/released queries with visual feedback
 - Completed: asset pipeline validation and dependency tracking — `validate_manifest()` for pre-load checks, `manifest_dependencies()` for tracking which files each manifest loaded, `loaded_asset_summary()` for debugging, `unload_texture/mesh/data()` for cache eviction
+- Completed: serializable resources — `load_resource<T>()` and `load_resource_list<T>()` on Engine and Engine3D for JSON-driven data definitions with serde deserialization
+- Completed: fixed-timestep update — `EngineConfig::fixed_dt` (default 1/60), accumulator-based `consume_fixed_step()`, `fixed_update()` hooks on Game, Game3D, Scene, and Scene3D traits wired into all four run functions
+- Completed: collision layers and masks — `CollisionLayer` bitmask struct with named constants (WORLD, PLAYER, ENEMY, PROJECTILE, TRIGGER, UI), `interacts_with()` check, `aabb_overlap_layered()` for filtered AABB tests
 - Partial: 3D transforms still only support position-based translation; rotation and scale per draw are not yet supported (caused the recurring door visibility issue)
 
 ---
@@ -74,8 +77,8 @@ These are the features that most directly increase the engine’s usefulness for
 5. Prefabs or reusable scene instances [partially done]
    Allow reusable object templates with data overrides for enemies, pickups, UI panels, props, and level chunks.
 
-6. Serializable resources
-   Data-driven definitions for entities, items, attacks, animation clips, tile sets, dialogue, and configuration.
+6. Serializable resources [done]
+   `load_resource<T>()` and `load_resource_list<T>()` on Engine and Engine3D load JSON files through the asset pipeline and deserialize them with serde. Any `Deserialize + DeserializeOwned` type works.
 
 7. Better 2D transforms [done]
    Add rotation, scale, and origin support.
@@ -91,8 +94,8 @@ These are the features that most directly increase the engine’s usefulness for
 11. Rebindable controls
     Let players or games remap keyboard and gamepad actions.
 
-12. Collision layers and masks
-    Support filtering between world, player, enemy, trigger, projectile, and UI collision groups.
+12. Collision layers and masks [done]
+    `CollisionLayer` with `layer` and `mask` u32 bitmasks. Named constants for WORLD, PLAYER, ENEMY, PROJECTILE, TRIGGER, UI. `aabb_overlap_layered()` checks layer compatibility before spatial overlap. Default is all-bits so existing code is unaffected.
 
 13. Trigger volumes and overlap sensors
     Needed for pickups, checkpoints, dialogue zones, scripted events, and hurtboxes.
@@ -100,8 +103,8 @@ These are the features that most directly increase the engine’s usefulness for
 14. Stronger 2D physics
     Expand beyond simple AABB overlap into rigid bodies, velocity, gravity, friction, restitution, and moving platforms.
 
-15. Fixed update support
-    Make simulation-friendly fixed stepping explicit and ergonomic.
+15. Fixed update support [done]
+    `EngineConfig::fixed_dt` sets the step size (default 1/60). `TimeState` accumulates frame time and `consume_fixed_step()` drains it. `Game::fixed_update()`, `Game3D::fixed_update()`, `Scene::fixed_update()`, and `Scene3D::fixed_update()` are called N times per frame before the variable `update()`. All four run functions and their headless paths are wired.
 
 16. Save and load support
     Profiles, settings, progress, keybindings, and serialized game state.

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -29,6 +29,7 @@ pub struct EngineConfig {
     pub headless: bool,
     pub hot_reload: bool,
     pub show_fps: bool,
+    pub fixed_dt: f32,
 }
 
 impl Default for EngineConfig {
@@ -41,6 +42,7 @@ impl Default for EngineConfig {
             headless: false,
             hot_reload: true,
             show_fps: true,
+            fixed_dt: 1.0 / 60.0,
         }
     }
 }
@@ -400,6 +402,8 @@ pub trait Game: 'static + Sized {
 
     fn update(&mut self, engine: &Engine);
 
+    fn fixed_update(&mut self, _engine: &Engine) {}
+
     fn render(&mut self, engine: &Engine, frame: &mut Frame);
 
     fn should_exit(&self) -> bool {
@@ -412,6 +416,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
 
     let headless = config.headless;
     let show_fps = config.show_fps;
+    let fixed_dt = config.fixed_dt;
 
     let event_loop = EventLoop::new()?;
     let window = Arc::new(
@@ -441,6 +446,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
         hot_reload_enabled: config.hot_reload,
         actions: ActionMap::new(),
     };
+    engine.time.set_fixed_dt(fixed_dt);
 
     let mut game = G::new(&mut engine);
     let mut frame = Frame::new();
@@ -450,6 +456,9 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
             engine.time.tick();
             engine.gamepads.update();
             engine.reload_assets_if_changed();
+            while engine.time.consume_fixed_step() {
+                game.fixed_update(&engine);
+            }
             game.update(&engine);
             if game.should_exit() {
                 return Ok(());
@@ -487,6 +496,9 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                     engine.gamepads.update();
                     engine.reload_assets_if_changed();
 
+                    while engine.time.consume_fixed_step() {
+                        game.fixed_update(&engine);
+                    }
                     game.update(&engine);
 
                     if game.should_exit() {
@@ -535,6 +547,7 @@ where
 
     let headless = config.headless;
     let show_fps = config.show_fps;
+    let fixed_dt = config.fixed_dt;
 
     let event_loop = EventLoop::new()?;
     let window = Arc::new(
@@ -564,6 +577,7 @@ where
         hot_reload_enabled: config.hot_reload,
         actions: ActionMap::new(),
     };
+    engine.time.set_fixed_dt(fixed_dt);
 
     let mut globals = Globals::new();
     let mut stack: Vec<Box<dyn Scene>> = Vec::new();
@@ -578,6 +592,12 @@ where
             engine.time.tick();
             engine.gamepads.update();
             engine.reload_assets_if_changed();
+
+            while engine.time.consume_fixed_step() {
+                if let Some(scene) = stack.last_mut() {
+                    scene.fixed_update(&engine, &mut globals);
+                }
+            }
 
             let op = if let Some(scene) = stack.last_mut() {
                 scene.update(&engine, &mut globals)
@@ -623,6 +643,12 @@ where
                     engine.time.tick();
                     engine.gamepads.update();
                     engine.reload_assets_if_changed();
+
+                    while engine.time.consume_fixed_step() {
+                        if let Some(scene) = stack.last_mut() {
+                            scene.fixed_update(&engine, &mut globals);
+                        }
+                    }
 
                     let op = if let Some(scene) = stack.last_mut() {
                         scene.update(&engine, &mut globals)
@@ -987,6 +1013,7 @@ impl Engine3D {
 pub trait Game3D: 'static + Sized {
     fn new(engine: &mut Engine3D) -> Self;
     fn update(&mut self, engine: &Engine3D);
+    fn fixed_update(&mut self, _engine: &Engine3D) {}
     fn render(&mut self, engine: &Engine3D, frame: &mut Frame3D);
     fn should_exit(&self) -> bool {
         false
@@ -998,6 +1025,7 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
 
     let headless = config.headless;
     let show_fps = config.show_fps;
+    let fixed_dt = config.fixed_dt;
 
     let event_loop = EventLoop::new()?;
     let window = Arc::new(
@@ -1028,6 +1056,7 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
         actions: ActionMap::new(),
         no_gamepad: crate::input::GamepadState::new(),
     };
+    engine.time.set_fixed_dt(fixed_dt);
 
     let mut game = G::new(&mut engine);
 
@@ -1035,6 +1064,9 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
         loop {
             engine.time.tick();
             engine.reload_assets_if_changed();
+            while engine.time.consume_fixed_step() {
+                game.fixed_update(&engine);
+            }
             game.update(&engine);
             if game.should_exit() {
                 return Ok(());
@@ -1129,6 +1161,9 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                     engine.time.tick();
                     engine.reload_assets_if_changed();
 
+                    while engine.time.consume_fixed_step() {
+                        game.fixed_update(&engine);
+                    }
                     game.update(&engine);
 
                     if game.should_exit() {
@@ -1177,6 +1212,7 @@ where
 
     let headless = config.headless;
     let show_fps = config.show_fps;
+    let fixed_dt = config.fixed_dt;
 
     let event_loop = EventLoop::new()?;
     let window = Arc::new(
@@ -1207,6 +1243,7 @@ where
         actions: ActionMap::new(),
         no_gamepad: crate::input::GamepadState::new(),
     };
+    engine.time.set_fixed_dt(fixed_dt);
 
     let mut globals = Globals::new();
     let mut stack: Vec<Box<dyn Scene3D>> = Vec::new();
@@ -1219,6 +1256,12 @@ where
         loop {
             engine.time.tick();
             engine.reload_assets_if_changed();
+
+            while engine.time.consume_fixed_step() {
+                if let Some(scene) = stack.last_mut() {
+                    scene.fixed_update(&engine, &mut globals);
+                }
+            }
 
             let op = if let Some(scene) = stack.last_mut() {
                 scene.update(&engine, &mut globals)
@@ -1321,6 +1364,12 @@ where
                 WindowEvent::RedrawRequested => {
                     engine.time.tick();
                     engine.reload_assets_if_changed();
+
+                    while engine.time.consume_fixed_step() {
+                        if let Some(scene) = stack.last_mut() {
+                            scene.fixed_update(&engine, &mut globals);
+                        }
+                    }
 
                     let op = if let Some(scene) = stack.last_mut() {
                         scene.update(&engine, &mut globals)

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use serde::de::DeserializeOwned;
 use winit::dpi::LogicalSize;
 use winit::event::{DeviceEvent, Event, KeyEvent, MouseButton, WindowEvent};
 use winit::event_loop::EventLoop;
@@ -154,6 +155,30 @@ impl Engine {
 
     pub fn load_text<P: AsRef<Path>>(&mut self, path: P) -> Result<Arc<str>, AssetError> {
         self.assets.load_text(path)
+    }
+
+    pub fn load_resource<T: DeserializeOwned, P: AsRef<Path>>(
+        &mut self,
+        path: P,
+    ) -> Result<T, AssetError> {
+        let text = self.assets.load_text(&path)?;
+        let resolved = self.assets.resolve_path(path.as_ref());
+        serde_json::from_str(&text).map_err(|source| AssetError::Json {
+            path: resolved,
+            source,
+        })
+    }
+
+    pub fn load_resource_list<T: DeserializeOwned, P: AsRef<Path>>(
+        &mut self,
+        path: P,
+    ) -> Result<Vec<T>, AssetError> {
+        let text = self.assets.load_text(&path)?;
+        let resolved = self.assets.resolve_path(path.as_ref());
+        serde_json::from_str(&text).map_err(|source| AssetError::Json {
+            path: resolved,
+            source,
+        })
     }
 
     pub fn load_asset_manifest<P: AsRef<Path>>(
@@ -761,6 +786,30 @@ impl Engine3D {
 
     pub fn load_text<P: AsRef<Path>>(&mut self, path: P) -> Result<Arc<str>, AssetError> {
         self.assets.load_text(path)
+    }
+
+    pub fn load_resource<T: DeserializeOwned, P: AsRef<Path>>(
+        &mut self,
+        path: P,
+    ) -> Result<T, AssetError> {
+        let text = self.assets.load_text(&path)?;
+        let resolved = self.assets.resolve_path(path.as_ref());
+        serde_json::from_str(&text).map_err(|source| AssetError::Json {
+            path: resolved,
+            source,
+        })
+    }
+
+    pub fn load_resource_list<T: DeserializeOwned, P: AsRef<Path>>(
+        &mut self,
+        path: P,
+    ) -> Result<Vec<T>, AssetError> {
+        let text = self.assets.load_text(&path)?;
+        let resolved = self.assets.resolve_path(path.as_ref());
+        serde_json::from_str(&text).map_err(|source| AssetError::Json {
+            path: resolved,
+            source,
+        })
     }
 
     pub fn load_asset_manifest<P: AsRef<Path>>(

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -27,7 +27,7 @@ pub use math::TimeState;
 pub use renderer::{Camera2D, CameraBounds, DrawParams, Frame, TextureId};
 
 pub use world::tilemap;
-pub use world::{aabb_overlap, iso_to_screen, screen_to_iso, TileDef, TileMap};
+pub use world::{aabb_overlap, aabb_overlap_layered, iso_to_screen, screen_to_iso, CollisionLayer, TileDef, TileMap};
 
 pub use assets::pixelart;
 pub use assets::{

--- a/engine/src/math/time.rs
+++ b/engine/src/math/time.rs
@@ -7,6 +7,8 @@ pub struct TimeState {
     dt: f32,
     total_time: f32,
     frame_count: u64,
+    fixed_dt: f32,
+    accumulator: f32,
 }
 
 impl TimeState {
@@ -18,6 +20,8 @@ impl TimeState {
             dt: 1.0 / 60.0,
             total_time: 0.0,
             frame_count: 0,
+            fixed_dt: 1.0 / 60.0,
+            accumulator: 0.0,
         }
     }
 
@@ -43,6 +47,14 @@ impl TimeState {
         }
     }
 
+    pub fn fixed_dt(&self) -> f32 {
+        self.fixed_dt
+    }
+
+    pub(crate) fn set_fixed_dt(&mut self, fixed_dt: f32) {
+        self.fixed_dt = fixed_dt;
+    }
+
     pub(crate) fn tick(&mut self) {
         let now = Instant::now();
         self.dt = now.duration_since(self.last_frame).as_secs_f32();
@@ -53,5 +65,18 @@ impl TimeState {
         self.total_time = now.duration_since(self.start_time).as_secs_f32();
         self.last_frame = now;
         self.frame_count += 1;
+        self.accumulator += self.dt;
+    }
+
+    /// Consume one fixed-step tick from the accumulator. Returns `true` if a
+    /// step was consumed (caller should run fixed_update), `false` when the
+    /// accumulator is drained.
+    pub(crate) fn consume_fixed_step(&mut self) -> bool {
+        if self.accumulator >= self.fixed_dt {
+            self.accumulator -= self.fixed_dt;
+            true
+        } else {
+            false
+        }
     }
 }

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -26,6 +26,8 @@ pub trait Scene: 'static {
 
     fn update(&mut self, engine: &Engine, globals: &mut Globals) -> SceneOp;
 
+    fn fixed_update(&mut self, _engine: &Engine, _globals: &mut Globals) {}
+
     fn render(&self, engine: &Engine, globals: &Globals, frame: &mut Frame);
 
     fn on_pause(&mut self, _engine: &Engine, _globals: &Globals) {}
@@ -47,6 +49,7 @@ pub enum SceneOp3D {
 pub trait Scene3D: 'static {
     fn on_enter(&mut self, engine: &mut Engine3D, globals: &mut Globals);
     fn update(&mut self, engine: &Engine3D, globals: &mut Globals) -> SceneOp3D;
+    fn fixed_update(&mut self, _engine: &Engine3D, _globals: &mut Globals) {}
     fn render(&self, engine: &Engine3D, globals: &Globals, frame: &mut Frame3D);
     fn on_pause(&mut self, _engine: &Engine3D, _globals: &Globals) {}
     fn on_resume(&mut self, _engine: &mut Engine3D, _globals: &mut Globals) {}

--- a/engine/src/world/mod.rs
+++ b/engine/src/world/mod.rs
@@ -3,5 +3,5 @@ pub mod physics;
 pub mod tilemap;
 
 pub use iso::{iso_to_screen, screen_to_iso};
-pub use physics::aabb_overlap;
+pub use physics::{aabb_overlap, aabb_overlap_layered, CollisionLayer};
 pub use tilemap::{TileDef, TileMap};

--- a/engine/src/world/physics.rs
+++ b/engine/src/world/physics.rs
@@ -1,6 +1,71 @@
 use crate::math::rect::Rect;
 use glam::Vec2;
 
+/// Bitmask-based collision layer for filtering which objects can collide.
+///
+/// Each body has a `layer` (which groups it belongs to) and a `mask` (which
+/// groups it interacts with). Two bodies can collide when
+/// `a.layer & b.mask != 0 && b.layer & a.mask != 0`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CollisionLayer {
+    /// Which groups this body belongs to.
+    pub layer: u32,
+    /// Which groups this body can collide with.
+    pub mask: u32,
+}
+
+impl CollisionLayer {
+    pub const NONE: u32 = 0;
+    pub const WORLD: u32 = 1 << 0;
+    pub const PLAYER: u32 = 1 << 1;
+    pub const ENEMY: u32 = 1 << 2;
+    pub const PROJECTILE: u32 = 1 << 3;
+    pub const TRIGGER: u32 = 1 << 4;
+    pub const UI: u32 = 1 << 5;
+
+    /// Create a collision layer that belongs to `layer` groups and collides
+    /// with `mask` groups.
+    pub const fn new(layer: u32, mask: u32) -> Self {
+        Self { layer, mask }
+    }
+
+    /// Shorthand: belongs to and collides with the same groups.
+    pub const fn symmetric(bits: u32) -> Self {
+        Self {
+            layer: bits,
+            mask: bits,
+        }
+    }
+
+    /// Returns `true` if these two layers should interact.
+    pub const fn interacts_with(&self, other: &CollisionLayer) -> bool {
+        (self.layer & other.mask != 0) && (other.layer & self.mask != 0)
+    }
+}
+
+impl Default for CollisionLayer {
+    fn default() -> Self {
+        Self {
+            layer: u32::MAX,
+            mask: u32::MAX,
+        }
+    }
+}
+
+/// AABB overlap with layer/mask filtering. Returns the MTV only when the two
+/// layers interact and the rectangles overlap spatially.
+pub fn aabb_overlap_layered(
+    a: &Rect,
+    a_layer: &CollisionLayer,
+    b: &Rect,
+    b_layer: &CollisionLayer,
+) -> Option<Vec2> {
+    if !a_layer.interacts_with(b_layer) {
+        return None;
+    }
+    aabb_overlap(a, b)
+}
+
 
 pub fn aabb_overlap(a: &Rect, b: &Rect) -> Option<Vec2> {
     let overlap_x = f32::min(a.right(), b.right()) - f32::max(a.left(), b.left());


### PR DESCRIPTION
## Summary

Three roadmap features implemented in succession:

### Serializable Resources (Roadmap #6)
- `load_resource<T>(path)` and `load_resource_list<T>(path)` on both `Engine` and `Engine3D`
- Loads JSON through the asset pipeline, deserializes via serde into any `Deserialize + DeserializeOwned` type
- Enables data-driven definitions for entities, items, attacks, configs, etc.

### Fixed-Timestep Update (Roadmap #15)
- `EngineConfig::fixed_dt` (default 1/60) controls the step size
- `TimeState` accumulates frame time; `consume_fixed_step()` drains it
- `Game::fixed_update()`, `Game3D::fixed_update()`, `Scene::fixed_update()`, `Scene3D::fixed_update()` are called N times per frame before the variable `update()`
- All four run functions (`run`, `run_with_scenes`, `run3d`, `run3d_with_scenes`) and their headless paths are wired
- Default impls are empty for full backward compat

### Collision Layers & Masks (Roadmap #12)
- `CollisionLayer` struct with `layer` (belongs-to) and `mask` (interacts-with) u32 bitmasks
- Named constants: `WORLD`, `PLAYER`, `ENEMY`, `PROJECTILE`, `TRIGGER`, `UI`
- `interacts_with()` check: `a.layer & b.mask != 0 && b.layer & a.mask != 0`
- `aabb_overlap_layered()` filters by layer compatibility before spatial overlap
- Default is all-bits so existing `aabb_overlap()` usage is unaffected

### Docs
- ROADMAP.md: All three items marked done with progress entries
- ARCHITECTURE.md: EngineConfig, Game trait, TimeState, physics, and public API sections updated