### PR TITLE
Add fixed-timestep update support (#15)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -198,10 +198,11 @@ pub struct EngineConfig {
     pub headless: bool,     // Skip window creation visibility + mute audio
     pub hot_reload: bool,   // File-watching for assets at runtime
     pub show_fps: bool,     // Render FPS counter overlay on canvas
+    pub fixed_dt: f32,      // Fixed-timestep interval (default 1/60)
 }
 ```
 
-Default: 800×600, no vsync, not headless, hot reload on, FPS shown.
+Default: 800×600, no vsync, not headless, hot reload on, FPS shown, fixed_dt 1/60.
 
 The `headless` flag is critical for testing:
 
@@ -258,9 +259,15 @@ This is the simplest way to run a 2D game. The type parameter `G` must implement
 pub trait Game: 'static + Sized {
     fn new(engine: &mut Engine) -> Self;     // Constructor — load assets, init state
     fn update(&mut self, engine: &Engine);   // Logic tick — receives immutable engine
+    fn fixed_update(&mut self, _engine: &Engine) {} // Fixed-timestep tick (default empty)
     fn render(&mut self, engine: &Engine, frame: &mut Frame);  // Populate frame for rendering
     fn should_exit(&self) -> bool { false }  // Return true to exit the game loop
 }
+```
+
+`fixed_update()` is called N times per frame (where N depends on the accumulated time vs `EngineConfig::fixed_dt`) **before** the variable-rate `update()`. The same pattern exists on `Game3D`, `Scene`, and `Scene3D`.
+
+```rust
 ```
 
 **Line-by-line boot sequence in `run()`:**
@@ -293,10 +300,12 @@ pub trait Game: 'static + Sized {
 On every `WindowEvent::RedrawRequested`:
 
 ```
-┌─ engine.time.tick()              // Measure delta-time
+┌─ engine.time.tick()              // Measure delta-time, accumulate for fixed step
 ├─ engine.gamepads.update()        // Poll gilrs for gamepad events
 ├─ engine.reload_assets_if_changed() // Hot-reload textures, manifests, audio
-├─ game.update(&engine)            // Run game logic (reads input, modifies game state)
+├─ while engine.time.consume_fixed_step():
+│   └─ game.fixed_update(&engine)  // Fixed-timestep logic (physics, netcode)
+├─ game.update(&engine)            // Variable-rate logic (reads input, modifies game state)
 ├─ if game.should_exit() → exit
 ├─ frame.begin()                   // Clear sprites + canvases; camera state persists
 ├─ game.render(&engine, &mut frame)// Game populates frame with DrawParams + canvases
@@ -1326,6 +1335,8 @@ pub struct TimeState {
     dt: f32,
     total_time: f32,
     frame_count: u64,
+    fixed_dt: f32,       // Fixed-timestep interval (default 1/60)
+    accumulator: f32,    // Accumulated time for fixed steps
 }
 ```
 
@@ -1333,7 +1344,9 @@ pub struct TimeState {
 - [`total_time()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L30) — Seconds since engine start.
 - [`frame_count()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L34) — Total frames processed.
 - [`fps()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L38) — `1.0 / dt`.
-- [`tick()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L46) — Called once per frame by the engine; updates all fields.
+- [`tick()`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L46) — Called once per frame by the engine; updates all fields and adds `dt` to `accumulator`.
+- [`fixed_dt()`] — Returns the configured fixed-timestep interval.
+- [`consume_fixed_step()`] — Returns `true` and subtracts `fixed_dt` from `accumulator` if enough time has accumulated. Called in a `while` loop before `update()` to drive `fixed_update()` N times per frame.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -265,10 +265,7 @@ pub trait Game: 'static + Sized {
 }
 ```
 
-`fixed_update()` is called N times per frame (where N depends on the accumulated time vs `EngineConfig::fixed_dt`) **before** the variable-rate `update()`. The same pattern exists on `Game3D`, `Scene`, and `Scene3D`.
-
-```rust
-```
+`fixed_update()` is called N times per frame (where N depends on the accumulated time vs `EngineConfig::fixed_dt`) **before** the variable-rate `update()`. The same pattern exists on `Game3D`, `Scene`, and `Scene3D`. The accumulator is capped at `10 * fixed_dt` to prevent spiral-of-death.
 
 **Line-by-line boot sequence in `run()`:**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,6 +52,7 @@ Recently completed or partially completed:
 - Completed: `feature-input` sample — demonstrates action binding setup, axis-driven movement, pressed/down/released queries with visual feedback
 - Completed: asset pipeline validation and dependency tracking — `validate_manifest()` for pre-load checks, `manifest_dependencies()` for tracking which files each manifest loaded, `loaded_asset_summary()` for debugging, `unload_texture/mesh/data()` for cache eviction
 - Completed: serializable resources — `load_resource<T>()` and `load_resource_list<T>()` on Engine and Engine3D for JSON-driven data definitions with serde deserialization
+- Completed: fixed-timestep update — `EngineConfig::fixed_dt` (default 1/60), accumulator-based `consume_fixed_step()`, `fixed_update()` hooks on Game, Game3D, Scene, and Scene3D traits wired into all four run functions
 - Partial: 3D transforms still only support position-based translation; rotation and scale per draw are not yet supported (caused the recurring door visibility issue)
 
 ---
@@ -101,8 +102,8 @@ These are the features that most directly increase the engine’s usefulness for
 14. Stronger 2D physics
     Expand beyond simple AABB overlap into rigid bodies, velocity, gravity, friction, restitution, and moving platforms.
 
-15. Fixed update support
-    Make simulation-friendly fixed stepping explicit and ergonomic.
+15. Fixed update support [done]
+    `EngineConfig::fixed_dt` sets the step size (default 1/60). `TimeState` accumulates frame time and `consume_fixed_step()` drains it. `Game::fixed_update()`, `Game3D::fixed_update()`, `Scene::fixed_update()`, and `Scene3D::fixed_update()` are called N times per frame before the variable `update()`. All four run functions and their headless paths are wired.
 
 16. Save and load support
     Profiles, settings, progress, keybindings, and serialized game state.

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -29,6 +29,7 @@ pub struct EngineConfig {
     pub headless: bool,
     pub hot_reload: bool,
     pub show_fps: bool,
+    pub fixed_dt: f32,
 }
 
 impl Default for EngineConfig {
@@ -41,6 +42,7 @@ impl Default for EngineConfig {
             headless: false,
             hot_reload: true,
             show_fps: true,
+            fixed_dt: 1.0 / 60.0,
         }
     }
 }
@@ -400,6 +402,8 @@ pub trait Game: 'static + Sized {
 
     fn update(&mut self, engine: &Engine);
 
+    fn fixed_update(&mut self, _engine: &Engine) {}
+
     fn render(&mut self, engine: &Engine, frame: &mut Frame);
 
     fn should_exit(&self) -> bool {
@@ -412,6 +416,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
 
     let headless = config.headless;
     let show_fps = config.show_fps;
+    let fixed_dt = config.fixed_dt;
 
     let event_loop = EventLoop::new()?;
     let window = Arc::new(
@@ -441,6 +446,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
         hot_reload_enabled: config.hot_reload,
         actions: ActionMap::new(),
     };
+    engine.time.set_fixed_dt(fixed_dt);
 
     let mut game = G::new(&mut engine);
     let mut frame = Frame::new();
@@ -450,6 +456,9 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
             engine.time.tick();
             engine.gamepads.update();
             engine.reload_assets_if_changed();
+            while engine.time.consume_fixed_step() {
+                game.fixed_update(&engine);
+            }
             game.update(&engine);
             if game.should_exit() {
                 return Ok(());
@@ -487,6 +496,9 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                     engine.gamepads.update();
                     engine.reload_assets_if_changed();
 
+                    while engine.time.consume_fixed_step() {
+                        game.fixed_update(&engine);
+                    }
                     game.update(&engine);
 
                     if game.should_exit() {
@@ -535,6 +547,7 @@ where
 
     let headless = config.headless;
     let show_fps = config.show_fps;
+    let fixed_dt = config.fixed_dt;
 
     let event_loop = EventLoop::new()?;
     let window = Arc::new(
@@ -564,6 +577,7 @@ where
         hot_reload_enabled: config.hot_reload,
         actions: ActionMap::new(),
     };
+    engine.time.set_fixed_dt(fixed_dt);
 
     let mut globals = Globals::new();
     let mut stack: Vec<Box<dyn Scene>> = Vec::new();
@@ -578,6 +592,12 @@ where
             engine.time.tick();
             engine.gamepads.update();
             engine.reload_assets_if_changed();
+
+            while engine.time.consume_fixed_step() {
+                if let Some(scene) = stack.last_mut() {
+                    scene.fixed_update(&engine, &mut globals);
+                }
+            }
 
             let op = if let Some(scene) = stack.last_mut() {
                 scene.update(&engine, &mut globals)
@@ -623,6 +643,12 @@ where
                     engine.time.tick();
                     engine.gamepads.update();
                     engine.reload_assets_if_changed();
+
+                    while engine.time.consume_fixed_step() {
+                        if let Some(scene) = stack.last_mut() {
+                            scene.fixed_update(&engine, &mut globals);
+                        }
+                    }
 
                     let op = if let Some(scene) = stack.last_mut() {
                         scene.update(&engine, &mut globals)
@@ -987,6 +1013,7 @@ impl Engine3D {
 pub trait Game3D: 'static + Sized {
     fn new(engine: &mut Engine3D) -> Self;
     fn update(&mut self, engine: &Engine3D);
+    fn fixed_update(&mut self, _engine: &Engine3D) {}
     fn render(&mut self, engine: &Engine3D, frame: &mut Frame3D);
     fn should_exit(&self) -> bool {
         false
@@ -998,6 +1025,7 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
 
     let headless = config.headless;
     let show_fps = config.show_fps;
+    let fixed_dt = config.fixed_dt;
 
     let event_loop = EventLoop::new()?;
     let window = Arc::new(
@@ -1028,6 +1056,7 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
         actions: ActionMap::new(),
         no_gamepad: crate::input::GamepadState::new(),
     };
+    engine.time.set_fixed_dt(fixed_dt);
 
     let mut game = G::new(&mut engine);
 
@@ -1035,6 +1064,9 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
         loop {
             engine.time.tick();
             engine.reload_assets_if_changed();
+            while engine.time.consume_fixed_step() {
+                game.fixed_update(&engine);
+            }
             game.update(&engine);
             if game.should_exit() {
                 return Ok(());
@@ -1129,6 +1161,9 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                     engine.time.tick();
                     engine.reload_assets_if_changed();
 
+                    while engine.time.consume_fixed_step() {
+                        game.fixed_update(&engine);
+                    }
                     game.update(&engine);
 
                     if game.should_exit() {
@@ -1177,6 +1212,7 @@ where
 
     let headless = config.headless;
     let show_fps = config.show_fps;
+    let fixed_dt = config.fixed_dt;
 
     let event_loop = EventLoop::new()?;
     let window = Arc::new(
@@ -1207,6 +1243,7 @@ where
         actions: ActionMap::new(),
         no_gamepad: crate::input::GamepadState::new(),
     };
+    engine.time.set_fixed_dt(fixed_dt);
 
     let mut globals = Globals::new();
     let mut stack: Vec<Box<dyn Scene3D>> = Vec::new();
@@ -1219,6 +1256,12 @@ where
         loop {
             engine.time.tick();
             engine.reload_assets_if_changed();
+
+            while engine.time.consume_fixed_step() {
+                if let Some(scene) = stack.last_mut() {
+                    scene.fixed_update(&engine, &mut globals);
+                }
+            }
 
             let op = if let Some(scene) = stack.last_mut() {
                 scene.update(&engine, &mut globals)
@@ -1321,6 +1364,12 @@ where
                 WindowEvent::RedrawRequested => {
                     engine.time.tick();
                     engine.reload_assets_if_changed();
+
+                    while engine.time.consume_fixed_step() {
+                        if let Some(scene) = stack.last_mut() {
+                            scene.fixed_update(&engine, &mut globals);
+                        }
+                    }
 
                     let op = if let Some(scene) = stack.last_mut() {
                         scene.update(&engine, &mut globals)

--- a/engine/src/math/time.rs
+++ b/engine/src/math/time.rs
@@ -7,6 +7,8 @@ pub struct TimeState {
     dt: f32,
     total_time: f32,
     frame_count: u64,
+    fixed_dt: f32,
+    accumulator: f32,
 }
 
 impl TimeState {
@@ -18,6 +20,8 @@ impl TimeState {
             dt: 1.0 / 60.0,
             total_time: 0.0,
             frame_count: 0,
+            fixed_dt: 1.0 / 60.0,
+            accumulator: 0.0,
         }
     }
 
@@ -43,6 +47,14 @@ impl TimeState {
         }
     }
 
+    pub fn fixed_dt(&self) -> f32 {
+        self.fixed_dt
+    }
+
+    pub(crate) fn set_fixed_dt(&mut self, fixed_dt: f32) {
+        self.fixed_dt = fixed_dt;
+    }
+
     pub(crate) fn tick(&mut self) {
         let now = Instant::now();
         self.dt = now.duration_since(self.last_frame).as_secs_f32();
@@ -53,5 +65,18 @@ impl TimeState {
         self.total_time = now.duration_since(self.start_time).as_secs_f32();
         self.last_frame = now;
         self.frame_count += 1;
+        self.accumulator += self.dt;
+    }
+
+    /// Consume one fixed-step tick from the accumulator. Returns `true` if a
+    /// step was consumed (caller should run fixed_update), `false` when the
+    /// accumulator is drained.
+    pub(crate) fn consume_fixed_step(&mut self) -> bool {
+        if self.accumulator >= self.fixed_dt {
+            self.accumulator -= self.fixed_dt;
+            true
+        } else {
+            false
+        }
     }
 }

--- a/engine/src/math/time.rs
+++ b/engine/src/math/time.rs
@@ -52,6 +52,10 @@ impl TimeState {
     }
 
     pub(crate) fn set_fixed_dt(&mut self, fixed_dt: f32) {
+        assert!(
+            fixed_dt.is_finite() && fixed_dt > 0.0,
+            "fixed_dt must be finite and > 0.0"
+        );
         self.fixed_dt = fixed_dt;
     }
 
@@ -66,6 +70,11 @@ impl TimeState {
         self.last_frame = now;
         self.frame_count += 1;
         self.accumulator += self.dt;
+        // Cap accumulator to prevent spiral-of-death with very small fixed_dt
+        let max_accumulator = self.fixed_dt * 10.0;
+        if self.accumulator > max_accumulator {
+            self.accumulator = max_accumulator;
+        }
     }
 
     /// Consume one fixed-step tick from the accumulator. Returns `true` if a

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -26,6 +26,8 @@ pub trait Scene: 'static {
 
     fn update(&mut self, engine: &Engine, globals: &mut Globals) -> SceneOp;
 
+    fn fixed_update(&mut self, _engine: &Engine, _globals: &mut Globals) {}
+
     fn render(&self, engine: &Engine, globals: &Globals, frame: &mut Frame);
 
     fn on_pause(&mut self, _engine: &Engine, _globals: &Globals) {}
@@ -47,6 +49,7 @@ pub enum SceneOp3D {
 pub trait Scene3D: 'static {
     fn on_enter(&mut self, engine: &mut Engine3D, globals: &mut Globals);
     fn update(&mut self, engine: &Engine3D, globals: &mut Globals) -> SceneOp3D;
+    fn fixed_update(&mut self, _engine: &Engine3D, _globals: &mut Globals) {}
     fn render(&self, engine: &Engine3D, globals: &Globals, frame: &mut Frame3D);
     fn on_pause(&mut self, _engine: &Engine3D, _globals: &Globals) {}
     fn on_resume(&mut self, _engine: &mut Engine3D, _globals: &mut Globals) {}


### PR DESCRIPTION
## Summary

Accumulator-based fixed-timestep update loop for deterministic simulation.

### Changes
- `EngineConfig::fixed_dt` (default 1/60) controls the step size
- `TimeState` accumulates frame time; `consume_fixed_step()` drains it
- `Game::fixed_update()`, `Game3D::fixed_update()`, `Scene::fixed_update()`, `Scene3D::fixed_update()` called N times per frame before variable `update()`
- All four run functions (`run`, `run_with_scenes`, `run3d`, `run3d_with_scenes`) and their headless paths are wired
- Default impls are empty for full backward compat

### Files
- `engine/src/app.rs`: `fixed_dt` on EngineConfig, `fixed_update()` on Game/Game3D traits, accumulator loops in all 8 update sites
- `engine/src/math/time.rs`: `fixed_dt`, `accumulator` fields, `consume_fixed_step()`
- `engine/src/scene/mod.rs`: `fixed_update()` on Scene/Scene3D traits
- ROADMAP.md / ARCHITECTURE.md: scoped updates