### PR TITLE
Add collision layers and masks (#12)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -176,7 +176,7 @@ Then selective re-exports:
 - **Input:** [`InputState`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L6), `KeyCode` (from winit), `GamepadButton` (from gilrs), [`GamepadState`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L9), [`GamepadSystem`](https://github.com/justinwash/rengine/blob/master/engine/src/input/gamepad.rs#L58), [`ActionMap`](https://github.com/justinwash/rengine/blob/master/engine/src/input/action.rs), [`Binding`](https://github.com/justinwash/rengine/blob/master/engine/src/input/action.rs), [`AxisMapping`](https://github.com/justinwash/rengine/blob/master/engine/src/input/action.rs), [`GamepadAxis`](https://github.com/justinwash/rengine/blob/master/engine/src/input/action.rs)
 - **Assets:** [`Color`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/color.rs#L2), [`Animation`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L56), [`AssetError`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L15), [`AssetManifest`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L158), [`AssetPack`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L174), [`AudioBus`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L14), [`AudioClip`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L25), [`AudioId`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/audio.rs#L22), [`MeshAsset`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L137), [`SpriteSheet`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/spritesheet.rs#L5), [`SpriteSheetAssetDef`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L151), [`TextureAsset`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pipeline.rs#L119)
 - **Scene:** [`Globals`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L4), [`Prefab2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L61)/[`Prefab2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L26), [`PrefabSprite2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L50)/[`PrefabSprite2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L11), [`Scene`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L24), [`Scene2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L98)/[`Scene2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L42), [`SceneInstance2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L67)/[`SceneInstance2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L32), [`SceneOp`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L16), [`Scene3D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L47), [`SceneOp3D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L39)
-- **World:** [`tilemap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs), [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs#L5), [`iso_to_screen`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L4), [`screen_to_iso`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L11), [`TileDef`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L16), [`TileMap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L6)
+- **World:** [`tilemap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs), [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs), [`aabb_overlap_layered`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs), [`CollisionLayer`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs), [`iso_to_screen`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L4), [`screen_to_iso`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L11), [`TileDef`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L16), [`TileMap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L6)
 - **Canvas/Text:** [`screen_to_ndc`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L145), [`Canvas`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L42), [`CanvasVertex`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L6), [`FontAtlas`](https://github.com/justinwash/rengine/blob/master/engine/src/text.rs#L17)
 - **Pixel art:** [`pixelart`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs) (module-level re-export of [`PixelCanvas`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L3), [`darken`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L106), [`lighten`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L110))
 - **Math:** [`Rect`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L5), [`TimeState`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L4), `Vec2`, `Vec3` (from glam)
@@ -1287,7 +1287,7 @@ API:
 - **[`tilemap.collide_rect(rect)`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L97)** → `Option<Vec2>` — Checks a `Rect` against all occupied tiles within range, accumulates AABB minimum translation vectors. Returns the total push-back vector to resolve overlap.
 - **[`tilemap.draw(frame)`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L141)** — Frustum-culled tile rendering: only draws tiles visible within a hardcoded 600×400 half-extent around the camera. Each visible tile emits a `DrawParams` with the tile's texture, color, and UV rect.
 
-### 12.2 [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs#L5) — AABB Physics
+### 12.2 [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs) — AABB Physics
 
 ```rust
 pub fn aabb_overlap(a: &Rect, b: &Rect) -> Option<Vec2>
@@ -1299,6 +1299,23 @@ Computes the **Minimum Translation Vector (MTV)** for two overlapping AABBs. Ret
 - Returns the smaller overlap as the push direction, with sign determined by the relative center positions.
 
 This is used by `TileMap::collide_rect()` for tilemap collision.
+
+#### Collision Layers
+
+```rust
+pub struct CollisionLayer {
+    pub layer: u32,  // which groups this body belongs to
+    pub mask: u32,   // which groups this body collides with
+}
+```
+
+Bitmask-based collision filtering. Two bodies interact when `a.layer & b.mask != 0 && b.layer & a.mask != 0`. Named constants: `WORLD`, `PLAYER`, `ENEMY`, `PROJECTILE`, `TRIGGER`, `UI`. `CollisionLayer::default()` sets all bits so existing code is unaffected.
+
+```rust
+pub fn aabb_overlap_layered(a: &Rect, a_layer: &CollisionLayer, b: &Rect, b_layer: &CollisionLayer) -> Option<Vec2>
+```
+
+Checks layer compatibility via `interacts_with()` before delegating to `aabb_overlap()`. Returns `None` if layers don't interact or AABBs don't overlap.
 
 ### 12.3 [`iso_to_screen`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L4) / [`screen_to_iso`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L11) — Isometric Helpers
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,6 +53,7 @@ Recently completed or partially completed:
 - Completed: asset pipeline validation and dependency tracking — `validate_manifest()` for pre-load checks, `manifest_dependencies()` for tracking which files each manifest loaded, `loaded_asset_summary()` for debugging, `unload_texture/mesh/data()` for cache eviction
 - Completed: serializable resources — `load_resource<T>()` and `load_resource_list<T>()` on Engine and Engine3D for JSON-driven data definitions with serde deserialization
 - Completed: fixed-timestep update — `EngineConfig::fixed_dt` (default 1/60), accumulator-based `consume_fixed_step()`, `fixed_update()` hooks on Game, Game3D, Scene, and Scene3D traits wired into all four run functions
+- Completed: collision layers and masks — `CollisionLayer` bitmask struct with named constants (WORLD, PLAYER, ENEMY, PROJECTILE, TRIGGER, UI), `interacts_with()` check, `aabb_overlap_layered()` for filtered AABB tests
 - Partial: 3D transforms still only support position-based translation; rotation and scale per draw are not yet supported (caused the recurring door visibility issue)
 
 ---
@@ -93,8 +94,8 @@ These are the features that most directly increase the engine’s usefulness for
 11. Rebindable controls
     Let players or games remap keyboard and gamepad actions.
 
-12. Collision layers and masks
-    Support filtering between world, player, enemy, trigger, projectile, and UI collision groups.
+12. Collision layers and masks [done]
+    `CollisionLayer` with `layer` and `mask` u32 bitmasks. Named constants for WORLD, PLAYER, ENEMY, PROJECTILE, TRIGGER, UI. `aabb_overlap_layered()` checks layer compatibility before spatial overlap. Default is all-bits so existing code is unaffected.
 
 13. Trigger volumes and overlap sensors
     Needed for pickups, checkpoints, dialogue zones, scripted events, and hurtboxes.

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -27,7 +27,7 @@ pub use math::TimeState;
 pub use renderer::{Camera2D, CameraBounds, DrawParams, Frame, TextureId};
 
 pub use world::tilemap;
-pub use world::{aabb_overlap, iso_to_screen, screen_to_iso, TileDef, TileMap};
+pub use world::{aabb_overlap, aabb_overlap_layered, iso_to_screen, screen_to_iso, CollisionLayer, TileDef, TileMap};
 
 pub use assets::pixelart;
 pub use assets::{

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -27,7 +27,10 @@ pub use math::TimeState;
 pub use renderer::{Camera2D, CameraBounds, DrawParams, Frame, TextureId};
 
 pub use world::tilemap;
-pub use world::{aabb_overlap, aabb_overlap_layered, iso_to_screen, screen_to_iso, CollisionLayer, TileDef, TileMap};
+pub use world::{
+    aabb_overlap, aabb_overlap_layered, iso_to_screen, screen_to_iso, CollisionLayer, TileDef,
+    TileMap,
+};
 
 pub use assets::pixelart;
 pub use assets::{

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -12,7 +12,6 @@ use crate::app::{Engine, Engine3D};
 use crate::renderer::Frame;
 use crate::renderer3d::Frame3D;
 
-
 pub enum SceneOp {
     Continue,
     Push(Box<dyn Scene>),
@@ -36,7 +35,6 @@ pub trait Scene: 'static {
 
     fn on_exit(&mut self, _engine: &Engine, _globals: &Globals) {}
 }
-
 
 pub enum SceneOp3D {
     Continue,

--- a/engine/src/world/mod.rs
+++ b/engine/src/world/mod.rs
@@ -3,5 +3,5 @@ pub mod physics;
 pub mod tilemap;
 
 pub use iso::{iso_to_screen, screen_to_iso};
-pub use physics::aabb_overlap;
+pub use physics::{aabb_overlap, aabb_overlap_layered, CollisionLayer};
 pub use tilemap::{TileDef, TileMap};

--- a/engine/src/world/physics.rs
+++ b/engine/src/world/physics.rs
@@ -1,6 +1,71 @@
 use crate::math::rect::Rect;
 use glam::Vec2;
 
+/// Bitmask-based collision layer for filtering which objects can collide.
+///
+/// Each body has a `layer` (which groups it belongs to) and a `mask` (which
+/// groups it interacts with). Two bodies can collide when
+/// `a.layer & b.mask != 0 && b.layer & a.mask != 0`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CollisionLayer {
+    /// Which groups this body belongs to.
+    pub layer: u32,
+    /// Which groups this body can collide with.
+    pub mask: u32,
+}
+
+impl CollisionLayer {
+    pub const NONE: u32 = 0;
+    pub const WORLD: u32 = 1 << 0;
+    pub const PLAYER: u32 = 1 << 1;
+    pub const ENEMY: u32 = 1 << 2;
+    pub const PROJECTILE: u32 = 1 << 3;
+    pub const TRIGGER: u32 = 1 << 4;
+    pub const UI: u32 = 1 << 5;
+
+    /// Create a collision layer that belongs to `layer` groups and collides
+    /// with `mask` groups.
+    pub const fn new(layer: u32, mask: u32) -> Self {
+        Self { layer, mask }
+    }
+
+    /// Shorthand: belongs to and collides with the same groups.
+    pub const fn symmetric(bits: u32) -> Self {
+        Self {
+            layer: bits,
+            mask: bits,
+        }
+    }
+
+    /// Returns `true` if these two layers should interact.
+    pub const fn interacts_with(&self, other: &CollisionLayer) -> bool {
+        (self.layer & other.mask != 0) && (other.layer & self.mask != 0)
+    }
+}
+
+impl Default for CollisionLayer {
+    fn default() -> Self {
+        Self {
+            layer: u32::MAX,
+            mask: u32::MAX,
+        }
+    }
+}
+
+/// AABB overlap with layer/mask filtering. Returns the MTV only when the two
+/// layers interact and the rectangles overlap spatially.
+pub fn aabb_overlap_layered(
+    a: &Rect,
+    a_layer: &CollisionLayer,
+    b: &Rect,
+    b_layer: &CollisionLayer,
+) -> Option<Vec2> {
+    if !a_layer.interacts_with(b_layer) {
+        return None;
+    }
+    aabb_overlap(a, b)
+}
+
 
 pub fn aabb_overlap(a: &Rect, b: &Rect) -> Option<Vec2> {
     let overlap_x = f32::min(a.right(), b.right()) - f32::max(a.left(), b.left());

--- a/engine/src/world/physics.rs
+++ b/engine/src/world/physics.rs
@@ -39,7 +39,7 @@ impl CollisionLayer {
 
     /// Returns `true` if these two layers should interact.
     pub const fn interacts_with(&self, other: &CollisionLayer) -> bool {
-        (self.layer & other.mask != 0) && (other.layer & self.mask != 0)
+        ((self.layer & other.mask) != 0) && ((other.layer & self.mask) != 0)
     }
 }
 


### PR DESCRIPTION
## Summary

Bitmask-based collision filtering for AABB overlap tests.

### Changes
- `CollisionLayer` struct with `layer` (belongs-to) and `mask` (interacts-with) u32 bitmasks
- Named constants: `WORLD`, `PLAYER`, `ENEMY`, `PROJECTILE`, `TRIGGER`, `UI`
- `interacts_with()` check: `a.layer & b.mask != 0 && b.layer & a.mask != 0`
- `aabb_overlap_layered()` filters by layer compatibility before spatial overlap
- `CollisionLayer::default()` sets all bits, so existing `aabb_overlap()` usage is unaffected
- `CollisionLayer::symmetric(bits)` shorthand for same layer and mask

### Files
- `engine/src/world/physics.rs`: CollisionLayer struct, aabb_overlap_layered()
- `engine/src/world/mod.rs`: re-exports
- `engine/src/lib.rs`: public exports
- ROADMAP.md / ARCHITECTURE.md: scoped updates