### PR TITLE
Ergonomics: mouse input, canvas primitives, UI overhaul, scene transitions, timers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -770,7 +770,13 @@ pub struct Canvas {
 Methods:
 
 - **[`canvas.rect(x, y, w, h, color, screen_size)`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L55)** — Draws a solid rectangle. Converts screen coordinates to NDC via `screen_to_ndc()`, uses the `white_uv` from the font atlas so the fragment shader returns a solid color.
+- **[`canvas.line(x0, y0, x1, y1, thickness, color, screen_size)`]** — Thick line between two points. Computes a perpendicular offset vector and emits a quad (two triangles).
+- **[`canvas.polyline(points, thickness, color, screen_size)`]** — Draws connected line segments through a slice of `(f32, f32)` points.
+- **[`canvas.circle(cx, cy, radius, thickness, segments, color, screen_size)`]** — Circle outline via N line segments.
+- **[`canvas.circle_filled(cx, cy, radius, segments, color, screen_size)`]** — Filled circle via a triangle fan from the center.
 - **[`canvas.text(x, y, text, size, color, screen_size, atlas)`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L84)** — Renders text by emitting two triangles per visible glyph. Scales glyphs by `size / FONT_SIZE`. Each quad's UV maps to the glyph's region in the font atlas.
+- **[`canvas.text_spans(x, y, spans, size, screen_size, atlas)`]** — Renders colored text spans. Takes `&[(&str, Color)]` and draws each substring in its own color, advancing the cursor.
+- **[`canvas.text_spans_aligned(x, y, spans, size, align, screen_size, atlas)`]** — Like `text_spans` but measures total width first and applies `TextAlign` offset.
 - **[`canvas.shape(triangles)`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L51)** — Accepts raw `CanvasVertex` triangles for custom shapes.
 
 **NDC conversion:**
@@ -828,13 +834,19 @@ A lightweight immediate-mode widget builder for menus, pause screens, and HUDs. 
 - **`Ui::with_focus(index) -> Self`** — Set the initially focused button index.
 - **`Ui::label(text, size, color)`** / **`label_centered(text, size, color)`** — Static text (left-aligned or centered).
 - **`Ui::button(id, text)`** — Interactive button identified by a numeric `id`.
+- **`Ui::panel(color, padding, children)`** — Background panel that wraps the next `children` widgets with a colored rect and inward padding.
+- **`Ui::progress_bar(label, value, color)`** — Horizontal progress bar (`value` in 0.0–1.0) with a text label.
+- **`Ui::checkbox(id, label, checked)`** — Togglable checkbox. Focusable; toggled on Enter/Space or mouse click.
+- **`Ui::slider(id, label, value, min, max)`** — Horizontal slider. Arrow keys adjust by 5% of range; mouse drag maps x position to value.
 - **`Ui::separator(height)`** — Vertical gap between widgets.
-- **`Ui::update(input) -> UiResponse`** — Process keyboard/gamepad input:
-  - Arrow Up / W → focus previous button; Arrow Down / S → focus next button (wraps around).
-  - Enter / Space → activate the focused button.
-  - Returns `UiResponse { focused: Option<usize>, activated: Option<usize> }`.
+- **`Ui::update(input, mouse_pos) -> UiResponse`** — Process keyboard/gamepad/mouse input:
+  - Arrow Up / W → focus previous; Arrow Down / S → focus next (wraps).
+  - Enter / Space → activate focused button, toggle checkbox, or confirm slider.
+  - Mouse hover sets focus; mouse click activates.
+  - Returns `UiResponse { focused, activated, hovered, toggled, changed_values }`.
+  - Convenience: `response.was_activated(id)`, `was_toggled(id)`, `value_for(id) -> Option<f32>`.
 - **`Ui::render(canvas)`** — Draw all widgets into a `Canvas` layer.
-- **`UiStyle`** — Configurable struct with fields for `text_color`, `text_size`, `button_bg`, `button_focused_bg`, `button_pressed_bg`, `button_text_color`, `button_focused_text_color`, `button_padding`, and `spacing`.
+- **`UiStyle`** — Configurable struct with fields for text, button, panel, progress bar, checkbox, and slider colors/sizes/padding.
 
 ---
 
@@ -848,6 +860,7 @@ pub struct InputState {
     keys_pressed: HashSet<KeyCode>,    // Keys pressed THIS frame
     keys_released: HashSet<KeyCode>,   // Keys released THIS frame
     mouse_delta: (f64, f64),           // Accumulated mouse motion this frame
+    mouse_position: (f32, f32),        // Screen-space cursor position (center-origin, Y-up)
     mouse_buttons: [bool; 3],          // Held: [Left, Right, Middle]
     mouse_buttons_pressed: [bool; 3],  // Pressed this frame
     mouse_buttons_released: [bool; 3], // Released this frame
@@ -877,6 +890,8 @@ self.mouse_delta.1 += dy;
 ```
 
 Multiple motion events per frame are summed. The game reads [`input.mouse_delta()`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L45) and the total is reset at [`end_frame()`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L107).
+
+**Mouse position** is tracked via `handle_cursor_moved(x, y)`, which stores the screen-space cursor position in center-origin Y-up coordinates (matching the sprite/canvas coordinate system). Accessible via `input.mouse_position() -> (f32, f32)` or `engine.mouse_screen_pos() -> Vec2`. For world-space conversion, use `Camera2D::screen_to_world(screen_pos)` which reverses zoom and rotation and adds the camera offset.
 
 Mouse buttons use the same pressed/down/released model as keys, mapped by index: 0=Left, 1=Right, 2=Middle.
 
@@ -1473,13 +1488,25 @@ pub trait Scene: 'static {
 
 ```rust
 pub enum SceneOp {
-    Continue,                   // Do nothing
-    Push(Box<dyn Scene>),       // Push new scene (current paused)
-    Switch(Box<dyn Scene>),     // Replace current scene
-    Pop,                        // Remove current scene (previous resumed)
-    Quit,                       // Exit the game
+    Continue,                                   // Do nothing
+    Push(Box<dyn Scene>),                       // Push new scene (current paused)
+    Switch(Box<dyn Scene>),                     // Replace current scene
+    Pop,                                        // Remove current scene (previous resumed)
+    Quit,                                       // Exit the game
+    FadePush(Box<dyn Scene>, Transition),        // Push with fade transition
+    FadeSwitch(Box<dyn Scene>, Transition),      // Switch with fade transition
+    FadePop(Transition),                         // Pop with fade transition
 }
 ```
+
+**Transition** specifies a fade effect:
+
+```rust
+pub struct Transition { pub color: Color, pub duration: f32 }
+// Constructors: Transition::fade(duration), fade_color(color, duration), fade_white(duration)
+```
+
+When a `Fade*` variant is returned, the engine enters a transition state machine: fade out (overlay alpha 0→1), apply the scene change at midpoint, fade in (alpha 1→0). During the transition, `scene.update()` is not called (the scene is frozen). All scenes still render bottom-to-top, with the transition overlay drawn last.
 
 Lifecycle:
 
@@ -1764,6 +1791,36 @@ let mut tw = Tween::new(0.0, 1.0, 1.5, Easing::InOutSine).looping(LoopMode::Ping
 // One-shot ease without creating a Tween
 let v = ease(10.0, 50.0, 0.5, Easing::OutBounce);
 ```
+
+### 13.5 `Timer` and `EventQueue` — Scheduling
+
+**`Timer`** — Tracks countdown timers. `tick(dt)` returns `true` the frame it fires.
+
+```rust
+let mut cooldown = Timer::once(2.0);       // fires once after 2 seconds
+let mut heartbeat = Timer::repeating(0.5); // fires every 0.5 seconds
+
+// In update:
+if cooldown.tick(dt) { /* cooldown expired */ }
+if heartbeat.tick(dt) { /* periodic tick */ }
+```
+
+Methods: `once(duration)`, `repeating(interval)`, `tick(dt) -> bool`, `reset()`, `is_finished()`, `remaining()`, `fraction()` (0.0 at start → 1.0 at fire).
+
+**`EventQueue<E>`** — Schedule arbitrary events with delays, then drain them each frame.
+
+```rust
+let mut queue: EventQueue<&str> = EventQueue::new();
+queue.schedule(1.0, "spawn_wave");
+queue.schedule(3.0, "boss_intro");
+
+// In update:
+for event in queue.tick(dt) {
+    match event { /* handle */ }
+}
+```
+
+Methods: `new()`, `schedule(delay, event)`, `tick(dt) -> Vec<E>`, `is_empty()`, `len()`, `clear()`.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -829,7 +829,7 @@ Built on top of the existing single-font `FontAtlas` and `Canvas` text renderer:
 
 A lightweight immediate-mode widget builder for menus, pause screens, and HUDs. Each frame you create a `Ui`, add widgets, call `update()` for input handling, and `render()` to draw.
 
-- **`Ui::new(x, y, width, screen_size, atlas)`** — Create a new UI context anchored at `(x, y)` with the given column width.
+- **`Ui::new(x, y, width, screen_size)`** — Create a new UI context anchored at `(x, y)` with the given column width.
 - **`Ui::with_style(style) -> Self`** — Apply a custom `UiStyle` (colors, sizes, padding).
 - **`Ui::with_focus(index) -> Self`** — Set the initially focused button index.
 - **`Ui::label(text, size, color)`** / **`label_centered(text, size, color)`** — Static text (left-aligned or centered).
@@ -2024,7 +2024,7 @@ It is a 2D platformer with:
 | [`create_color_texture`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L256)                                                                                                            | `engine.create_color_texture(32, 32, Color::RED)`                                                                                   |
 | [`white_texture()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L270)                                                                                                                 | `engine.white_texture()` for solid rectangles without a texture file                                                                |
 | Mouse input                                                                                                                                                                                                   | `engine.input().mouse_delta()`, `is_mouse_down(0)`, `is_mouse_pressed(1)`                                                           |
-| [`Ui`](https://github.com/justinwash/rengine/blob/master/engine/src/ui.rs)                                                                                                                                    | `let mut ui = Ui::new(x, y, w, screen, atlas); ui.button(0, "Play"); let resp = ui.update(input); ui.render(canvas);`               |
+| [`Ui`](https://github.com/justinwash/rengine/blob/master/engine/src/ui.rs)                                                                                                                                    | `let mut ui = Ui::new(x, y, w, screen); ui.button(0, "Play"); let resp = ui.update(input, atlas); ui.render(canvas, atlas);`        |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,12 @@ Recently completed or partially completed:
 - Completed: particle system — `EmitterConfig` builder (14+ fields), `ParticleEmitter` pool with O(1) alive count, `EmitShape` (Point/Circle/Rect), `RangeF32` for randomized params, `Color::lerp`, burst/continuous modes, `feature-particles` sample, kitchen-sink integration
 - Completed: audio fades — `ActiveFade` with `FadeTarget` (MusicVolume/CrossfadeOut/BusVolume/MasterVolume), fade-in/fade-out/crossfade music, bus and master volume fades, any `Easing` curve, auto-ticked in game loop, `feature-audio` sample, kitchen-sink integration
 - Completed: post-processing pipeline — `PostFxChain` with `PostEffect` enum, 8 built-in effects (Vignette, Blur, Bloom, ColorGrade, Crt, Pixelate, ChromaticAberration, Invert), custom WGSL shader support via `PostEffect::Custom`, ping-pong texture chain, lazy pipeline rebuild, `feature-postfx` sample, kitchen-sink integration
+- Completed: mouse position tracking — `InputState::mouse_position` in screen-space center-origin coords, `handle_cursor_moved()`, `mouse_position()` accessor, `engine.mouse_screen_pos()` on Engine and Engine3D, `Camera2D::screen_to_world()` for world-space conversion, `MouseInput` handling in 2D event loops
+- Completed: canvas drawing primitives — `line()`, `polyline()`, `circle()` (outline), `circle_filled()` on Canvas for immediate-mode shape drawing
+- Completed: colored text spans — `text_spans()` and `text_spans_aligned()` on Canvas, accepting `&[(&str, Color)]` for per-substring coloring
+- Completed: UI overhaul — mouse hover/click support for all focusable widgets, Panel widget (background rect with padding), ProgressBar widget, Checkbox widget (toggle on Enter/Space/click), Slider widget (arrow keys adjust by 5%, mouse drag), expanded `UiResponse` with `hovered`, `toggled`, `changed_values` fields and `was_activated()`, `was_toggled()`, `value_for()` convenience methods, updated `feature-ui` sample with DemoScene
+- Completed: scene transitions — `Transition` struct with `fade()`, `fade_color()`, `fade_white()` constructors, `SceneOp::FadePush`, `FadeSwitch`, `FadePop` variants, transition state machine in `run_with_scenes` (fade out → apply at midpoint → fade in, scene frozen during transition), updated `feature-scenes` sample
+- Completed: timer and event queue — `Timer` struct with `once()` and `repeating()` constructors, `tick(dt) -> bool`, `fraction()` progress; `EventQueue<E>` generic delayed event scheduler with `schedule(delay, event)` and `tick(dt) -> Vec<E>`
 
 ---
 

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -106,6 +106,11 @@ impl Engine {
             .unwrap_or((self.window_width, self.window_height))
     }
 
+    pub fn mouse_screen_pos(&self) -> glam::Vec2 {
+        let (x, y) = self.input.mouse_position();
+        glam::Vec2::new(x, y)
+    }
+
     pub fn set_scale_mode(&self, mode: ScaleMode) {
         self.renderer.set_scale_mode(mode);
     }
@@ -611,6 +616,22 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                     engine.input.handle_key_event(key, state);
                 }
 
+                WindowEvent::CursorMoved { position, .. } => {
+                    let x = position.x as f32 - engine.window_width as f32 / 2.0;
+                    let y = -(position.y as f32 - engine.window_height as f32 / 2.0);
+                    engine.input.handle_cursor_moved(x, y);
+                }
+
+                WindowEvent::MouseInput { button, state, .. } => {
+                    let idx = match button {
+                        MouseButton::Left => 0,
+                        MouseButton::Right => 1,
+                        MouseButton::Middle => 2,
+                        _ => return,
+                    };
+                    engine.input.handle_mouse_button(idx, state);
+                }
+
                 WindowEvent::RedrawRequested => {
                     engine.time.tick();
                     engine.gamepads.update();
@@ -747,6 +768,8 @@ where
         }
     }
 
+    let mut transition: Option<crate::scene::ActiveTransition> = None;
+
     event_loop.run(move |event, target| {
         target.set_control_flow(winit::event_loop::ControlFlow::Poll);
         match event {
@@ -771,6 +794,22 @@ where
                     engine.input.handle_key_event(key, state);
                 }
 
+                WindowEvent::CursorMoved { position, .. } => {
+                    let x = position.x as f32 - engine.window_width as f32 / 2.0;
+                    let y = -(position.y as f32 - engine.window_height as f32 / 2.0);
+                    engine.input.handle_cursor_moved(x, y);
+                }
+
+                WindowEvent::MouseInput { button, state, .. } => {
+                    let idx = match button {
+                        MouseButton::Left => 0,
+                        MouseButton::Right => 1,
+                        MouseButton::Middle => 2,
+                        _ => return,
+                    };
+                    engine.input.handle_mouse_button(idx, state);
+                }
+
                 WindowEvent::RedrawRequested => {
                     engine.time.tick();
                     engine.gamepads.update();
@@ -783,14 +822,47 @@ where
                         }
                     }
 
-                    let op = if let Some(scene) = stack.last_mut() {
-                        scene.update(&engine, &mut globals)
-                    } else {
-                        target.exit();
-                        return;
-                    };
+                    if transition.is_none() {
+                        let op = if let Some(scene) = stack.last_mut() {
+                            scene.update(&engine, &mut globals)
+                        } else {
+                            target.exit();
+                            return;
+                        };
 
-                    apply_scene_op(&mut stack, op, &mut engine, &mut globals);
+                        match op {
+                            SceneOp::FadePush(new_scene, t) => {
+                                transition = Some(crate::scene::ActiveTransition::new(
+                                    t,
+                                    SceneOp::Push(new_scene),
+                                ));
+                            }
+                            SceneOp::FadeSwitch(new_scene, t) => {
+                                transition = Some(crate::scene::ActiveTransition::new(
+                                    t,
+                                    SceneOp::Switch(new_scene),
+                                ));
+                            }
+                            SceneOp::FadePop(t) => {
+                                transition = Some(crate::scene::ActiveTransition::new(
+                                    t,
+                                    SceneOp::Pop,
+                                ));
+                            }
+                            other => {
+                                apply_scene_op(&mut stack, other, &mut engine, &mut globals);
+                            }
+                        }
+                    }
+
+                    if let Some(ref mut t) = transition {
+                        t.tick(engine.time.dt());
+                        if t.at_midpoint() {
+                            if let Some(pending) = t.pending_op.take() {
+                                apply_scene_op(&mut stack, pending, &mut engine, &mut globals);
+                            }
+                        }
+                    }
 
                     if stack.is_empty() {
                         target.exit();
@@ -800,6 +872,30 @@ where
                     frame.begin();
                     for scene in stack.iter() {
                         scene.render(&engine, &globals, &mut frame);
+                    }
+
+                    if let Some(ref t) = transition {
+                        let alpha = t.alpha();
+                        if alpha > 0.001 {
+                            let screen_size = engine.window_size();
+                            let hw = screen_size.0 as f32 / 2.0;
+                            let hh = screen_size.1 as f32 / 2.0;
+                            let mut overlay = canvas::Canvas::new();
+                            let c = crate::assets::Color::new(
+                                t.color.r,
+                                t.color.g,
+                                t.color.b,
+                                alpha,
+                            );
+                            overlay.rect(-hw, -hh, screen_size.0 as f32, screen_size.1 as f32, c, screen_size);
+                            frame.canvases.push(overlay);
+                        }
+                    }
+
+                    if let Some(ref t) = transition {
+                        if t.is_done() {
+                            transition = None;
+                        }
                     }
 
                     if show_fps {
@@ -867,6 +963,15 @@ fn apply_scene_op(
             new_scene.on_enter(engine, globals);
             stack.push(new_scene);
         }
+        SceneOp::FadePush(new_scene, _) => {
+            apply_scene_op(stack, SceneOp::Push(new_scene), engine, globals);
+        }
+        SceneOp::FadeSwitch(new_scene, _) => {
+            apply_scene_op(stack, SceneOp::Switch(new_scene), engine, globals);
+        }
+        SceneOp::FadePop(_) => {
+            apply_scene_op(stack, SceneOp::Pop, engine, globals);
+        }
     }
 }
 
@@ -903,6 +1008,11 @@ impl Engine3D {
     pub fn game_size(&self) -> (u32, u32) {
         self.render_resolution
             .unwrap_or((self.window_width, self.window_height))
+    }
+
+    pub fn mouse_screen_pos(&self) -> glam::Vec2 {
+        let (x, y) = self.input.mouse_position();
+        glam::Vec2::new(x, y)
     }
 
     pub fn set_scale_mode(&self, mode: ScaleMode) {
@@ -1386,6 +1496,12 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                     engine.input.handle_mouse_button(idx, state);
                 }
 
+                WindowEvent::CursorMoved { position, .. } => {
+                    let x = position.x as f32 - engine.window_width as f32 / 2.0;
+                    let y = -(position.y as f32 - engine.window_height as f32 / 2.0);
+                    engine.input.handle_cursor_moved(x, y);
+                }
+
                 WindowEvent::RedrawRequested => {
                     engine.time.tick();
                     engine.reload_assets_if_changed();
@@ -1609,6 +1725,12 @@ where
                         engine.mouse_captured = true;
                     }
                     engine.input.handle_mouse_button(idx, state);
+                }
+
+                WindowEvent::CursorMoved { position, .. } => {
+                    let x = position.x as f32 - engine.window_width as f32 / 2.0;
+                    let y = -(position.y as f32 - engine.window_height as f32 / 2.0);
+                    engine.input.handle_cursor_moved(x, y);
                 }
 
                 WindowEvent::RedrawRequested => {

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -844,10 +844,8 @@ where
                                 ));
                             }
                             SceneOp::FadePop(t) => {
-                                transition = Some(crate::scene::ActiveTransition::new(
-                                    t,
-                                    SceneOp::Pop,
-                                ));
+                                transition =
+                                    Some(crate::scene::ActiveTransition::new(t, SceneOp::Pop));
                             }
                             other => {
                                 apply_scene_op(&mut stack, other, &mut engine, &mut globals);
@@ -881,13 +879,16 @@ where
                             let hw = screen_size.0 as f32 / 2.0;
                             let hh = screen_size.1 as f32 / 2.0;
                             let mut overlay = canvas::Canvas::new();
-                            let c = crate::assets::Color::new(
-                                t.color.r,
-                                t.color.g,
-                                t.color.b,
-                                alpha,
+                            let c =
+                                crate::assets::Color::new(t.color.r, t.color.g, t.color.b, alpha);
+                            overlay.rect(
+                                -hw,
+                                -hh,
+                                screen_size.0 as f32,
+                                screen_size.1 as f32,
+                                c,
+                                screen_size,
                             );
-                            overlay.rect(-hw, -hh, screen_size.0 as f32, screen_size.1 as f32, c, screen_size);
                             frame.canvases.push(overlay);
                         }
                     }

--- a/engine/src/canvas/mod.rs
+++ b/engine/src/canvas/mod.rs
@@ -88,6 +88,102 @@ impl Canvas {
         self.verts.extend_from_slice(&[v0, v2, v1, v0, v3, v2]);
     }
 
+    pub fn line(
+        &mut self,
+        x0: f32,
+        y0: f32,
+        x1: f32,
+        y1: f32,
+        thickness: f32,
+        color: Color,
+        screen_size: (u32, u32),
+    ) {
+        let dx = x1 - x0;
+        let dy = y1 - y0;
+        let len = (dx * dx + dy * dy).sqrt();
+        if len < 0.0001 {
+            return;
+        }
+        let nx = -dy / len * thickness * 0.5;
+        let ny = dx / len * thickness * 0.5;
+
+        let c = color.to_array();
+        let uv = WHITE_UV;
+        let a = screen_to_ndc(x0 + nx, y0 + ny, screen_size);
+        let b = screen_to_ndc(x0 - nx, y0 - ny, screen_size);
+        let cc = screen_to_ndc(x1 - nx, y1 - ny, screen_size);
+        let d = screen_to_ndc(x1 + nx, y1 + ny, screen_size);
+
+        let va = CanvasVertex { position: a, color: c, uv };
+        let vb = CanvasVertex { position: b, color: c, uv };
+        let vc = CanvasVertex { position: cc, color: c, uv };
+        let vd = CanvasVertex { position: d, color: c, uv };
+        self.verts.extend_from_slice(&[va, vc, vd, va, vb, vc]);
+    }
+
+    pub fn polyline(
+        &mut self,
+        points: &[(f32, f32)],
+        thickness: f32,
+        color: Color,
+        screen_size: (u32, u32),
+    ) {
+        for pair in points.windows(2) {
+            self.line(pair[0].0, pair[0].1, pair[1].0, pair[1].1, thickness, color, screen_size);
+        }
+    }
+
+    pub fn circle(
+        &mut self,
+        cx: f32,
+        cy: f32,
+        radius: f32,
+        thickness: f32,
+        segments: u32,
+        color: Color,
+        screen_size: (u32, u32),
+    ) {
+        let step = std::f32::consts::TAU / segments as f32;
+        for i in 0..segments {
+            let a0 = step * i as f32;
+            let a1 = step * (i + 1) as f32;
+            self.line(
+                cx + a0.cos() * radius,
+                cy + a0.sin() * radius,
+                cx + a1.cos() * radius,
+                cy + a1.sin() * radius,
+                thickness,
+                color,
+                screen_size,
+            );
+        }
+    }
+
+    pub fn circle_filled(
+        &mut self,
+        cx: f32,
+        cy: f32,
+        radius: f32,
+        segments: u32,
+        color: Color,
+        screen_size: (u32, u32),
+    ) {
+        let c = color.to_array();
+        let uv = WHITE_UV;
+        let center = screen_to_ndc(cx, cy, screen_size);
+        let vc = CanvasVertex { position: center, color: c, uv };
+        let step = std::f32::consts::TAU / segments as f32;
+        for i in 0..segments {
+            let a0 = step * i as f32;
+            let a1 = step * (i + 1) as f32;
+            let p0 = screen_to_ndc(cx + a0.cos() * radius, cy + a0.sin() * radius, screen_size);
+            let p1 = screen_to_ndc(cx + a1.cos() * radius, cy + a1.sin() * radius, screen_size);
+            let v0 = CanvasVertex { position: p0, color: c, uv };
+            let v1 = CanvasVertex { position: p1, color: c, uv };
+            self.verts.extend_from_slice(&[vc, v0, v1]);
+        }
+    }
+
     pub fn text(
         &mut self,
         x: f32,
@@ -170,6 +266,74 @@ impl Canvas {
             }
         };
         self.text(x + offset, y, text, size, color, screen_size, atlas);
+    }
+
+    pub fn text_spans(
+        &mut self,
+        x: f32,
+        y: f32,
+        spans: &[(&str, Color)],
+        size: f32,
+        screen_size: (u32, u32),
+        atlas: &FontAtlas,
+    ) {
+        let scale = size / FONT_SIZE;
+        let mut cursor_x = x;
+
+        for &(span_text, span_color) in spans {
+            let c = span_color.to_array();
+            for ch in span_text.chars() {
+                let idx = ch as usize;
+                if idx >= 128 {
+                    continue;
+                }
+                let entry = match atlas.glyphs[idx] {
+                    Some(e) => e,
+                    None => continue,
+                };
+
+                if entry.width_px > 0.0 {
+                    let gx = cursor_x + entry.x_offset * scale;
+                    let gy = y - (atlas.line_height - entry.y_offset) * scale;
+                    let gw = entry.width_px * scale;
+                    let gh = entry.height_px * scale;
+
+                    let [x0, y0] = screen_to_ndc(gx, gy, screen_size);
+                    let [x1, y1] = screen_to_ndc(gx + gw, gy + gh, screen_size);
+
+                    let v0 = CanvasVertex { position: [x0, y0], color: c, uv: [entry.u0, entry.v1] };
+                    let v1 = CanvasVertex { position: [x1, y0], color: c, uv: [entry.u1, entry.v1] };
+                    let v2 = CanvasVertex { position: [x1, y1], color: c, uv: [entry.u1, entry.v0] };
+                    let v3 = CanvasVertex { position: [x0, y1], color: c, uv: [entry.u0, entry.v0] };
+                    self.verts.extend_from_slice(&[v0, v2, v1, v0, v3, v2]);
+                }
+
+                cursor_x += entry.advance * scale;
+            }
+        }
+    }
+
+    pub fn text_spans_aligned(
+        &mut self,
+        x: f32,
+        y: f32,
+        spans: &[(&str, Color)],
+        size: f32,
+        align: TextAlign,
+        screen_size: (u32, u32),
+        atlas: &FontAtlas,
+    ) {
+        let offset = if align == TextAlign::Left {
+            0.0
+        } else {
+            let total_w: f32 = spans.iter().map(|(s, _)| atlas.measure_text(s, size).0).sum();
+            match align {
+                TextAlign::Center => -total_w / 2.0,
+                TextAlign::Right => -total_w,
+                TextAlign::Left => unreachable!(),
+            }
+        };
+        self.text_spans(x + offset, y, spans, size, screen_size, atlas);
     }
 
     pub fn text_block(

--- a/engine/src/input/keyboard.rs
+++ b/engine/src/input/keyboard.rs
@@ -7,6 +7,7 @@ pub struct InputState {
     keys_pressed: HashSet<KeyCode>,
     keys_released: HashSet<KeyCode>,
     mouse_delta: (f64, f64),
+    mouse_position: (f32, f32),
     mouse_buttons: [bool; 3],
     mouse_buttons_pressed: [bool; 3],
     mouse_buttons_released: [bool; 3],
@@ -19,6 +20,7 @@ impl InputState {
             keys_pressed: HashSet::new(),
             keys_released: HashSet::new(),
             mouse_delta: (0.0, 0.0),
+            mouse_position: (0.0, 0.0),
             mouse_buttons: [false; 3],
             mouse_buttons_pressed: [false; 3],
             mouse_buttons_released: [false; 3],
@@ -39,6 +41,10 @@ impl InputState {
 
     pub fn mouse_delta(&self) -> (f64, f64) {
         self.mouse_delta
+    }
+
+    pub fn mouse_position(&self) -> (f32, f32) {
+        self.mouse_position
     }
 
     pub fn is_mouse_down(&self, button: usize) -> bool {
@@ -76,6 +82,10 @@ impl InputState {
     pub(crate) fn handle_mouse_motion(&mut self, dx: f64, dy: f64) {
         self.mouse_delta.0 += dx;
         self.mouse_delta.1 += dy;
+    }
+
+    pub(crate) fn handle_cursor_moved(&mut self, x: f32, y: f32) {
+        self.mouse_position = (x, y);
     }
 
     pub(crate) fn handle_mouse_button(&mut self, button: usize, state: ElementState) {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -29,6 +29,7 @@ pub use math::Rect;
 pub use math::Rng;
 pub use math::TimeState;
 pub use math::{ease, lerp, Easing, LoopMode, Tween};
+pub use math::{EventQueue, Timer};
 pub use renderer::{
     Camera2D, CameraBounds, DrawParams, Frame, NineSlice, PostEffect, PostFxChain, TextureId,
 };
@@ -48,7 +49,7 @@ pub use assets::{
 pub use canvas::{screen_to_ndc, wrap_text, Canvas, CanvasVertex, TextAlign};
 pub use scene::{
     Globals, Prefab2D, Prefab2DDef, PrefabSprite2D, PrefabSprite2DDef, Scene, Scene2D, Scene2DDef,
-    SceneInstance2D, SceneInstance2DDef, SceneOp,
+    SceneInstance2D, SceneInstance2DDef, SceneOp, Transition,
 };
 pub use text::FontAtlas;
 pub use ui::{Ui, UiResponse, UiStyle};

--- a/engine/src/math/mod.rs
+++ b/engine/src/math/mod.rs
@@ -1,9 +1,11 @@
 pub mod rect;
 pub mod rng;
 pub mod time;
+pub mod timer;
 pub mod tween;
 
 pub use rect::Rect;
 pub use rng::Rng;
 pub use time::TimeState;
+pub use timer::{EventQueue, Timer};
 pub use tween::{ease, lerp, Easing, LoopMode, Tween};

--- a/engine/src/math/timer.rs
+++ b/engine/src/math/timer.rs
@@ -1,0 +1,114 @@
+pub struct Timer {
+    remaining: f32,
+    repeating: bool,
+    interval: f32,
+    finished: bool,
+}
+
+impl Timer {
+    pub fn once(duration: f32) -> Self {
+        Self {
+            remaining: duration,
+            repeating: false,
+            interval: duration,
+            finished: false,
+        }
+    }
+
+    pub fn repeating(interval: f32) -> Self {
+        Self {
+            remaining: interval,
+            repeating: true,
+            interval,
+            finished: false,
+        }
+    }
+
+    pub fn tick(&mut self, dt: f32) -> bool {
+        if self.finished {
+            return false;
+        }
+        self.remaining -= dt;
+        if self.remaining <= 0.0 {
+            if self.repeating {
+                self.remaining += self.interval;
+                if self.remaining < 0.0 {
+                    self.remaining = 0.0;
+                }
+            } else {
+                self.remaining = 0.0;
+                self.finished = true;
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.remaining = self.interval;
+        self.finished = false;
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+
+    pub fn remaining(&self) -> f32 {
+        self.remaining
+    }
+
+    pub fn fraction(&self) -> f32 {
+        if self.interval <= 0.0 {
+            return 1.0;
+        }
+        1.0 - (self.remaining / self.interval).clamp(0.0, 1.0)
+    }
+}
+
+pub struct EventQueue<E> {
+    events: Vec<(f32, E)>,
+}
+
+impl<E> EventQueue<E> {
+    pub fn new() -> Self {
+        Self { events: Vec::new() }
+    }
+
+    pub fn schedule(&mut self, delay: f32, event: E) {
+        self.events.push((delay, event));
+    }
+
+    pub fn tick(&mut self, dt: f32) -> Vec<E> {
+        let mut fired = Vec::new();
+        let mut i = 0;
+        while i < self.events.len() {
+            self.events[i].0 -= dt;
+            if self.events[i].0 <= 0.0 {
+                let (_, event) = self.events.swap_remove(i);
+                fired.push(event);
+            } else {
+                i += 1;
+            }
+        }
+        fired
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    pub fn clear(&mut self) {
+        self.events.clear();
+    }
+}
+
+impl<E> Default for EventQueue<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/engine/src/renderer/camera.rs
+++ b/engine/src/renderer/camera.rs
@@ -120,6 +120,19 @@ impl Camera2D {
 
         Vec2::new(rx * self.zoom, ry * self.zoom)
     }
+
+    pub fn screen_to_world(&self, screen_pos: Vec2) -> Vec2 {
+        let sx = screen_pos.x / self.zoom;
+        let sy = screen_pos.y / self.zoom;
+
+        let cos = self.rotation.cos();
+        let sin = self.rotation.sin();
+        let wx = sx * cos - sy * sin;
+        let wy = sx * sin + sy * cos;
+
+        let pos = self.position + self.shake_offset;
+        Vec2::new(wx + pos.x, wy + pos.y)
+    }
 }
 
 impl Default for Camera2D {

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -9,8 +9,35 @@ pub use data2d::{
 pub use globals::Globals;
 
 use crate::app::{Engine, Engine3D};
+use crate::assets::Color;
 use crate::renderer::Frame;
 use crate::renderer3d::Frame3D;
+
+#[derive(Clone, Copy)]
+pub struct Transition {
+    pub color: Color,
+    pub duration: f32,
+}
+
+impl Transition {
+    pub fn fade(duration: f32) -> Self {
+        Self {
+            color: Color::BLACK,
+            duration,
+        }
+    }
+
+    pub fn fade_color(color: Color, duration: f32) -> Self {
+        Self { color, duration }
+    }
+
+    pub fn fade_white(duration: f32) -> Self {
+        Self {
+            color: Color::WHITE,
+            duration,
+        }
+    }
+}
 
 pub enum SceneOp {
     Continue,
@@ -18,6 +45,51 @@ pub enum SceneOp {
     Switch(Box<dyn Scene>),
     Pop,
     Quit,
+    FadePush(Box<dyn Scene>, Transition),
+    FadeSwitch(Box<dyn Scene>, Transition),
+    FadePop(Transition),
+}
+
+pub(crate) struct ActiveTransition {
+    pub color: Color,
+    pub duration: f32,
+    pub elapsed: f32,
+    pub pending_op: Option<SceneOp>,
+}
+
+impl ActiveTransition {
+    pub fn new(transition: Transition, pending_op: SceneOp) -> Self {
+        Self {
+            color: transition.color,
+            duration: transition.duration,
+            elapsed: 0.0,
+            pending_op: Some(pending_op),
+        }
+    }
+
+    pub fn tick(&mut self, dt: f32) {
+        self.elapsed += dt;
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.elapsed >= self.duration
+    }
+
+    pub fn at_midpoint(&self) -> bool {
+        self.elapsed >= self.duration / 2.0 && self.pending_op.is_some()
+    }
+
+    pub fn alpha(&self) -> f32 {
+        let half = self.duration / 2.0;
+        if half <= 0.0 {
+            return 0.0;
+        }
+        if self.elapsed < half {
+            (self.elapsed / half).clamp(0.0, 1.0)
+        } else {
+            (1.0 - (self.elapsed - half) / half).clamp(0.0, 1.0)
+        }
+    }
 }
 
 pub trait Scene: 'static {

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -15,6 +15,18 @@ pub struct UiStyle {
     pub button_focused_text_color: Color,
     pub button_padding: f32,
     pub spacing: f32,
+    pub panel_bg: Color,
+    pub panel_padding: f32,
+    pub progress_bg: Color,
+    pub progress_fill: Color,
+    pub progress_height: f32,
+    pub checkbox_size: f32,
+    pub checkbox_bg: Color,
+    pub checkbox_checked_bg: Color,
+    pub slider_track_color: Color,
+    pub slider_fill_color: Color,
+    pub slider_thumb_color: Color,
+    pub slider_height: f32,
 }
 
 impl Default for UiStyle {
@@ -29,6 +41,18 @@ impl Default for UiStyle {
             button_focused_text_color: Color::WHITE,
             button_padding: 8.0,
             spacing: 4.0,
+            panel_bg: Color::from_rgba8(20, 20, 35, 200),
+            panel_padding: 12.0,
+            progress_bg: Color::from_rgba8(40, 40, 55, 200),
+            progress_fill: Color::from_rgba8(80, 160, 80, 255),
+            progress_height: 20.0,
+            checkbox_size: 16.0,
+            checkbox_bg: Color::from_rgba8(50, 50, 70, 220),
+            checkbox_checked_bg: Color::from_rgba8(80, 140, 200, 255),
+            slider_track_color: Color::from_rgba8(50, 50, 70, 220),
+            slider_fill_color: Color::from_rgba8(80, 140, 200, 255),
+            slider_thumb_color: Color::WHITE,
+            slider_height: 16.0,
         }
     }
 }
@@ -47,11 +71,53 @@ enum Widget {
     Separator {
         height: f32,
     },
+    Panel {
+        color: Color,
+        padding: f32,
+        children: usize,
+    },
+    ProgressBar {
+        label: String,
+        value: f32,
+        color: Option<Color>,
+    },
+    Checkbox {
+        id: usize,
+        label: String,
+        checked: bool,
+    },
+    Slider {
+        id: usize,
+        label: String,
+        value: f32,
+        min: f32,
+        max: f32,
+    },
 }
 
 pub struct UiResponse {
     pub focused: Option<usize>,
     pub activated: Option<usize>,
+    pub hovered: Option<usize>,
+    pub toggled: Vec<usize>,
+    pub changed_values: Vec<(usize, f32)>,
+}
+
+impl UiResponse {
+    pub fn was_activated(&self, id: usize) -> bool {
+        self.activated == Some(id)
+    }
+
+    pub fn was_toggled(&self, id: usize) -> bool {
+        self.toggled.contains(&id)
+    }
+
+    pub fn value_for(&self, id: usize) -> Option<f32> {
+        self.changed_values
+            .iter()
+            .find(|(cid, _)| *cid == id)
+            .map(|(_, v)| *v)
+    }
 }
 
 pub struct Ui<'a> {
@@ -62,9 +128,10 @@ pub struct Ui<'a> {
     atlas: &'a FontAtlas,
     style: UiStyle,
     widgets: Vec<Widget>,
-    button_ids: Vec<usize>,
+    focusable_ids: Vec<usize>,
     focus_index: usize,
     activated: Option<usize>,
+    mouse_focus: bool,
 }
 
 impl<'a> Ui<'a> {
@@ -77,9 +144,10 @@ impl<'a> Ui<'a> {
             atlas,
             style: UiStyle::default(),
             widgets: Vec::new(),
-            button_ids: Vec::new(),
+            focusable_ids: Vec::new(),
             focus_index: 0,
             activated: None,
+            mouse_focus: false,
         }
     }
 
@@ -112,7 +180,7 @@ impl<'a> Ui<'a> {
     }
 
     pub fn button(&mut self, id: usize, text: &str) {
-        self.button_ids.push(id);
+        self.focusable_ids.push(id);
         self.widgets.push(Widget::Button {
             id,
             text: text.to_string(),
@@ -123,20 +191,180 @@ impl<'a> Ui<'a> {
         self.widgets.push(Widget::Separator { height });
     }
 
+    pub fn panel(&mut self, children: usize) {
+        self.panel_colored(self.style.panel_bg, self.style.panel_padding, children);
+    }
+
+    pub fn panel_colored(&mut self, color: Color, padding: f32, children: usize) {
+        self.widgets.push(Widget::Panel {
+            color,
+            padding,
+            children,
+        });
+    }
+
+    pub fn progress_bar(&mut self, label: &str, value: f32) {
+        self.widgets.push(Widget::ProgressBar {
+            label: label.to_string(),
+            value: value.clamp(0.0, 1.0),
+            color: None,
+        });
+    }
+
+    pub fn progress_bar_colored(&mut self, label: &str, value: f32, fill_color: Color) {
+        self.widgets.push(Widget::ProgressBar {
+            label: label.to_string(),
+            value: value.clamp(0.0, 1.0),
+            color: Some(fill_color),
+        });
+    }
+
+    pub fn checkbox(&mut self, id: usize, label: &str, checked: bool) {
+        self.focusable_ids.push(id);
+        self.widgets.push(Widget::Checkbox {
+            id,
+            label: label.to_string(),
+            checked,
+        });
+    }
+
+    pub fn slider(&mut self, id: usize, label: &str, value: f32, min: f32, max: f32) {
+        self.focusable_ids.push(id);
+        self.widgets.push(Widget::Slider {
+            id,
+            label: label.to_string(),
+            value: value.clamp(min, max),
+            min,
+            max,
+        });
+    }
+
+    fn compute_widget_height(&self, widget: &Widget, remaining: &[Widget]) -> f32 {
+        match widget {
+            Widget::Label { size, .. } => self.atlas.line_height(*size) + self.style.spacing,
+            Widget::Button { .. } => {
+                let lh = self.atlas.line_height(self.style.text_size);
+                lh + self.style.button_padding * 2.0 + self.style.spacing
+            }
+            Widget::Separator { height } => *height,
+            Widget::Panel { padding, children, .. } => {
+                let mut h = padding * 2.0;
+                let n = (*children).min(remaining.len());
+                let child_slice = &remaining[..n];
+                let mut i = 0;
+                while i < child_slice.len() {
+                    h += self.compute_widget_height(&child_slice[i], &child_slice[i + 1..]);
+                    i += 1;
+                }
+                h + self.style.spacing
+            }
+            Widget::ProgressBar { .. } => {
+                let lh = self.atlas.line_height(self.style.text_size);
+                lh + self.style.progress_height + self.style.spacing * 2.0
+            }
+            Widget::Checkbox { .. } => {
+                let lh = self.atlas.line_height(self.style.text_size);
+                lh.max(self.style.checkbox_size) + self.style.spacing
+            }
+            Widget::Slider { label, .. } => {
+                let mut h = self.style.slider_height + self.style.spacing;
+                if !label.is_empty() {
+                    h += self.atlas.line_height(self.style.text_size) + self.style.spacing;
+                }
+                h
+            }
+        }
+    }
+
+    fn compute_focusable_rects(&self) -> Vec<(usize, f32, f32, f32, f32)> {
+        let mut rects = Vec::new();
+        let mut cursor_y = self.y;
+        let mut base_x = self.x;
+        let mut current_width = self.width;
+
+        let mut i = 0;
+        while i < self.widgets.len() {
+            match &self.widgets[i] {
+                Widget::Label { size, .. } => {
+                    cursor_y -= self.atlas.line_height(*size) + self.style.spacing;
+                }
+                Widget::Button { id, .. } => {
+                    let lh = self.atlas.line_height(self.style.text_size);
+                    let pad = self.style.button_padding;
+                    let btn_h = lh + pad * 2.0;
+                    let btn_y = cursor_y - btn_h + pad;
+                    rects.push((*id, base_x, btn_y, current_width, btn_h));
+                    cursor_y -= btn_h + self.style.spacing;
+                }
+                Widget::Separator { height } => {
+                    cursor_y -= *height;
+                }
+                Widget::Panel { padding, children, .. } => {
+                    cursor_y -= *padding;
+                    base_x += *padding;
+                    current_width -= *padding * 2.0;
+                    let end = (i + 1 + *children).min(self.widgets.len());
+                    let _ = end; // panel children processed inline
+                }
+                Widget::ProgressBar { .. } => {
+                    let lh = self.atlas.line_height(self.style.text_size);
+                    cursor_y -= lh + self.style.progress_height + self.style.spacing * 2.0;
+                }
+                Widget::Checkbox { id, .. } => {
+                    let lh = self.atlas.line_height(self.style.text_size);
+                    let row_h = lh.max(self.style.checkbox_size);
+                    rects.push((*id, base_x, cursor_y - row_h, current_width, row_h));
+                    cursor_y -= row_h + self.style.spacing;
+                }
+                Widget::Slider { id, label, .. } => {
+                    let h = self.style.slider_height;
+                    if !label.is_empty() {
+                        let lh = self.atlas.line_height(self.style.text_size);
+                        cursor_y -= lh + self.style.spacing;
+                    }
+                    rects.push((*id, base_x, cursor_y - h, current_width, h));
+                    cursor_y -= h + self.style.spacing;
+                }
+            }
+            i += 1;
+        }
+        rects
+    }
+
     pub fn update(&mut self, input: &InputState) -> UiResponse {
-        if self.button_ids.is_empty() {
+        let mut toggled = Vec::new();
+        let mut changed_values = Vec::new();
+        let mut hovered = None;
+
+        if self.focusable_ids.is_empty() {
             return UiResponse {
                 focused: None,
                 activated: None,
+                hovered: None,
+                toggled,
+                changed_values,
             };
         }
 
-        let count = self.button_ids.len();
+        let count = self.focusable_ids.len();
         if self.focus_index >= count {
             self.focus_index = 0;
         }
 
+        let rects = self.compute_focusable_rects();
+        let (mx, my) = input.mouse_position();
+
+        for (rect_idx, &(_, rx, ry, rw, rh)) in rects.iter().enumerate() {
+            if mx >= rx && mx <= rx + rw && my >= ry && my <= ry + rh {
+                hovered = Some(self.focusable_ids[rect_idx]);
+                self.focus_index = rect_idx;
+                self.mouse_focus = true;
+                break;
+            }
+        }
+
         if input.is_key_pressed(KeyCode::ArrowUp) || input.is_key_pressed(KeyCode::KeyW) {
+            self.mouse_focus = false;
             if self.focus_index == 0 {
                 self.focus_index = count - 1;
             } else {
@@ -144,32 +372,105 @@ impl<'a> Ui<'a> {
             }
         }
         if input.is_key_pressed(KeyCode::ArrowDown) || input.is_key_pressed(KeyCode::KeyS) {
+            self.mouse_focus = false;
             self.focus_index = (self.focus_index + 1) % count;
         }
 
-        let focused_id = self.button_ids[self.focus_index];
+        let focused_id = self.focusable_ids[self.focus_index];
 
-        if input.is_key_pressed(KeyCode::Enter) || input.is_key_pressed(KeyCode::Space) {
-            self.activated = Some(focused_id);
+        let keyboard_activate =
+            input.is_key_pressed(KeyCode::Enter) || input.is_key_pressed(KeyCode::Space);
+        let mouse_activate = input.is_mouse_pressed(0) && hovered.is_some();
+
+        if keyboard_activate || mouse_activate {
+            for widget in &self.widgets {
+                match widget {
+                    Widget::Checkbox { id, checked, .. } if *id == focused_id => {
+                        toggled.push(*id);
+                        let _ = checked;
+                    }
+                    Widget::Button { id, .. } if *id == focused_id => {
+                        self.activated = Some(*id);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if input.is_key_pressed(KeyCode::ArrowLeft) || input.is_key_pressed(KeyCode::ArrowRight) {
+            let delta = if input.is_key_pressed(KeyCode::ArrowRight) {
+                0.05
+            } else {
+                -0.05
+            };
+            for widget in &self.widgets {
+                if let Widget::Slider {
+                    id,
+                    value,
+                    min,
+                    max,
+                    ..
+                } = widget
+                {
+                    if *id == focused_id {
+                        let range = max - min;
+                        let new_val = (value + delta * range).clamp(*min, *max);
+                        changed_values.push((*id, new_val));
+                    }
+                }
+            }
+        }
+
+        if input.is_mouse_down(0) {
+            for (rect_idx, &(_, rx, ry, rw, rh)) in rects.iter().enumerate() {
+                let wid = self.focusable_ids[rect_idx];
+                if mx >= rx && mx <= rx + rw && my >= ry && my <= ry + rh {
+                    for widget in &self.widgets {
+                        if let Widget::Slider {
+                            id,
+                            min,
+                            max,
+                            ..
+                        } = widget
+                        {
+                            if *id == wid {
+                                let t = ((mx - rx) / rw).clamp(0.0, 1.0);
+                                let new_val = *min + t * (*max - *min);
+                                changed_values.push((*id, new_val));
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         UiResponse {
             focused: Some(self.focus_index),
             activated: self.activated,
+            hovered,
+            toggled,
+            changed_values,
         }
     }
 
     pub fn render(&self, canvas: &mut Canvas) {
         let mut cursor_y = self.y;
-        let focused_id = if !self.button_ids.is_empty() && self.focus_index < self.button_ids.len()
+        let mut base_x = self.x;
+        let mut current_width = self.width;
+        let focused_id = if !self.focusable_ids.is_empty()
+            && self.focus_index < self.focusable_ids.len()
         {
-            Some(self.button_ids[self.focus_index])
+            Some(self.focusable_ids[self.focus_index])
         } else {
             None
         };
 
-        for widget in &self.widgets {
-            match widget {
+        let mut panel_stack: Vec<(f32, f32, f32)> = Vec::new();
+        let mut panel_counters: Vec<usize> = Vec::new();
+
+        let mut i = 0;
+        while i < self.widgets.len() {
+            match &self.widgets[i] {
                 Widget::Label {
                     text,
                     size,
@@ -178,9 +479,9 @@ impl<'a> Ui<'a> {
                 } => {
                     let lh = self.atlas.line_height(*size);
                     let ax = match align {
-                        TextAlign::Left => self.x,
-                        TextAlign::Center => self.x + self.width / 2.0,
-                        TextAlign::Right => self.x + self.width,
+                        TextAlign::Left => base_x,
+                        TextAlign::Center => base_x + current_width / 2.0,
+                        TextAlign::Right => base_x + current_width,
                     };
                     canvas.text_aligned(
                         ax,
@@ -217,21 +518,21 @@ impl<'a> Ui<'a> {
                     let btn_h = lh + pad * 2.0;
 
                     canvas.rect(
-                        self.x,
+                        base_x,
                         cursor_y - btn_h + pad,
-                        self.width,
+                        current_width,
                         btn_h,
                         bg,
                         self.screen_size,
                     );
 
-                    let label = if is_focused {
+                    let label = if is_focused && !self.mouse_focus {
                         format!("> {}", text)
                     } else {
                         format!("  {}", text)
                     };
                     canvas.text(
-                        self.x + pad,
+                        base_x + pad,
                         cursor_y,
                         &label,
                         text_size,
@@ -245,7 +546,238 @@ impl<'a> Ui<'a> {
                 Widget::Separator { height } => {
                     cursor_y -= *height;
                 }
+                Widget::Panel {
+                    color,
+                    padding,
+                    children,
+                } => {
+                    let total_h = {
+                        let end = (i + 1 + *children).min(self.widgets.len());
+                        let child_slice = &self.widgets[i + 1..end];
+                        let mut h = 0.0;
+                        let mut ci = 0;
+                        while ci < child_slice.len() {
+                            h += self.compute_widget_height(
+                                &child_slice[ci],
+                                &child_slice[ci + 1..],
+                            );
+                            ci += 1;
+                        }
+                        h
+                    };
+
+                    let panel_h = total_h + *padding * 2.0;
+                    canvas.rect(
+                        base_x,
+                        cursor_y - panel_h + *padding,
+                        current_width,
+                        panel_h,
+                        *color,
+                        self.screen_size,
+                    );
+
+                    cursor_y -= *padding;
+                    panel_stack.push((base_x, current_width, *padding));
+                    base_x += *padding;
+                    current_width -= *padding * 2.0;
+                    panel_counters.push(*children);
+                }
+                Widget::ProgressBar {
+                    label, value, color,
+                } => {
+                    let text_size = self.style.text_size;
+                    let lh = self.atlas.line_height(text_size);
+                    let bar_h = self.style.progress_height;
+                    let fill_color = color.unwrap_or(self.style.progress_fill);
+
+                    if !label.is_empty() {
+                        let display = format!("{} ({}%)", label, (*value * 100.0) as u32);
+                        canvas.text(
+                            base_x,
+                            cursor_y,
+                            &display,
+                            text_size,
+                            self.style.text_color,
+                            self.screen_size,
+                            self.atlas,
+                        );
+                        cursor_y -= lh + self.style.spacing;
+                    }
+
+                    canvas.rect(
+                        base_x,
+                        cursor_y - bar_h,
+                        current_width,
+                        bar_h,
+                        self.style.progress_bg,
+                        self.screen_size,
+                    );
+                    if *value > 0.0 {
+                        canvas.rect(
+                            base_x,
+                            cursor_y - bar_h,
+                            current_width * *value,
+                            bar_h,
+                            fill_color,
+                            self.screen_size,
+                        );
+                    }
+                    cursor_y -= bar_h + self.style.spacing;
+                }
+                Widget::Checkbox { id, label, checked } => {
+                    let is_focused = focused_id == Some(*id);
+                    let text_size = self.style.text_size;
+                    let box_size = self.style.checkbox_size;
+                    let lh = self.atlas.line_height(text_size);
+                    let row_h = lh.max(box_size);
+
+                    let box_bg = if *checked {
+                        self.style.checkbox_checked_bg
+                    } else {
+                        self.style.checkbox_bg
+                    };
+
+                    let bx = base_x;
+                    let by = cursor_y - row_h + (row_h - box_size) / 2.0;
+                    canvas.rect(bx, by, box_size, box_size, box_bg, self.screen_size);
+
+                    if *checked {
+                        let inset = box_size * 0.25;
+                        canvas.rect(
+                            bx + inset,
+                            by + inset,
+                            box_size - inset * 2.0,
+                            box_size - inset * 2.0,
+                            Color::WHITE,
+                            self.screen_size,
+                        );
+                    }
+
+                    if is_focused {
+                        let border = 2.0;
+                        let outline = if self.mouse_focus {
+                            self.style.button_focused_bg
+                        } else {
+                            Color::WHITE
+                        };
+                        canvas.rect(bx - border, by - border, box_size + border * 2.0, border, outline, self.screen_size);
+                        canvas.rect(bx - border, by + box_size, box_size + border * 2.0, border, outline, self.screen_size);
+                        canvas.rect(bx - border, by, border, box_size, outline, self.screen_size);
+                        canvas.rect(bx + box_size, by, border, box_size, outline, self.screen_size);
+                    }
+
+                    let text_x = base_x + box_size + 8.0;
+                    let text_y = cursor_y - (row_h - lh) / 2.0;
+                    let fg = if is_focused {
+                        self.style.button_focused_text_color
+                    } else {
+                        self.style.text_color
+                    };
+                    canvas.text(
+                        text_x,
+                        text_y,
+                        label,
+                        text_size,
+                        fg,
+                        self.screen_size,
+                        self.atlas,
+                    );
+
+                    cursor_y -= row_h + self.style.spacing;
+                }
+                Widget::Slider {
+                    id,
+                    label,
+                    value,
+                    min,
+                    max,
+                } => {
+                    let is_focused = focused_id == Some(*id);
+                    let text_size = self.style.text_size;
+                    let bar_h = self.style.slider_height;
+
+                    if !label.is_empty() {
+                        let display = format!("{}: {:.1}", label, value);
+                        canvas.text(
+                            base_x,
+                            cursor_y,
+                            &display,
+                            text_size,
+                            self.style.text_color,
+                            self.screen_size,
+                            self.atlas,
+                        );
+                        cursor_y -= self.atlas.line_height(text_size) + self.style.spacing;
+                    }
+
+                    canvas.rect(
+                        base_x,
+                        cursor_y - bar_h,
+                        current_width,
+                        bar_h,
+                        self.style.slider_track_color,
+                        self.screen_size,
+                    );
+
+                    let range = max - min;
+                    let t = if range > 0.0 {
+                        (value - min) / range
+                    } else {
+                        0.0
+                    };
+                    if t > 0.0 {
+                        canvas.rect(
+                            base_x,
+                            cursor_y - bar_h,
+                            current_width * t,
+                            bar_h,
+                            self.style.slider_fill_color,
+                            self.screen_size,
+                        );
+                    }
+
+                    let thumb_w = 8.0;
+                    let thumb_x = base_x + current_width * t - thumb_w / 2.0;
+                    canvas.rect(
+                        thumb_x,
+                        cursor_y - bar_h - 2.0,
+                        thumb_w,
+                        bar_h + 4.0,
+                        self.style.slider_thumb_color,
+                        self.screen_size,
+                    );
+
+                    if is_focused {
+                        let border = 2.0;
+                        let outline = self.style.button_focused_bg;
+                        canvas.rect(base_x - border, cursor_y - bar_h - border, current_width + border * 2.0, border, outline, self.screen_size);
+                        canvas.rect(base_x - border, cursor_y, current_width + border * 2.0, border, outline, self.screen_size);
+                        canvas.rect(base_x - border, cursor_y - bar_h, border, bar_h, outline, self.screen_size);
+                        canvas.rect(base_x + current_width, cursor_y - bar_h, border, bar_h, outline, self.screen_size);
+                    }
+
+                    cursor_y -= bar_h + self.style.spacing;
+                }
             }
+
+            for counter in panel_counters.iter_mut().rev() {
+                if *counter > 0 {
+                    *counter -= 1;
+                    if *counter == 0 {
+                        if let Some((old_x, old_w, padding)) = panel_stack.pop() {
+                            cursor_y -= padding;
+                            base_x = old_x;
+                            current_width = old_w;
+                            cursor_y -= self.style.spacing;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            panel_counters.retain(|c| *c > 0);
+
+            i += 1;
         }
     }
 }

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -101,6 +101,7 @@ pub struct UiResponse {
     pub hovered: Option<usize>,
     pub toggled: Vec<usize>,
     pub changed_values: Vec<(usize, f32)>,
+    pub dragging: Option<usize>,
 }
 
 impl UiResponse {
@@ -120,34 +121,34 @@ impl UiResponse {
     }
 }
 
-pub struct Ui<'a> {
+pub struct Ui {
     x: f32,
     y: f32,
     width: f32,
     screen_size: (u32, u32),
-    atlas: &'a FontAtlas,
     style: UiStyle,
     widgets: Vec<Widget>,
     focusable_ids: Vec<usize>,
     focus_index: usize,
     activated: Option<usize>,
     mouse_focus: bool,
+    dragging_slider: Option<usize>,
 }
 
-impl<'a> Ui<'a> {
-    pub fn new(x: f32, y: f32, width: f32, screen_size: (u32, u32), atlas: &'a FontAtlas) -> Self {
+impl Ui {
+    pub fn new(x: f32, y: f32, width: f32, screen_size: (u32, u32)) -> Self {
         Self {
             x,
             y,
             width,
             screen_size,
-            atlas,
             style: UiStyle::default(),
             widgets: Vec::new(),
             focusable_ids: Vec::new(),
             focus_index: 0,
             activated: None,
             mouse_focus: false,
+            dragging_slider: None,
         }
     }
 
@@ -158,6 +159,11 @@ impl<'a> Ui<'a> {
 
     pub fn with_focus(mut self, focus: usize) -> Self {
         self.focus_index = focus;
+        self
+    }
+
+    pub fn with_dragging(mut self, dragging: Option<usize>) -> Self {
+        self.dragging_slider = dragging;
         self
     }
 
@@ -239,57 +245,68 @@ impl<'a> Ui<'a> {
         });
     }
 
-    fn compute_widget_height(&self, widget: &Widget, remaining: &[Widget]) -> f32 {
+    fn compute_widget_height(
+        &self,
+        widget: &Widget,
+        remaining: &[Widget],
+        atlas: &FontAtlas,
+    ) -> f32 {
         match widget {
-            Widget::Label { size, .. } => self.atlas.line_height(*size) + self.style.spacing,
+            Widget::Label { size, .. } => atlas.line_height(*size) + self.style.spacing,
             Widget::Button { .. } => {
-                let lh = self.atlas.line_height(self.style.text_size);
+                let lh = atlas.line_height(self.style.text_size);
                 lh + self.style.button_padding * 2.0 + self.style.spacing
             }
             Widget::Separator { height } => *height,
-            Widget::Panel { padding, children, .. } => {
+            Widget::Panel {
+                padding, children, ..
+            } => {
                 let mut h = padding * 2.0;
                 let n = (*children).min(remaining.len());
                 let child_slice = &remaining[..n];
                 let mut i = 0;
                 while i < child_slice.len() {
-                    h += self.compute_widget_height(&child_slice[i], &child_slice[i + 1..]);
+                    h += self.compute_widget_height(&child_slice[i], &child_slice[i + 1..], atlas);
                     i += 1;
                 }
                 h + self.style.spacing
             }
             Widget::ProgressBar { .. } => {
-                let lh = self.atlas.line_height(self.style.text_size);
+                let lh = atlas.line_height(self.style.text_size);
                 lh + self.style.progress_height + self.style.spacing * 2.0
             }
             Widget::Checkbox { .. } => {
-                let lh = self.atlas.line_height(self.style.text_size);
+                let lh = atlas.line_height(self.style.text_size);
                 lh.max(self.style.checkbox_size) + self.style.spacing
             }
             Widget::Slider { label, .. } => {
                 let mut h = self.style.slider_height + self.style.spacing;
                 if !label.is_empty() {
-                    h += self.atlas.line_height(self.style.text_size) + self.style.spacing;
+                    h += atlas.line_height(self.style.text_size) + self.style.spacing;
                 }
                 h
             }
         }
     }
 
-    fn compute_focusable_rects(&self) -> Vec<(usize, f32, f32, f32, f32)> {
+    fn compute_focusable_rects(&self, atlas: &FontAtlas) -> Vec<(usize, f32, f32, f32, f32)> {
         let mut rects = Vec::new();
         let mut cursor_y = self.y;
         let mut base_x = self.x;
         let mut current_width = self.width;
+        let mut panel_stack: Vec<(f32, f32, f32)> = Vec::new();
+        let mut panel_counters: Vec<usize> = Vec::new();
 
         let mut i = 0;
         while i < self.widgets.len() {
+            let mut pending_panel: Option<(f32, usize)> = None;
+
             match &self.widgets[i] {
                 Widget::Label { size, .. } => {
-                    cursor_y -= self.atlas.line_height(*size) + self.style.spacing;
+                    cursor_y -= atlas.line_height(*size) + self.style.spacing;
                 }
                 Widget::Button { id, .. } => {
-                    let lh = self.atlas.line_height(self.style.text_size);
+                    let lh = atlas.line_height(self.style.text_size);
                     let pad = self.style.button_padding;
                     let btn_h = lh + pad * 2.0;
                     let btn_y = cursor_y - btn_h + pad;
@@ -299,19 +316,17 @@ impl<'a> Ui<'a> {
                 Widget::Separator { height } => {
                     cursor_y -= *height;
                 }
-                Widget::Panel { padding, children, .. } => {
-                    cursor_y -= *padding;
-                    base_x += *padding;
-                    current_width -= *padding * 2.0;
-                    let end = (i + 1 + *children).min(self.widgets.len());
-                    let _ = end; // panel children processed inline
+                Widget::Panel {
+                    padding, children, ..
+                } => {
+                    pending_panel = Some((*padding, *children));
                 }
                 Widget::ProgressBar { .. } => {
-                    let lh = self.atlas.line_height(self.style.text_size);
+                    let lh = atlas.line_height(self.style.text_size);
                     cursor_y -= lh + self.style.progress_height + self.style.spacing * 2.0;
                 }
                 Widget::Checkbox { id, .. } => {
-                    let lh = self.atlas.line_height(self.style.text_size);
+                    let lh = atlas.line_height(self.style.text_size);
                     let row_h = lh.max(self.style.checkbox_size);
                     rects.push((*id, base_x, cursor_y - row_h, current_width, row_h));
                     cursor_y -= row_h + self.style.spacing;
@@ -319,19 +334,44 @@ impl<'a> Ui<'a> {
                 Widget::Slider { id, label, .. } => {
                     let h = self.style.slider_height;
                     if !label.is_empty() {
-                        let lh = self.atlas.line_height(self.style.text_size);
+                        let lh = atlas.line_height(self.style.text_size);
                         cursor_y -= lh + self.style.spacing;
                     }
                     rects.push((*id, base_x, cursor_y - h, current_width, h));
                     cursor_y -= h + self.style.spacing;
                 }
             }
+
+            for counter in panel_counters.iter_mut().rev() {
+                if *counter > 0 {
+                    *counter -= 1;
+                    if *counter == 0 {
+                        if let Some((old_x, old_w, padding)) = panel_stack.pop() {
+                            cursor_y -= padding;
+                            base_x = old_x;
+                            current_width = old_w;
+                            cursor_y -= self.style.spacing;
+                        }
+                    }
+                    break;
+                }
+            }
+            panel_counters.retain(|c| *c > 0);
+
+            if let Some((padding, children)) = pending_panel {
+                cursor_y -= padding;
+                panel_stack.push((base_x, current_width, padding));
+                base_x += padding;
+                current_width -= padding * 2.0;
+                panel_counters.push(children);
+            }
+
             i += 1;
         }
         rects
     }
 
-    pub fn update(&mut self, input: &InputState) -> UiResponse {
+    pub fn update(&mut self, input: &InputState, atlas: &FontAtlas) -> UiResponse {
         let mut toggled = Vec::new();
         let mut changed_values = Vec::new();
         let mut hovered = None;
@@ -343,6 +383,7 @@ impl<'a> Ui<'a> {
                 hovered: None,
                 toggled,
                 changed_values,
+                dragging: None,
             };
         }
 
@@ -351,7 +392,7 @@ impl<'a> Ui<'a> {
             self.focus_index = 0;
         }
 
-        let rects = self.compute_focusable_rects();
+        let rects = self.compute_focusable_rects(atlas);
         let (mx, my) = input.mouse_position();
 
         for (rect_idx, &(_, rx, ry, rw, rh)) in rects.iter().enumerate() {
@@ -421,23 +462,34 @@ impl<'a> Ui<'a> {
             }
         }
 
-        if input.is_mouse_down(0) {
+        if !input.is_mouse_down(0) {
+            self.dragging_slider = None;
+        }
+
+        if input.is_mouse_pressed(0) {
             for (rect_idx, &(_, rx, ry, rw, rh)) in rects.iter().enumerate() {
                 let wid = self.focusable_ids[rect_idx];
                 if mx >= rx && mx <= rx + rw && my >= ry && my <= ry + rh {
                     for widget in &self.widgets {
-                        if let Widget::Slider {
-                            id,
-                            min,
-                            max,
-                            ..
-                        } = widget
-                        {
+                        if let Widget::Slider { id, .. } = widget {
                             if *id == wid {
-                                let t = ((mx - rx) / rw).clamp(0.0, 1.0);
-                                let new_val = *min + t * (*max - *min);
-                                changed_values.push((*id, new_val));
+                                self.dragging_slider = Some(*id);
                             }
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(drag_id) = self.dragging_slider {
+            if let Some(&(_, rx, _, rw, _)) = rects.iter().find(|(rid, _, _, _, _)| *rid == drag_id)
+            {
+                for widget in &self.widgets {
+                    if let Widget::Slider { id, min, max, .. } = widget {
+                        if *id == drag_id {
+                            let t = ((mx - rx) / rw).clamp(0.0, 1.0);
+                            let new_val = *min + t * (*max - *min);
+                            changed_values.push((*id, new_val));
                         }
                     }
                 }
@@ -450,26 +502,28 @@ impl<'a> Ui<'a> {
             hovered,
             toggled,
             changed_values,
+            dragging: self.dragging_slider,
         }
     }
 
-    pub fn render(&self, canvas: &mut Canvas) {
+    pub fn render(&self, canvas: &mut Canvas, atlas: &FontAtlas) {
         let mut cursor_y = self.y;
         let mut base_x = self.x;
         let mut current_width = self.width;
-        let focused_id = if !self.focusable_ids.is_empty()
-            && self.focus_index < self.focusable_ids.len()
-        {
-            Some(self.focusable_ids[self.focus_index])
-        } else {
-            None
-        };
+        let focused_id =
+            if !self.focusable_ids.is_empty() && self.focus_index < self.focusable_ids.len() {
+                Some(self.focusable_ids[self.focus_index])
+            } else {
+                None
+            };
 
         let mut panel_stack: Vec<(f32, f32, f32)> = Vec::new();
         let mut panel_counters: Vec<usize> = Vec::new();
 
         let mut i = 0;
         while i < self.widgets.len() {
+            let mut pending_panel: Option<(f32, usize)> = None;
+
             match &self.widgets[i] {
                 Widget::Label {
                     text,
@@ -477,7 +531,7 @@ impl<'a> Ui<'a> {
                     color,
                     align,
                 } => {
-                    let lh = self.atlas.line_height(*size);
+                    let lh = atlas.line_height(*size);
                     let ax = match align {
                         TextAlign::Left => base_x,
                         TextAlign::Center => base_x + current_width / 2.0,
@@ -491,7 +545,7 @@ impl<'a> Ui<'a> {
                         *color,
                         *align,
                         self.screen_size,
-                        self.atlas,
+                        atlas,
                     );
                     cursor_y -= lh + self.style.spacing;
                 }
@@ -514,7 +568,7 @@ impl<'a> Ui<'a> {
 
                     let text_size = self.style.text_size;
                     let pad = self.style.button_padding;
-                    let lh = self.atlas.line_height(text_size);
+                    let lh = atlas.line_height(text_size);
                     let btn_h = lh + pad * 2.0;
 
                     canvas.rect(
@@ -538,7 +592,7 @@ impl<'a> Ui<'a> {
                         text_size,
                         fg,
                         self.screen_size,
-                        self.atlas,
+                        atlas,
                     );
 
                     cursor_y -= btn_h + self.style.spacing;
@@ -560,6 +614,7 @@ impl<'a> Ui<'a> {
                             h += self.compute_widget_height(
                                 &child_slice[ci],
                                 &child_slice[ci + 1..],
+                                atlas,
                             );
                             ci += 1;
                         }
@@ -576,17 +631,15 @@ impl<'a> Ui<'a> {
                         self.screen_size,
                     );
 
-                    cursor_y -= *padding;
-                    panel_stack.push((base_x, current_width, *padding));
-                    base_x += *padding;
-                    current_width -= *padding * 2.0;
-                    panel_counters.push(*children);
+                    pending_panel = Some((*padding, *children));
                 }
                 Widget::ProgressBar {
-                    label, value, color,
+                    label,
+                    value,
+                    color,
                 } => {
                     let text_size = self.style.text_size;
-                    let lh = self.atlas.line_height(text_size);
+                    let lh = atlas.line_height(text_size);
                     let bar_h = self.style.progress_height;
                     let fill_color = color.unwrap_or(self.style.progress_fill);
 
@@ -599,7 +652,7 @@ impl<'a> Ui<'a> {
                             text_size,
                             self.style.text_color,
                             self.screen_size,
-                            self.atlas,
+                            atlas,
                         );
                         cursor_y -= lh + self.style.spacing;
                     }
@@ -628,7 +681,7 @@ impl<'a> Ui<'a> {
                     let is_focused = focused_id == Some(*id);
                     let text_size = self.style.text_size;
                     let box_size = self.style.checkbox_size;
-                    let lh = self.atlas.line_height(text_size);
+                    let lh = atlas.line_height(text_size);
                     let row_h = lh.max(box_size);
 
                     let box_bg = if *checked {
@@ -660,10 +713,31 @@ impl<'a> Ui<'a> {
                         } else {
                             Color::WHITE
                         };
-                        canvas.rect(bx - border, by - border, box_size + border * 2.0, border, outline, self.screen_size);
-                        canvas.rect(bx - border, by + box_size, box_size + border * 2.0, border, outline, self.screen_size);
+                        canvas.rect(
+                            bx - border,
+                            by - border,
+                            box_size + border * 2.0,
+                            border,
+                            outline,
+                            self.screen_size,
+                        );
+                        canvas.rect(
+                            bx - border,
+                            by + box_size,
+                            box_size + border * 2.0,
+                            border,
+                            outline,
+                            self.screen_size,
+                        );
                         canvas.rect(bx - border, by, border, box_size, outline, self.screen_size);
-                        canvas.rect(bx + box_size, by, border, box_size, outline, self.screen_size);
+                        canvas.rect(
+                            bx + box_size,
+                            by,
+                            border,
+                            box_size,
+                            outline,
+                            self.screen_size,
+                        );
                     }
 
                     let text_x = base_x + box_size + 8.0;
@@ -680,7 +754,7 @@ impl<'a> Ui<'a> {
                         text_size,
                         fg,
                         self.screen_size,
-                        self.atlas,
+                        atlas,
                     );
 
                     cursor_y -= row_h + self.style.spacing;
@@ -705,9 +779,9 @@ impl<'a> Ui<'a> {
                             text_size,
                             self.style.text_color,
                             self.screen_size,
-                            self.atlas,
+                            atlas,
                         );
-                        cursor_y -= self.atlas.line_height(text_size) + self.style.spacing;
+                        cursor_y -= atlas.line_height(text_size) + self.style.spacing;
                     }
 
                     canvas.rect(
@@ -750,10 +824,38 @@ impl<'a> Ui<'a> {
                     if is_focused {
                         let border = 2.0;
                         let outline = self.style.button_focused_bg;
-                        canvas.rect(base_x - border, cursor_y - bar_h - border, current_width + border * 2.0, border, outline, self.screen_size);
-                        canvas.rect(base_x - border, cursor_y, current_width + border * 2.0, border, outline, self.screen_size);
-                        canvas.rect(base_x - border, cursor_y - bar_h, border, bar_h, outline, self.screen_size);
-                        canvas.rect(base_x + current_width, cursor_y - bar_h, border, bar_h, outline, self.screen_size);
+                        canvas.rect(
+                            base_x - border,
+                            cursor_y - bar_h - border,
+                            current_width + border * 2.0,
+                            border,
+                            outline,
+                            self.screen_size,
+                        );
+                        canvas.rect(
+                            base_x - border,
+                            cursor_y,
+                            current_width + border * 2.0,
+                            border,
+                            outline,
+                            self.screen_size,
+                        );
+                        canvas.rect(
+                            base_x - border,
+                            cursor_y - bar_h,
+                            border,
+                            bar_h,
+                            outline,
+                            self.screen_size,
+                        );
+                        canvas.rect(
+                            base_x + current_width,
+                            cursor_y - bar_h,
+                            border,
+                            bar_h,
+                            outline,
+                            self.screen_size,
+                        );
                     }
 
                     cursor_y -= bar_h + self.style.spacing;
@@ -776,6 +878,14 @@ impl<'a> Ui<'a> {
             }
 
             panel_counters.retain(|c| *c > 0);
+
+            if let Some((padding, children)) = pending_panel {
+                cursor_y -= padding;
+                panel_stack.push((base_x, current_width, padding));
+                base_x += padding;
+                current_width -= padding * 2.0;
+                panel_counters.push(children);
+            }
 
             i += 1;
         }

--- a/samples/features/feature-everything/src/main.rs
+++ b/samples/features/feature-everything/src/main.rs
@@ -1227,6 +1227,15 @@ struct PauseOverlay {
     focus: usize,
 }
 
+impl PauseOverlay {
+    fn build_pause_ui(ui: &mut Ui) {
+        ui.label_centered("PAUSED", 40.0, Color::WHITE);
+        ui.separator(12.0);
+        ui.button(0, "Resume");
+        ui.button(1, "Quit");
+    }
+}
+
 impl Scene for PauseOverlay {
     fn on_enter(&mut self, _engine: &mut Engine, globals: &mut Globals) {
         if let Some(counter) = globals.get_mut::<TransitionCounter>() {
@@ -1258,10 +1267,9 @@ impl Scene for PauseOverlay {
         let hh = sh as f32 / 2.0;
         let atlas = engine.font_atlas();
 
-        let mut ui = Ui::new(-100.0, hh - 40.0, 200.0, (sw, sh), atlas).with_focus(self.focus);
-        ui.button(0, "Resume");
-        ui.button(1, "Quit");
-        let resp = ui.update(engine.input());
+        let mut ui = Ui::new(-100.0, hh - 40.0, 200.0, (sw, sh)).with_focus(self.focus);
+        Self::build_pause_ui(&mut ui);
+        let resp = ui.update(engine.input(), atlas);
         self.focus = resp.focused.unwrap_or(self.focus);
 
         if let Some(id) = resp.activated {
@@ -1297,12 +1305,9 @@ impl Scene for PauseOverlay {
             (sw, sh),
         );
 
-        let mut ui = Ui::new(-100.0, hh - 40.0, 200.0, (sw, sh), atlas).with_focus(self.focus);
-        ui.label_centered("PAUSED", 40.0, Color::WHITE);
-        ui.separator(12.0);
-        ui.button(0, "Resume");
-        ui.button(1, "Quit");
-        ui.render(overlay);
+        let mut ui = Ui::new(-100.0, hh - 40.0, 200.0, (sw, sh)).with_focus(self.focus);
+        Self::build_pause_ui(&mut ui);
+        ui.render(overlay, atlas);
 
         if let Some(stats) = globals.get::<PlayerStats>() {
             overlay.text(

--- a/samples/features/feature-scenes/src/main.rs
+++ b/samples/features/feature-scenes/src/main.rs
@@ -47,26 +47,26 @@ impl Scene for ColorScene {
         let input = engine.input();
 
         if input.is_key_pressed(KeyCode::Digit1) {
-            return SceneOp::Switch(Box::new(ColorScene::new(
-                "Red",
-                Color::new(0.8, 0.2, 0.2, 1.0),
-            )));
+            return SceneOp::FadeSwitch(
+                Box::new(ColorScene::new("Red", Color::new(0.8, 0.2, 0.2, 1.0))),
+                Transition::fade(0.5),
+            );
         }
         if input.is_key_pressed(KeyCode::Digit2) {
-            return SceneOp::Switch(Box::new(ColorScene::new(
-                "Green",
-                Color::new(0.2, 0.7, 0.2, 1.0),
-            )));
+            return SceneOp::FadeSwitch(
+                Box::new(ColorScene::new("Green", Color::new(0.2, 0.7, 0.2, 1.0))),
+                Transition::fade(0.5),
+            );
         }
         if input.is_key_pressed(KeyCode::Digit3) {
-            return SceneOp::Switch(Box::new(ColorScene::new(
-                "Blue",
-                Color::new(0.2, 0.3, 0.9, 1.0),
-            )));
+            return SceneOp::FadeSwitch(
+                Box::new(ColorScene::new("Blue", Color::new(0.2, 0.3, 0.9, 1.0))),
+                Transition::fade_white(0.8),
+            );
         }
 
         if input.is_key_pressed(KeyCode::KeyP) {
-            return SceneOp::Push(Box::new(PauseOverlay));
+            return SceneOp::FadePush(Box::new(PauseOverlay), Transition::fade(0.3));
         }
 
         if input.is_key_pressed(KeyCode::Space) {
@@ -108,7 +108,7 @@ impl Scene for ColorScene {
             28.0,
             12.0,
             Color::WHITE,
-            "[1] Red  [2] Green  [3] Blue  [P] Pause  [Space] +1  [Esc] Quit",
+            "[1] Red  [2] Green  [3] Blue (white fade)  [P] Pause  [Esc] Quit",
         );
     }
 
@@ -136,7 +136,7 @@ impl Scene for PauseOverlay {
         if engine.input().is_key_pressed(KeyCode::Escape)
             || engine.input().is_key_pressed(KeyCode::KeyP)
         {
-            return SceneOp::Pop;
+            return SceneOp::FadePop(Transition::fade(0.3));
         }
         SceneOp::Continue
     }

--- a/samples/features/feature-ui/src/main.rs
+++ b/samples/features/feature-ui/src/main.rs
@@ -20,7 +20,7 @@ impl Scene for MenuScene {
         ui.separator(10.0);
         ui.button(0, "Start Game");
         ui.button(1, "Options");
-        ui.button(2, "Credits");
+        ui.button(2, "Widget Demo");
         ui.button(3, "Quit");
 
         let response = ui.update(engine.input());
@@ -35,7 +35,9 @@ impl Scene for MenuScene {
                     self.message = "Options not implemented".into();
                     return SceneOp::Push(Box::new(OptionsScene { focus: 0 }));
                 }
-                2 => self.message = "Credits: rengine UI demo".into(),
+                2 => {
+                    return SceneOp::Push(Box::new(DemoScene::new()));
+                }
                 3 => return SceneOp::Quit,
                 _ => {}
             }
@@ -59,7 +61,7 @@ impl Scene for MenuScene {
         ui.separator(10.0);
         ui.button(0, "Start Game");
         ui.button(1, "Options");
-        ui.button(2, "Credits");
+        ui.button(2, "Widget Demo");
         ui.button(3, "Quit");
 
         ui.render(canvas);
@@ -80,7 +82,7 @@ impl Scene for MenuScene {
         canvas.text_aligned(
             0.0,
             -hh + 12.0,
-            "Arrow keys: navigate | Enter: select",
+            "Mouse or arrow keys: navigate | Click or Enter: select",
             10.0,
             Color::from_rgba8(140, 140, 140, 255),
             TextAlign::Center,
@@ -179,6 +181,141 @@ impl Scene for OptionsScene {
     }
 }
 
+struct DemoScene {
+    focus: usize,
+    speed: f32,
+    volume: f32,
+    fullscreen: bool,
+    vsync: bool,
+    health: f32,
+    fuel: f32,
+}
+
+impl DemoScene {
+    fn new() -> Self {
+        Self {
+            focus: 0,
+            speed: 1.5,
+            volume: 0.75,
+            fullscreen: false,
+            vsync: true,
+            health: 0.82,
+            fuel: 0.45,
+        }
+    }
+}
+
+impl Scene for DemoScene {
+    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
+
+    fn update(&mut self, engine: &Engine, _globals: &mut Globals) -> SceneOp {
+        let (sw, sh) = engine.window_size();
+        let atlas = engine.font_atlas();
+        let hh = sh as f32 / 2.0;
+
+        let mut ui = Ui::new(-180.0, hh - 40.0, 360.0, (sw, sh), atlas)
+            .with_focus(self.focus);
+
+        ui.label_centered("Widget Demo", 24.0, Color::WHITE);
+        ui.separator(8.0);
+
+        ui.panel(8);
+        ui.label("Stats", 18.0, Color::from_rgba8(180, 200, 255, 255));
+        ui.separator(4.0);
+        ui.progress_bar("Health", self.health);
+        ui.progress_bar_colored("Fuel", self.fuel, Color::from_rgba8(220, 160, 40, 255));
+        ui.separator(4.0);
+        ui.checkbox(10, "Fullscreen", self.fullscreen);
+        ui.checkbox(11, "VSync", self.vsync);
+        ui.slider(20, "Game Speed", self.speed, 0.5, 3.0);
+        ui.slider(21, "Volume", self.volume, 0.0, 1.0);
+
+        ui.separator(8.0);
+        ui.button(99, "Back");
+
+        let response = ui.update(engine.input());
+        if let Some(f) = response.focused {
+            self.focus = f;
+        }
+
+        if response.was_toggled(10) {
+            self.fullscreen = !self.fullscreen;
+        }
+        if response.was_toggled(11) {
+            self.vsync = !self.vsync;
+        }
+        if let Some(v) = response.value_for(20) {
+            self.speed = v;
+        }
+        if let Some(v) = response.value_for(21) {
+            self.volume = v;
+        }
+
+        if response.was_activated(99) || engine.input().is_key_pressed(KeyCode::Escape) {
+            return SceneOp::Pop;
+        }
+
+        self.health = (self.health - engine.dt() * 0.02).max(0.0);
+        self.fuel = (self.fuel - engine.dt() * 0.01).max(0.0);
+
+        SceneOp::Continue
+    }
+
+    fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
+        let (sw, sh) = engine.window_size();
+        let hh = sh as f32 / 2.0;
+        let atlas = engine.font_atlas();
+        frame.clear_color = Color::from_rgba8(20, 20, 35, 255);
+
+        let canvas = frame.canvas(0);
+
+        let mut ui = Ui::new(-180.0, hh - 40.0, 360.0, (sw, sh), atlas)
+            .with_focus(self.focus);
+
+        ui.label_centered("Widget Demo", 24.0, Color::WHITE);
+        ui.separator(8.0);
+
+        ui.panel(8);
+        ui.label("Stats", 18.0, Color::from_rgba8(180, 200, 255, 255));
+        ui.separator(4.0);
+        ui.progress_bar("Health", self.health);
+        ui.progress_bar_colored("Fuel", self.fuel, Color::from_rgba8(220, 160, 40, 255));
+        ui.separator(4.0);
+        ui.checkbox(10, "Fullscreen", self.fullscreen);
+        ui.checkbox(11, "VSync", self.vsync);
+        ui.slider(20, "Game Speed", self.speed, 0.5, 3.0);
+        ui.slider(21, "Volume", self.volume, 0.0, 1.0);
+
+        ui.separator(8.0);
+        ui.button(99, "Back");
+
+        ui.render(canvas);
+
+        let mouse = engine.mouse_screen_pos();
+        canvas.text_aligned(
+            0.0,
+            -hh + 30.0,
+            &format!("Mouse: ({:.0}, {:.0})", mouse.x, mouse.y),
+            10.0,
+            Color::from_rgba8(180, 180, 180, 255),
+            TextAlign::Center,
+            (sw, sh),
+            atlas,
+        );
+
+        canvas.text_aligned(
+            0.0,
+            -hh + 12.0,
+            "Mouse or arrows: navigate | Click/Enter: interact | Left/Right: adjust sliders",
+            10.0,
+            Color::from_rgba8(140, 140, 140, 255),
+            TextAlign::Center,
+            (sw, sh),
+            atlas,
+        );
+    }
+}
+
 struct GameScene {
     time: f32,
 }
@@ -246,7 +383,7 @@ fn main() {
     let config = EngineConfig {
         title: "UI Widget Demo".into(),
         width: 500,
-        height: 400,
+        height: 500,
         ..Default::default()
     };
     let _ = rengine::run_with_scenes(config, |_engine, _globals| -> Box<dyn Scene> {

--- a/samples/features/feature-ui/src/main.rs
+++ b/samples/features/feature-ui/src/main.rs
@@ -5,6 +5,17 @@ struct MenuScene {
     message: String,
 }
 
+impl MenuScene {
+    fn build_menu(ui: &mut Ui) {
+        ui.label_centered("Main Menu", 28.0, Color::WHITE);
+        ui.separator(10.0);
+        ui.button(0, "Start Game");
+        ui.button(1, "Options");
+        ui.button(2, "Widget Demo");
+        ui.button(3, "Quit");
+    }
+}
+
 impl Scene for MenuScene {
     fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
 
@@ -13,17 +24,10 @@ impl Scene for MenuScene {
         let atlas = engine.font_atlas();
         let hh = sh as f32 / 2.0;
 
-        let mut ui = Ui::new(-120.0, hh - 80.0, 240.0, (sw, sh), atlas)
-            .with_focus(self.focus);
+        let mut ui = Ui::new(-120.0, hh - 80.0, 240.0, (sw, sh)).with_focus(self.focus);
+        Self::build_menu(&mut ui);
 
-        ui.label_centered("Main Menu", 28.0, Color::WHITE);
-        ui.separator(10.0);
-        ui.button(0, "Start Game");
-        ui.button(1, "Options");
-        ui.button(2, "Widget Demo");
-        ui.button(3, "Quit");
-
-        let response = ui.update(engine.input());
+        let response = ui.update(engine.input(), atlas);
         if let Some(f) = response.focused {
             self.focus = f;
         }
@@ -54,17 +58,10 @@ impl Scene for MenuScene {
 
         let canvas = frame.canvas(0);
 
-        let mut ui = Ui::new(-120.0, hh - 80.0, 240.0, (sw, sh), atlas)
-            .with_focus(self.focus);
+        let mut ui = Ui::new(-120.0, hh - 80.0, 240.0, (sw, sh)).with_focus(self.focus);
+        Self::build_menu(&mut ui);
 
-        ui.label_centered("Main Menu", 28.0, Color::WHITE);
-        ui.separator(10.0);
-        ui.button(0, "Start Game");
-        ui.button(1, "Options");
-        ui.button(2, "Widget Demo");
-        ui.button(3, "Quit");
-
-        ui.render(canvas);
+        ui.render(canvas, atlas);
 
         if !self.message.is_empty() {
             canvas.text_aligned(
@@ -96,6 +93,25 @@ struct OptionsScene {
     focus: usize,
 }
 
+impl OptionsScene {
+    fn options_style() -> UiStyle {
+        UiStyle {
+            button_bg: Color::from_rgba8(50, 70, 50, 200),
+            button_focused_bg: Color::from_rgba8(70, 120, 70, 240),
+            button_pressed_bg: Color::from_rgba8(100, 160, 100, 255),
+            ..UiStyle::default()
+        }
+    }
+
+    fn build_options(ui: &mut Ui) {
+        ui.label_centered("Options", 24.0, Color::from_rgba8(150, 220, 150, 255));
+        ui.separator(8.0);
+        ui.button(0, "Audio");
+        ui.button(1, "Video");
+        ui.button(2, "Back");
+    }
+}
+
 impl Scene for OptionsScene {
     fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
 
@@ -104,24 +120,12 @@ impl Scene for OptionsScene {
         let atlas = engine.font_atlas();
         let hh = sh as f32 / 2.0;
 
-        let style = UiStyle {
-            button_bg: Color::from_rgba8(50, 70, 50, 200),
-            button_focused_bg: Color::from_rgba8(70, 120, 70, 240),
-            button_pressed_bg: Color::from_rgba8(100, 160, 100, 255),
-            ..UiStyle::default()
-        };
-
-        let mut ui = Ui::new(-100.0, hh - 60.0, 200.0, (sw, sh), atlas)
-            .with_style(style)
+        let mut ui = Ui::new(-100.0, hh - 60.0, 200.0, (sw, sh))
+            .with_style(Self::options_style())
             .with_focus(self.focus);
+        Self::build_options(&mut ui);
 
-        ui.label_centered("Options", 24.0, Color::from_rgba8(150, 220, 150, 255));
-        ui.separator(8.0);
-        ui.button(0, "Audio");
-        ui.button(1, "Video");
-        ui.button(2, "Back");
-
-        let response = ui.update(engine.input());
+        let response = ui.update(engine.input(), atlas);
         if let Some(f) = response.focused {
             self.focus = f;
         }
@@ -147,26 +151,21 @@ impl Scene for OptionsScene {
         let canvas = frame.canvas(1);
         let fw = sw as f32;
         let fh = sh as f32;
-        canvas.rect(-fw / 2.0, -hh, fw, fh, Color::new(0.0, 0.0, 0.0, 0.6), (sw, sh));
+        canvas.rect(
+            -fw / 2.0,
+            -hh,
+            fw,
+            fh,
+            Color::new(0.0, 0.0, 0.0, 0.6),
+            (sw, sh),
+        );
 
-        let style = UiStyle {
-            button_bg: Color::from_rgba8(50, 70, 50, 200),
-            button_focused_bg: Color::from_rgba8(70, 120, 70, 240),
-            button_pressed_bg: Color::from_rgba8(100, 160, 100, 255),
-            ..UiStyle::default()
-        };
-
-        let mut ui = Ui::new(-100.0, hh - 60.0, 200.0, (sw, sh), atlas)
-            .with_style(style)
+        let mut ui = Ui::new(-100.0, hh - 60.0, 200.0, (sw, sh))
+            .with_style(Self::options_style())
             .with_focus(self.focus);
+        Self::build_options(&mut ui);
 
-        ui.label_centered("Options", 24.0, Color::from_rgba8(150, 220, 150, 255));
-        ui.separator(8.0);
-        ui.button(0, "Audio");
-        ui.button(1, "Video");
-        ui.button(2, "Back");
-
-        ui.render(canvas);
+        ui.render(canvas, atlas);
 
         canvas.text_aligned(
             0.0,
@@ -183,6 +182,7 @@ impl Scene for OptionsScene {
 
 struct DemoScene {
     focus: usize,
+    dragging: Option<usize>,
     speed: f32,
     volume: f32,
     fullscreen: bool,
@@ -195,6 +195,7 @@ impl DemoScene {
     fn new() -> Self {
         Self {
             focus: 0,
+            dragging: None,
             speed: 1.5,
             volume: 0.75,
             fullscreen: false,
@@ -203,19 +204,8 @@ impl DemoScene {
             fuel: 0.45,
         }
     }
-}
 
-impl Scene for DemoScene {
-    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
-
-    fn update(&mut self, engine: &Engine, _globals: &mut Globals) -> SceneOp {
-        let (sw, sh) = engine.window_size();
-        let atlas = engine.font_atlas();
-        let hh = sh as f32 / 2.0;
-
-        let mut ui = Ui::new(-180.0, hh - 40.0, 360.0, (sw, sh), atlas)
-            .with_focus(self.focus);
-
+    fn build_widgets(&self, ui: &mut Ui) {
         ui.label_centered("Widget Demo", 24.0, Color::WHITE);
         ui.separator(8.0);
 
@@ -232,11 +222,27 @@ impl Scene for DemoScene {
 
         ui.separator(8.0);
         ui.button(99, "Back");
+    }
+}
 
-        let response = ui.update(engine.input());
+impl Scene for DemoScene {
+    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
+
+    fn update(&mut self, engine: &Engine, _globals: &mut Globals) -> SceneOp {
+        let (sw, sh) = engine.window_size();
+        let atlas = engine.font_atlas();
+        let hh = sh as f32 / 2.0;
+
+        let mut ui = Ui::new(-180.0, hh - 40.0, 360.0, (sw, sh))
+            .with_focus(self.focus)
+            .with_dragging(self.dragging);
+        self.build_widgets(&mut ui);
+
+        let response = ui.update(engine.input(), atlas);
         if let Some(f) = response.focused {
             self.focus = f;
         }
+        self.dragging = response.dragging;
 
         if response.was_toggled(10) {
             self.fullscreen = !self.fullscreen;
@@ -269,27 +275,12 @@ impl Scene for DemoScene {
 
         let canvas = frame.canvas(0);
 
-        let mut ui = Ui::new(-180.0, hh - 40.0, 360.0, (sw, sh), atlas)
-            .with_focus(self.focus);
+        let mut ui = Ui::new(-180.0, hh - 40.0, 360.0, (sw, sh))
+            .with_focus(self.focus)
+            .with_dragging(self.dragging);
+        self.build_widgets(&mut ui);
 
-        ui.label_centered("Widget Demo", 24.0, Color::WHITE);
-        ui.separator(8.0);
-
-        ui.panel(8);
-        ui.label("Stats", 18.0, Color::from_rgba8(180, 200, 255, 255));
-        ui.separator(4.0);
-        ui.progress_bar("Health", self.health);
-        ui.progress_bar_colored("Fuel", self.fuel, Color::from_rgba8(220, 160, 40, 255));
-        ui.separator(4.0);
-        ui.checkbox(10, "Fullscreen", self.fullscreen);
-        ui.checkbox(11, "VSync", self.vsync);
-        ui.slider(20, "Game Speed", self.speed, 0.5, 3.0);
-        ui.slider(21, "Volume", self.volume, 0.0, 1.0);
-
-        ui.separator(8.0);
-        ui.button(99, "Back");
-
-        ui.render(canvas);
+        ui.render(canvas, atlas);
 
         let mouse = engine.mouse_screen_pos();
         canvas.text_aligned(


### PR DESCRIPTION
Batch of ergonomics improvements identified in the API audit:

**Mouse Input**
- `mouse_position` tracking in all 4 event loops (CursorMoved + MouseInput)
- `engine.mouse_screen_pos()` on Engine and Engine3D
- `Camera2D::screen_to_world()` for converting screen coords to world space

**Canvas Primitives**
- `line()`, `polyline()`, `circle()` (outline), `circle_filled()`
- `text_spans()` and `text_spans_aligned()` for per-substring colored text

**UI Overhaul**
- Mouse hover/click support for all focusable widgets
- New widgets: Panel, ProgressBar, Checkbox, Slider
- Expanded `UiResponse` with `hovered`, `toggled`, `changed_values`
- Convenience methods: `was_activated()`, `was_toggled()`, `value_for()`

**Scene Transitions**
- `Transition` struct with `fade()`, `fade_color()`, `fade_white()`
- `SceneOp::FadePush`, `FadeSwitch`, `FadePop` variants
- State machine in `run_with_scenes`: fade out → apply at midpoint → fade in

**Timer / Event Queue**
- `Timer` with `once()` and `repeating()`, `tick(dt) -> bool`, `fraction()`
- `EventQueue<E>` generic delayed event scheduler

Updated feature-ui and feature-scenes samples. Updated ARCHITECTURE.md and ROADMAP.md.