### PR TITLE
Scroll regions with GPU scissor clipping

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,8 @@
     - [6.3 The canvas.wgsl Shader](#63-the-canvaswgsl-shader)
     - [6.4 The FPS Counter](#64-the-fps-counter)
     - [6.5 Text Layout (Measurement, Alignment, Wrapping)](#65-text-layout-measurement-alignment-wrapping)
-    - [6.6 Immediate-Mode Widget System (`ui.rs`)](#66-immediate-mode-widget-system-uirs)
+    - [6.6 Canvas Clipping](#66-canvas-clipping)
+    - [6.7 Immediate-Mode Widget System (`ui.rs`)](#67-immediate-mode-widget-system-uirs)
   - [7. Input System (`input/`)](#7-input-system-input)
     - [7.1 `InputState` — Keyboard State](#71-inputstate--keyboard-state)
     - [7.2 Mouse State](#72-mouse-state)
@@ -829,7 +830,16 @@ Built on top of the existing single-font `FontAtlas` and `Canvas` text renderer:
 - **`Canvas::text_block(x, y, text, size, color, max_width, align, atlas)`** — Word-wraps text to fit `max_width`, then draws each line with `text_aligned()`. Lines advance downward by `line_height`.
 - **`wrap_text(text, size, max_width, atlas) -> Vec<String>`** — Standalone word-wrapping function. Splits on spaces, respects explicit `\n` line breaks. Returns wrapped lines as a `Vec<String>`.
 
-### 6.6 Immediate-Mode Widget System ([`ui.rs`](https://github.com/justinwash/rengine/blob/master/engine/src/ui.rs))
+### 6.6 Canvas Clipping
+
+`Canvas` supports GPU scissor-rect clipping via a clip stack:
+
+- **`canvas.push_clip(x, y, w, h)`** — Push a clip rectangle in center-origin Y-up coordinates. All subsequent drawing is clipped to this rect (intersected with any parent clip). Internally closes the current draw segment and starts a new one with the scissor rect.
+- **`canvas.pop_clip()`** — Pop the most recent clip rectangle. Restores the previous clip (or no clip if the stack is empty).
+- **`DrawSegment`** — Internal struct tracking a contiguous range of vertices sharing the same scissor state. The render pass iterates segments and applies `set_scissor_rect()` per segment when any clip is active.
+- **`canvas.finalize()`** — Called before rendering to close the final open segment. When no clips are used, the render pass falls back to a single draw call.
+
+### 6.7 Immediate-Mode Widget System ([`ui.rs`](https://github.com/justinwash/rengine/blob/master/engine/src/ui.rs))
 
 A lightweight immediate-mode widget builder for menus, pause screens, and HUDs. Each frame you create a `Ui`, add widgets, call `update()` for input handling, and `render()` to draw.
 
@@ -844,13 +854,14 @@ A lightweight immediate-mode widget builder for menus, pause screens, and HUDs. 
 - **`Ui::progress_bar(label, value, color)`** — Horizontal progress bar (`value` in 0.0–1.0) with a text label.
 - **`Ui::checkbox(id, label, checked)`** — Togglable checkbox. Focusable; toggled on Enter/Space or mouse click.
 - **`Ui::slider(id, label, value, min, max)`** — Horizontal slider. Arrow keys adjust by 5% of range; mouse drag maps x position to value.
+- **`Ui::scroll(id, height, scroll_offset, children)`** — Scrollable container. The next `children` widgets are rendered inside a clipped region of the given `height`. Content is offset vertically by `scroll_offset` (0.0 = top). Mouse wheel scrolling updates the offset, returned via `UiResponse::scroll_for(id)`. Uses Canvas `push_clip`/`pop_clip` for GPU scissor-rect clipping. Focusable rects inside the region are clipped to the visible area.
 - **`Ui::separator(height)`** — Vertical gap between widgets.
 - **`Ui::update(input, mouse_pos) -> UiResponse`** — Process keyboard/gamepad/mouse input:
   - Arrow Up / W → focus previous; Arrow Down / S → focus next (wraps).
   - Enter / Space → activate focused button, toggle checkbox, or confirm slider.
   - Mouse hover sets focus; mouse click activates.
-  - Returns `UiResponse { focused, activated, hovered, toggled, changed_values }`.
-  - Convenience: `response.was_activated(id)`, `was_toggled(id)`, `value_for(id) -> Option<f32>`.
+  - Returns `UiResponse { focused, activated, hovered, toggled, changed_values, scroll_offsets }`.
+  - Convenience: `response.was_activated(id)`, `was_toggled(id)`, `value_for(id) -> Option<f32>`, `scroll_for(id) -> Option<f32>`.
 - **`Ui::render(canvas)`** — Draw all widgets into a `Canvas` layer.
 - **`UiStyle`** — Configurable struct with fields for text, button, panel, progress bar, checkbox, and slider colors/sizes/padding.
 
@@ -870,6 +881,7 @@ pub struct InputState {
     mouse_buttons: [bool; 3],          // Held: [Left, Right, Middle]
     mouse_buttons_pressed: [bool; 3],  // Pressed this frame
     mouse_buttons_released: [bool; 3], // Released this frame
+    scroll_delta: (f32, f32),          // Accumulated mouse wheel delta this frame
 }
 ```
 
@@ -884,7 +896,7 @@ pub struct InputState {
 - On `Pressed`: insert into `keys_down`. If it was newly inserted (not already held), also insert into `keys_pressed`.
 - On `Released`: remove from `keys_down`, insert into `keys_released`.
 
-[`end_frame()`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L107) clears `keys_pressed`, `keys_released`, `mouse_delta`, and `mouse_buttons_pressed/released`. This ensures "pressed" and "released" are one-frame events.
+[`end_frame()`](https://github.com/justinwash/rengine/blob/master/engine/src/input/keyboard.rs#L107) clears `keys_pressed`, `keys_released`, `mouse_delta`, `mouse_buttons_pressed/released`, and `scroll_delta`. This ensures "pressed" and "released" are one-frame events.
 
 ### 7.2 Mouse State
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,6 +74,7 @@ Recently completed or partially completed:
 - Completed: timer and event queue — `Timer` struct with `once()` and `repeating()` constructors, `tick(dt) -> bool`, `fraction()` progress; `EventQueue<E>` generic delayed event scheduler with `schedule(delay, event)` and `tick(dt) -> Vec<E>`
 - Completed: canvas ergonomics — `Canvas` now stores `screen_size` internally. `Canvas::new(screen_size)` constructor, `screen_size()` getter. All shape and text methods (`rect`, `line`, `polyline`, `circle`, `circle_filled`, `text`, `text_aligned`, `text_spans`, `text_spans_aligned`, `text_block`) no longer require a `screen_size` parameter. Text methods still require `&FontAtlas`. `Frame::begin(screen_size)` and `Frame3D::new(screen_size)` propagate screen size to canvases automatically. `draw_fps()` no longer takes `screen_size`. Public `screen_to_ndc(x, y, screen_size)` standalone function unchanged. All samples updated.
 - Completed: UI layout containers — `Row` and `Grid` container widgets. `row(children)` distributes N children equally across the available width. `row_spaced(spacing, children)` adds horizontal gaps. `grid(columns, children)` wraps children into rows of N columns. `grid_spaced(columns, spacing, children)` adds gaps. Both containers track per-row max height so mixed-height children align correctly. Generalized internal Container stack (replaces old panel-only stack) handles Panel, Row, and Grid uniformly in both hit-testing and rendering. Updated `feature-ui` sample with LayoutScene demonstrating all variants.
+- Completed: scroll regions — `Ui::scroll(id, height, scroll_offset, children)` creates a clipped scrollable container. Canvas `push_clip`/`pop_clip` for GPU scissor-rect clipping with segment-based render pass. `InputState::scroll_delta()` for mouse wheel input wired through all event loops. `UiResponse::scroll_for(id)` returns updated offsets. Focusable rects inside scroll regions are clipped to the visible area. Updated `feature-ui` sample with ScrollScene.
 
 ---
 
@@ -203,8 +204,11 @@ These features make 2D development substantially more practical.
 37. Nine-slice support [done]
     `NineSlice` struct with uniform/asymmetric borders, `frame.draw_nine_slice()`, color tinting, z-order, `feature-nineslice` sample.
 
-38. Masking and clipping
-    Essential for UI panels, scroll regions, and some gameplay effects.
+38. Masking and clipping [done]
+    Canvas `push_clip`/`pop_clip` for GPU scissor-rect clipping. Segment-based render pass splits draw calls at clip boundaries. Used by `ScrollRegion` UI widget.
+
+39. Scroll regions [done]
+    `Ui::scroll(id, height, scroll_offset, children)` creates a clipped, scrollable container. Mouse-wheel input via `InputState::scroll_delta()`. Updated offsets returned in `UiResponse::scroll_for(id)`. `feature-ui` sample demonstrates a scrollable button list.
 
 ---
 

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -684,7 +684,9 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                         );
                         frame.canvases.push(fps_canvas);
                     }
-                    engine.renderer.render_frame(&mut frame, &engine.postfx_chain);
+                    engine
+                        .renderer
+                        .render_frame(&mut frame, &engine.postfx_chain);
 
                     engine.input.end_frame();
                 }
@@ -937,7 +939,9 @@ where
                         );
                         frame.canvases.push(fps_canvas);
                     }
-                    engine.renderer.render_frame(&mut frame, &engine.postfx_chain);
+                    engine
+                        .renderer
+                        .render_frame(&mut frame, &engine.postfx_chain);
 
                     engine.input.end_frame();
                 }

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use serde::de::DeserializeOwned;
 use winit::dpi::LogicalSize;
-use winit::event::{DeviceEvent, Event, KeyEvent, MouseButton, WindowEvent};
+use winit::event::{DeviceEvent, Event, KeyEvent, MouseButton, MouseScrollDelta, WindowEvent};
 use winit::event_loop::EventLoop;
 use winit::keyboard::PhysicalKey;
 use winit::window::{CursorGrabMode, WindowBuilder};
@@ -645,6 +645,16 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                     engine.input.handle_mouse_button(idx, state);
                 }
 
+                WindowEvent::MouseWheel { delta, .. } => {
+                    let (dx, dy) = match delta {
+                        MouseScrollDelta::LineDelta(x, y) => (x, y),
+                        MouseScrollDelta::PixelDelta(pos) => {
+                            (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
+                        }
+                    };
+                    engine.input.handle_scroll(dx, dy);
+                }
+
                 WindowEvent::RedrawRequested => {
                     engine.time.tick();
                     engine.gamepads.update();
@@ -674,7 +684,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                         );
                         frame.canvases.push(fps_canvas);
                     }
-                    engine.renderer.render_frame(&frame, &engine.postfx_chain);
+                    engine.renderer.render_frame(&mut frame, &engine.postfx_chain);
 
                     engine.input.end_frame();
                 }
@@ -824,6 +834,16 @@ where
                     engine.input.handle_mouse_button(idx, state);
                 }
 
+                WindowEvent::MouseWheel { delta, .. } => {
+                    let (dx, dy) = match delta {
+                        MouseScrollDelta::LineDelta(x, y) => (x, y),
+                        MouseScrollDelta::PixelDelta(pos) => {
+                            (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
+                        }
+                    };
+                    engine.input.handle_scroll(dx, dy);
+                }
+
                 WindowEvent::RedrawRequested => {
                     engine.time.tick();
                     engine.gamepads.update();
@@ -917,7 +937,7 @@ where
                         );
                         frame.canvases.push(fps_canvas);
                     }
-                    engine.renderer.render_frame(&frame, &engine.postfx_chain);
+                    engine.renderer.render_frame(&mut frame, &engine.postfx_chain);
 
                     engine.input.end_frame();
                 }
@@ -1505,6 +1525,16 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                     engine.input.handle_mouse_button(idx, state);
                 }
 
+                WindowEvent::MouseWheel { delta, .. } => {
+                    let (dx, dy) = match delta {
+                        MouseScrollDelta::LineDelta(x, y) => (x, y),
+                        MouseScrollDelta::PixelDelta(pos) => {
+                            (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
+                        }
+                    };
+                    engine.input.handle_scroll(dx, dy);
+                }
+
                 WindowEvent::CursorMoved { position, .. } => {
                     let x = position.x as f32 - engine.window_width as f32 / 2.0;
                     let y = -(position.y as f32 - engine.window_height as f32 / 2.0);
@@ -1539,7 +1569,7 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                         );
                         frame.canvases.push(fps_canvas);
                     }
-                    engine.renderer.render_frame(&frame);
+                    engine.renderer.render_frame(&mut frame);
 
                     engine.input.end_frame();
                 }
@@ -1736,6 +1766,16 @@ where
                     engine.input.handle_mouse_button(idx, state);
                 }
 
+                WindowEvent::MouseWheel { delta, .. } => {
+                    let (dx, dy) = match delta {
+                        MouseScrollDelta::LineDelta(x, y) => (x, y),
+                        MouseScrollDelta::PixelDelta(pos) => {
+                            (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
+                        }
+                    };
+                    engine.input.handle_scroll(dx, dy);
+                }
+
                 WindowEvent::CursorMoved { position, .. } => {
                     let x = position.x as f32 - engine.window_width as f32 / 2.0;
                     let y = -(position.y as f32 - engine.window_height as f32 / 2.0);
@@ -1783,7 +1823,7 @@ where
                         );
                         frame.canvases.push(fps_canvas);
                     }
-                    engine.renderer.render_frame(&frame);
+                    engine.renderer.render_frame(&mut frame);
 
                     engine.input.end_frame();
                 }

--- a/engine/src/canvas/mod.rs
+++ b/engine/src/canvas/mod.rs
@@ -46,21 +46,83 @@ pub const MAX_CANVAS_VERTICES: usize = 8_000;
 
 const WHITE_UV: [f32; 2] = [1.0 / ATLAS_SIZE as f32, 1.0 / ATLAS_SIZE as f32];
 
+pub(crate) struct DrawSegment {
+    pub start: usize,
+    pub count: usize,
+    pub scissor: Option<[u32; 4]>,
+}
+
 pub struct Canvas {
     pub(crate) verts: Vec<CanvasVertex>,
+    pub(crate) segments: Vec<DrawSegment>,
     screen_size: (u32, u32),
+    clip_stack: Vec<[u32; 4]>,
+    segment_start: usize,
 }
 
 impl Canvas {
     pub fn new(screen_size: (u32, u32)) -> Self {
         Self {
             verts: Vec::new(),
+            segments: Vec::new(),
             screen_size,
+            clip_stack: Vec::new(),
+            segment_start: 0,
         }
     }
 
     pub fn screen_size(&self) -> (u32, u32) {
         self.screen_size
+    }
+
+    pub fn push_clip(&mut self, x: f32, y: f32, w: f32, h: f32) {
+        self.close_segment();
+
+        let (sw, sh) = self.screen_size;
+        let hw = sw as f32 / 2.0;
+        let hh = sh as f32 / 2.0;
+
+        let px = ((x + hw).max(0.0)) as u32;
+        let py = ((hh - y - h).max(0.0)) as u32;
+        let pw = (w as u32).min(sw.saturating_sub(px));
+        let ph = (h as u32).min(sh.saturating_sub(py));
+
+        let mut rect = [px, py, pw, ph];
+
+        if let Some(parent) = self.clip_stack.last() {
+            let l = rect[0].max(parent[0]);
+            let t = rect[1].max(parent[1]);
+            let r = (rect[0] + rect[2]).min(parent[0] + parent[2]);
+            let b = (rect[1] + rect[3]).min(parent[1] + parent[3]);
+            if l >= r || t >= b {
+                rect = [0, 0, 0, 0];
+            } else {
+                rect = [l, t, r - l, b - t];
+            }
+        }
+
+        self.clip_stack.push(rect);
+    }
+
+    pub fn pop_clip(&mut self) {
+        self.close_segment();
+        self.clip_stack.pop();
+    }
+
+    fn close_segment(&mut self) {
+        let count = self.verts.len() - self.segment_start;
+        if count > 0 {
+            self.segments.push(DrawSegment {
+                start: self.segment_start,
+                count,
+                scissor: self.clip_stack.last().copied(),
+            });
+        }
+        self.segment_start = self.verts.len();
+    }
+
+    pub(crate) fn finalize(&mut self) {
+        self.close_segment();
     }
 
     pub fn shape(&mut self, triangles: &[CanvasVertex]) {
@@ -530,9 +592,13 @@ pub(crate) fn render_pass(
     pipeline: &wgpu::RenderPipeline,
     vertex_buffer: &wgpu::Buffer,
     queue: &wgpu::Queue,
-    canvases: &[Canvas],
+    canvases: &mut [Canvas],
     font_atlas: &FontAtlas,
 ) {
+    for canvas in canvases.iter_mut() {
+        canvas.finalize();
+    }
+
     let verts: Vec<CanvasVertex> = canvases
         .iter()
         .flat_map(|c| c.verts.iter().copied())
@@ -541,6 +607,21 @@ pub(crate) fn render_pass(
         return;
     }
     queue.write_buffer(vertex_buffer, 0, bytemuck::cast_slice(&verts));
+
+    let mut global_segments: Vec<(usize, usize, Option<[u32; 4]>)> = Vec::new();
+    let mut offset = 0usize;
+    for canvas in canvases.iter() {
+        if canvas.segments.is_empty() {
+            if !canvas.verts.is_empty() {
+                global_segments.push((offset, canvas.verts.len(), None));
+            }
+        } else {
+            for seg in &canvas.segments {
+                global_segments.push((offset + seg.start, seg.count, seg.scissor));
+            }
+        }
+        offset += canvas.verts.len();
+    }
 
     let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
         label: Some("canvas_pass"),
@@ -561,5 +642,25 @@ pub(crate) fn render_pass(
     pass.set_pipeline(pipeline);
     pass.set_bind_group(0, &font_atlas.bind_group, &[]);
     pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-    pass.draw(0..verts.len() as u32, 0..1);
+
+    let has_scissors = global_segments.iter().any(|(_, _, s)| s.is_some());
+
+    if has_scissors {
+        let surface_w = canvases.first().map(|c| c.screen_size.0).unwrap_or(1);
+        let surface_h = canvases.first().map(|c| c.screen_size.1).unwrap_or(1);
+
+        for (start, count, scissor) in &global_segments {
+            if *count == 0 {
+                continue;
+            }
+            if let Some([sx, sy, sw, sh]) = scissor {
+                pass.set_scissor_rect(*sx, *sy, (*sw).max(1), (*sh).max(1));
+            } else {
+                pass.set_scissor_rect(0, 0, surface_w, surface_h);
+            }
+            pass.draw(*start as u32..(*start + *count) as u32, 0..1);
+        }
+    } else {
+        pass.draw(0..verts.len() as u32, 0..1);
+    }
 }

--- a/engine/src/canvas/mod.rs
+++ b/engine/src/canvas/mod.rs
@@ -654,7 +654,10 @@ pub(crate) fn render_pass(
                 continue;
             }
             if let Some([sx, sy, sw, sh]) = scissor {
-                pass.set_scissor_rect(*sx, *sy, (*sw).max(1), (*sh).max(1));
+                if *sw == 0 || *sh == 0 {
+                    continue;
+                }
+                pass.set_scissor_rect(*sx, *sy, *sw, *sh);
             } else {
                 pass.set_scissor_rect(0, 0, surface_w, surface_h);
             }

--- a/engine/src/input/keyboard.rs
+++ b/engine/src/input/keyboard.rs
@@ -11,6 +11,7 @@ pub struct InputState {
     mouse_buttons: [bool; 3],
     mouse_buttons_pressed: [bool; 3],
     mouse_buttons_released: [bool; 3],
+    scroll_delta: (f32, f32),
 }
 
 impl InputState {
@@ -24,6 +25,7 @@ impl InputState {
             mouse_buttons: [false; 3],
             mouse_buttons_pressed: [false; 3],
             mouse_buttons_released: [false; 3],
+            scroll_delta: (0.0, 0.0),
         }
     }
 
@@ -63,6 +65,10 @@ impl InputState {
             .get(button)
             .copied()
             .unwrap_or(false)
+    }
+
+    pub fn scroll_delta(&self) -> (f32, f32) {
+        self.scroll_delta
     }
 
     pub(crate) fn handle_key_event(&mut self, key: KeyCode, state: ElementState) {
@@ -105,11 +111,17 @@ impl InputState {
         }
     }
 
+    pub(crate) fn handle_scroll(&mut self, dx: f32, dy: f32) {
+        self.scroll_delta.0 += dx;
+        self.scroll_delta.1 += dy;
+    }
+
     pub(crate) fn end_frame(&mut self) {
         self.keys_pressed.clear();
         self.keys_released.clear();
         self.mouse_delta = (0.0, 0.0);
         self.mouse_buttons_pressed = [false; 3];
         self.mouse_buttons_released = [false; 3];
+        self.scroll_delta = (0.0, 0.0);
     }
 }

--- a/engine/src/renderer/mod.rs
+++ b/engine/src/renderer/mod.rs
@@ -486,7 +486,7 @@ impl Renderer {
         }
     }
 
-    pub fn render_frame(&mut self, frame: &Frame, postfx_chain: &PostFxChain) {
+    pub fn render_frame(&mut self, frame: &mut Frame, postfx_chain: &PostFxChain) {
         let output = match self.surface.get_current_texture() {
             Ok(t) => t,
             Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
@@ -710,7 +710,7 @@ impl Renderer {
             &self.canvas_pipeline,
             &self.canvas_vb,
             &self.queue,
-            &frame.canvases,
+            &mut frame.canvases,
             &self.font_atlas,
         );
 

--- a/engine/src/renderer3d/mod.rs
+++ b/engine/src/renderer3d/mod.rs
@@ -411,7 +411,7 @@ impl Renderer3D {
         }
     }
 
-    pub fn render_frame(&mut self, frame: &Frame3D) {
+    pub fn render_frame(&mut self, frame: &mut Frame3D) {
         let output = match self.surface.get_current_texture() {
             Ok(t) => t,
             Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
@@ -607,7 +607,7 @@ impl Renderer3D {
             &self.canvas_pipeline,
             &self.canvas_vb,
             &self.queue,
-            &frame.canvases,
+            &mut frame.canvases,
             &self.font_atlas,
         );
 

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -581,11 +581,15 @@ impl Ui {
                         current_width = cont.saved_width;
                         let clip_top = cont.scroll_clip_top;
                         let clip_bot = cont.scroll_clip_bottom;
-                        rects.retain(|(_, _, ry, _, rh)| {
-                            let top = *ry + *rh;
-                            let bot = *ry;
-                            top > clip_bot && bot < clip_top
-                        });
+                        let start = cont.col_index;
+                        for r in &mut rects[start..] {
+                            let top = r.2 + r.4;
+                            let bot = r.2;
+                            if top <= clip_bot || bot >= clip_top {
+                                r.3 = 0.0;
+                                r.4 = 0.0;
+                            }
+                        }
                         cursor_y -= self.style.spacing;
                     }
                     _ => {
@@ -612,6 +616,7 @@ impl Ui {
                         stack.push(cont);
                     }
                     3 => {
+                        cont.col_index = rects.len();
                         stack.push(cont);
                     }
                     _ => {
@@ -792,6 +797,13 @@ impl Ui {
                     }
                     other => {
                         sy -= self.compute_widget_height(other, &self.widgets[si + 1..], atlas);
+                        let skip = match other {
+                            Widget::Panel { children, .. }
+                            | Widget::Row { children, .. }
+                            | Widget::Grid { children, .. } => *children,
+                            _ => 0,
+                        };
+                        si += skip;
                     }
                 }
                 si += 1;
@@ -1189,7 +1201,7 @@ impl Ui {
                         col_count: 0,
                         col_width: 0.0,
                         col_spacing: 0.0,
-                        row_start_y: 0.0,
+                        row_start_y: cursor_y,
                         row_max_h: 0.0,
                         scroll_height: *height,
                     });
@@ -1269,7 +1281,6 @@ impl Ui {
                         stack.push(cont);
                     }
                     3 => {
-                        cont.row_start_y = cursor_y;
                         stack.push(cont);
                     }
                     _ => {

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -343,9 +343,7 @@ impl Ui {
                 }
                 h
             }
-            Widget::Row {
-                children, ..
-            } => {
+            Widget::Row { children, .. } => {
                 let n = (*children).min(remaining.len());
                 let child_slice = &remaining[..n];
                 let mut max_h: f32 = 0.0;
@@ -359,9 +357,7 @@ impl Ui {
                 max_h + self.style.spacing
             }
             Widget::Grid {
-                columns,
-                children,
-                ..
+                columns, children, ..
             } => {
                 let n = (*children).min(remaining.len());
                 let child_slice = &remaining[..n];
@@ -381,9 +377,7 @@ impl Ui {
                 }
                 total_h + self.style.spacing
             }
-            Widget::ScrollRegion { height, .. } => {
-                *height + self.style.spacing
-            }
+            Widget::ScrollRegion { height, .. } => *height + self.style.spacing,
         }
     }
 
@@ -784,14 +778,12 @@ impl Ui {
                             let child_slice = &self.widgets[si + 1..si + 1 + n];
                             let mut content_h: f32 = 0.0;
                             for (ci, cw) in child_slice.iter().enumerate() {
-                                content_h += self.compute_widget_height(
-                                    cw,
-                                    &child_slice[ci + 1..],
-                                    atlas,
-                                );
+                                content_h +=
+                                    self.compute_widget_height(cw, &child_slice[ci + 1..], atlas);
                             }
                             let max_scroll = (content_h - *height).max(0.0);
-                            let new_offset = (*scroll_offset - scroll_dy * 30.0).clamp(0.0, max_scroll);
+                            let new_offset =
+                                (*scroll_offset - scroll_dy * 30.0).clamp(0.0, max_scroll);
                             scroll_offsets.push((*id, new_offset));
                         }
                         sy -= *height + self.style.spacing;
@@ -799,11 +791,7 @@ impl Ui {
                         continue;
                     }
                     other => {
-                        sy -= self.compute_widget_height(
-                            other,
-                            &self.widgets[si + 1..],
-                            atlas,
-                        );
+                        sy -= self.compute_widget_height(other, &self.widgets[si + 1..], atlas);
                     }
                 }
                 si += 1;

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -102,6 +102,12 @@ enum Widget {
         min: f32,
         max: f32,
     },
+    ScrollRegion {
+        id: usize,
+        height: f32,
+        scroll_offset: f32,
+        children: usize,
+    },
 }
 
 pub struct UiResponse {
@@ -111,6 +117,7 @@ pub struct UiResponse {
     pub toggled: Vec<usize>,
     pub changed_values: Vec<(usize, f32)>,
     pub dragging: Option<usize>,
+    pub scroll_offsets: Vec<(usize, f32)>,
 }
 
 impl UiResponse {
@@ -126,6 +133,13 @@ impl UiResponse {
         self.changed_values
             .iter()
             .find(|(cid, _)| *cid == id)
+            .map(|(_, v)| *v)
+    }
+
+    pub fn scroll_for(&self, id: usize) -> Option<f32> {
+        self.scroll_offsets
+            .iter()
+            .find(|(sid, _)| *sid == id)
             .map(|(_, v)| *v)
     }
 }
@@ -252,8 +266,6 @@ impl Ui {
         });
     }
 
-    /// Lay out the next `children` widgets horizontally in a single row.
-    /// Each child gets an equal share of the current width.
     pub fn row(&mut self, children: usize) {
         self.widgets.push(Widget::Row {
             spacing: self.style.spacing,
@@ -261,13 +273,10 @@ impl Ui {
         });
     }
 
-    /// Lay out the next `children` widgets horizontally with custom inter-column spacing.
     pub fn row_spaced(&mut self, spacing: f32, children: usize) {
         self.widgets.push(Widget::Row { spacing, children });
     }
 
-    /// Lay out the next `children` widgets in a grid with the given number of columns.
-    /// Rows wrap automatically. Each cell gets an equal share of the current width.
     pub fn grid(&mut self, columns: usize, children: usize) {
         self.widgets.push(Widget::Grid {
             columns: columns.max(1),
@@ -276,11 +285,19 @@ impl Ui {
         });
     }
 
-    /// Lay out the next `children` widgets in a grid with custom inter-cell spacing.
     pub fn grid_spaced(&mut self, columns: usize, spacing: f32, children: usize) {
         self.widgets.push(Widget::Grid {
             columns: columns.max(1),
             spacing,
+            children,
+        });
+    }
+
+    pub fn scroll(&mut self, id: usize, height: f32, scroll_offset: f32, children: usize) {
+        self.widgets.push(Widget::ScrollRegion {
+            id,
+            height,
+            scroll_offset,
             children,
         });
     }
@@ -364,6 +381,9 @@ impl Ui {
                 }
                 total_h + self.style.spacing
             }
+            Widget::ScrollRegion { height, .. } => {
+                *height + self.style.spacing
+            }
         }
     }
 
@@ -373,22 +393,20 @@ impl Ui {
         let mut base_x = self.x;
         let mut current_width = self.width;
 
-        // Container stack: each entry stores the saved layout state and remaining child count.
-        // kind: 0=panel, 1=row, 2=grid
         struct Container {
             kind: u8,
             saved_x: f32,
             saved_width: f32,
             remaining: usize,
-            // Panel fields
             padding: f32,
-            // Row/Grid fields
             col_index: usize,
             col_count: usize,
             col_width: f32,
             col_spacing: f32,
             row_start_y: f32,
             row_max_h: f32,
+            scroll_clip_top: f32,
+            scroll_clip_bottom: f32,
         }
         let mut stack: Vec<Container> = Vec::new();
 
@@ -426,6 +444,8 @@ impl Ui {
                         col_spacing: 0.0,
                         row_start_y: 0.0,
                         row_max_h: 0.0,
+                        scroll_clip_top: 0.0,
+                        scroll_clip_bottom: 0.0,
                     });
                 }
                 Widget::Row { spacing, children } => {
@@ -444,6 +464,8 @@ impl Ui {
                         col_spacing: *spacing,
                         row_start_y: cursor_y,
                         row_max_h: 0.0,
+                        scroll_clip_top: 0.0,
+                        scroll_clip_bottom: 0.0,
                     });
                 }
                 Widget::Grid {
@@ -466,6 +488,8 @@ impl Ui {
                         col_spacing: *spacing,
                         row_start_y: cursor_y,
                         row_max_h: 0.0,
+                        scroll_clip_top: 0.0,
+                        scroll_clip_bottom: 0.0,
                     });
                 }
                 Widget::ProgressBar { .. } => {
@@ -487,16 +511,39 @@ impl Ui {
                     rects.push((*id, base_x, cursor_y - h, current_width, h));
                     cursor_y -= h + self.style.spacing;
                 }
+                Widget::ScrollRegion {
+                    id: _,
+                    height,
+                    scroll_offset,
+                    children,
+                } => {
+                    let clip_top = cursor_y;
+                    let clip_bottom = cursor_y - *height;
+                    pending = Some(Container {
+                        kind: 3,
+                        saved_x: base_x,
+                        saved_width: current_width,
+                        remaining: *children,
+                        padding: 0.0,
+                        col_index: 0,
+                        col_count: 0,
+                        col_width: 0.0,
+                        col_spacing: 0.0,
+                        row_start_y: 0.0,
+                        row_max_h: 0.0,
+                        scroll_clip_top: clip_top,
+                        scroll_clip_bottom: clip_bottom,
+                    });
+                    cursor_y += *scroll_offset;
+                }
             }
 
-            // Decrement container child counters and pop finished containers
             let mut pop_idx = None;
             for (si, cont) in stack.iter_mut().enumerate().rev() {
                 if cont.remaining > 0 {
                     cont.remaining -= 1;
 
-                    // For Row/Grid, track column position
-                    if cont.kind >= 1 {
+                    if cont.kind == 1 || cont.kind == 2 {
                         let used_h = cont.row_start_y - cursor_y;
                         if used_h > cont.row_max_h {
                             cont.row_max_h = used_h;
@@ -507,7 +554,6 @@ impl Ui {
                         let last_child = cont.remaining == 0;
 
                         if end_of_row || last_child {
-                            // Finish this row: advance cursor_y by the tallest child
                             cursor_y = cont.row_start_y - cont.row_max_h;
                             cont.row_max_h = 0.0;
                             cont.col_index = 0;
@@ -515,7 +561,6 @@ impl Ui {
                             base_x = cont.saved_x;
                             current_width = cont.col_width;
                         } else {
-                            // Move to next column
                             cursor_y = cont.row_start_y;
                             base_x += cont.col_width + cont.col_spacing;
                         }
@@ -531,14 +576,25 @@ impl Ui {
                 let cont = stack.remove(si);
                 match cont.kind {
                     0 => {
-                        // Panel: restore and add bottom padding
                         cursor_y -= cont.padding;
                         base_x = cont.saved_x;
                         current_width = cont.saved_width;
                         cursor_y -= self.style.spacing;
                     }
+                    3 => {
+                        cursor_y = cont.scroll_clip_bottom;
+                        base_x = cont.saved_x;
+                        current_width = cont.saved_width;
+                        let clip_top = cont.scroll_clip_top;
+                        let clip_bot = cont.scroll_clip_bottom;
+                        rects.retain(|(_, _, ry, _, rh)| {
+                            let top = *ry + *rh;
+                            let bot = *ry;
+                            top > clip_bot && bot < clip_top
+                        });
+                        cursor_y -= self.style.spacing;
+                    }
                     _ => {
-                        // Row/Grid: restore saved layout
                         base_x = cont.saved_x;
                         current_width = cont.saved_width;
                         cursor_y -= self.style.spacing;
@@ -549,11 +605,9 @@ impl Ui {
             if let Some(mut cont) = pending {
                 match cont.kind {
                     0 => {
-                        // Panel: push padding
                         cursor_y -= cont.padding;
                         cont.saved_x = base_x;
                         cont.saved_width = current_width;
-                        // base_x already set in the Container init above, but we need to offset
                         let pad = cont.padding;
                         let old_x = base_x;
                         let old_w = current_width;
@@ -563,8 +617,10 @@ impl Ui {
                         cont.saved_width = old_w;
                         stack.push(cont);
                     }
+                    3 => {
+                        stack.push(cont);
+                    }
                     _ => {
-                        // Row/Grid: set up first column
                         cont.row_start_y = cursor_y;
                         base_x = cont.saved_x;
                         current_width = cont.col_width;
@@ -591,6 +647,7 @@ impl Ui {
                 toggled,
                 changed_values,
                 dragging: None,
+                scroll_offsets: Vec::new(),
             };
         }
 
@@ -703,6 +760,57 @@ impl Ui {
             }
         }
 
+        let mut scroll_offsets = Vec::new();
+        let (scroll_dx, scroll_dy) = input.scroll_delta();
+        if scroll_dy.abs() > 0.0 {
+            let mut sy = self.y;
+            let mut si = 0;
+            while si < self.widgets.len() {
+                match &self.widgets[si] {
+                    Widget::ScrollRegion {
+                        id,
+                        height,
+                        scroll_offset,
+                        children,
+                    } => {
+                        let region_top = sy;
+                        let region_bottom = sy - *height;
+                        if mx >= self.x
+                            && mx <= self.x + self.width
+                            && my <= region_top
+                            && my >= region_bottom
+                        {
+                            let n = (*children).min(self.widgets.len() - si - 1);
+                            let child_slice = &self.widgets[si + 1..si + 1 + n];
+                            let mut content_h: f32 = 0.0;
+                            for (ci, cw) in child_slice.iter().enumerate() {
+                                content_h += self.compute_widget_height(
+                                    cw,
+                                    &child_slice[ci + 1..],
+                                    atlas,
+                                );
+                            }
+                            let max_scroll = (content_h - *height).max(0.0);
+                            let new_offset = (*scroll_offset - scroll_dy * 30.0).clamp(0.0, max_scroll);
+                            scroll_offsets.push((*id, new_offset));
+                        }
+                        sy -= *height + self.style.spacing;
+                        si += 1 + *children;
+                        continue;
+                    }
+                    other => {
+                        sy -= self.compute_widget_height(
+                            other,
+                            &self.widgets[si + 1..],
+                            atlas,
+                        );
+                    }
+                }
+                si += 1;
+            }
+            let _ = scroll_dx;
+        }
+
         UiResponse {
             focused: Some(self.focus_index),
             activated: self.activated,
@@ -710,6 +818,7 @@ impl Ui {
             toggled,
             changed_values,
             dragging: self.dragging_slider,
+            scroll_offsets,
         }
     }
 
@@ -736,6 +845,7 @@ impl Ui {
             col_spacing: f32,
             row_start_y: f32,
             row_max_h: f32,
+            scroll_height: f32,
         }
         let mut stack: Vec<RenderContainer> = Vec::new();
 
@@ -837,6 +947,7 @@ impl Ui {
                         col_spacing: 0.0,
                         row_start_y: 0.0,
                         row_max_h: 0.0,
+                        scroll_height: 0.0,
                     });
                 }
                 Widget::Row { spacing, children } => {
@@ -855,6 +966,7 @@ impl Ui {
                         col_spacing: *spacing,
                         row_start_y: cursor_y,
                         row_max_h: 0.0,
+                        scroll_height: 0.0,
                     });
                 }
                 Widget::Grid {
@@ -877,6 +989,7 @@ impl Ui {
                         col_spacing: *spacing,
                         row_start_y: cursor_y,
                         row_max_h: 0.0,
+                        scroll_height: 0.0,
                     });
                 }
                 Widget::ProgressBar {
@@ -1071,15 +1184,37 @@ impl Ui {
 
                     cursor_y -= bar_h + self.style.spacing;
                 }
+                Widget::ScrollRegion {
+                    height,
+                    scroll_offset,
+                    children,
+                    ..
+                } => {
+                    canvas.push_clip(base_x, cursor_y - *height, current_width, *height);
+                    pending = Some(RenderContainer {
+                        kind: 3,
+                        saved_x: base_x,
+                        saved_width: current_width,
+                        remaining: *children,
+                        padding: 0.0,
+                        col_index: 0,
+                        col_count: 0,
+                        col_width: 0.0,
+                        col_spacing: 0.0,
+                        row_start_y: 0.0,
+                        row_max_h: 0.0,
+                        scroll_height: *height,
+                    });
+                    cursor_y += *scroll_offset;
+                }
             }
 
-            // Decrement container child counters and pop finished containers
             let mut pop_idx = None;
             for (si, cont) in stack.iter_mut().enumerate().rev() {
                 if cont.remaining > 0 {
                     cont.remaining -= 1;
 
-                    if cont.kind >= 1 {
+                    if cont.kind == 1 || cont.kind == 2 {
                         let used_h = cont.row_start_y - cursor_y;
                         if used_h > cont.row_max_h {
                             cont.row_max_h = used_h;
@@ -1117,6 +1252,13 @@ impl Ui {
                         current_width = cont.saved_width;
                         cursor_y -= self.style.spacing;
                     }
+                    3 => {
+                        canvas.pop_clip();
+                        cursor_y = cont.row_start_y - cont.scroll_height;
+                        base_x = cont.saved_x;
+                        current_width = cont.saved_width;
+                        cursor_y -= self.style.spacing;
+                    }
                     _ => {
                         base_x = cont.saved_x;
                         current_width = cont.saved_width;
@@ -1136,6 +1278,10 @@ impl Ui {
                         current_width -= pad * 2.0;
                         cont.saved_x = old_x;
                         cont.saved_width = old_w;
+                        stack.push(cont);
+                    }
+                    3 => {
+                        cont.row_start_y = cursor_y;
                         stack.push(cont);
                     }
                     _ => {

--- a/samples/features/feature-ui/src/main.rs
+++ b/samples/features/feature-ui/src/main.rs
@@ -13,6 +13,7 @@ impl MenuScene {
         ui.button(1, "Options");
         ui.button(2, "Widget Demo");
         ui.button(3, "Layout Demo");
+        ui.button(5, "Scroll Demo");
         ui.button(4, "Quit");
     }
 }
@@ -45,6 +46,9 @@ impl Scene for MenuScene {
                 }
                 3 => {
                     return SceneOp::Push(Box::new(LayoutScene::new()));
+                }
+                5 => {
+                    return SceneOp::Push(Box::new(ScrollScene::new()));
                 }
                 4 => return SceneOp::Quit,
                 _ => {}
@@ -399,6 +403,93 @@ impl Scene for LayoutScene {
             0.0,
             -hh + 12.0,
             "ESC: back | Arrows: navigate | Enter: select",
+            10.0,
+            Color::from_rgba8(140, 140, 140, 255),
+            TextAlign::Center,
+            atlas,
+        );
+    }
+}
+
+struct ScrollScene {
+    focus: usize,
+    scroll_offset: f32,
+}
+
+impl ScrollScene {
+    fn new() -> Self {
+        Self {
+            focus: 0,
+            scroll_offset: 0.0,
+        }
+    }
+
+    fn build_widgets(&self, ui: &mut Ui) {
+        ui.label_centered("Scroll Demo", 24.0, Color::WHITE);
+        ui.separator(8.0);
+
+        ui.label("Scrollable list:", 14.0, Color::from_rgba8(180, 200, 255, 255));
+        ui.scroll(100, 150.0, self.scroll_offset, 10);
+        ui.button(10, "Item 1");
+        ui.button(11, "Item 2");
+        ui.button(12, "Item 3");
+        ui.button(13, "Item 4");
+        ui.button(14, "Item 5");
+        ui.button(15, "Item 6");
+        ui.button(16, "Item 7");
+        ui.button(17, "Item 8");
+        ui.button(18, "Item 9");
+        ui.button(19, "Item 10");
+
+        ui.separator(10.0);
+        ui.button(99, "Back");
+    }
+}
+
+impl Scene for ScrollScene {
+    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
+
+    fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
+        let (sw, sh) = engine.window_size();
+        let atlas = engine.font_atlas();
+        let hh = sh as f32 / 2.0;
+
+        let mut ui = Ui::new(-200.0, hh - 30.0, 400.0, (sw, sh)).with_focus(self.focus);
+        self.build_widgets(&mut ui);
+
+        let response = ui.update(engine.input(), atlas);
+        if let Some(f) = response.focused {
+            self.focus = f;
+        }
+
+        if let Some(offset) = response.scroll_for(100) {
+            self.scroll_offset = offset;
+        }
+
+        if response.was_activated(99) || engine.input().is_key_pressed(KeyCode::Escape) {
+            return SceneOp::Pop;
+        }
+
+        SceneOp::Continue
+    }
+
+    fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
+        let (sw, sh) = engine.window_size();
+        let hh = sh as f32 / 2.0;
+        let atlas = engine.font_atlas();
+        frame.clear_color = Color::from_rgba8(25, 20, 35, 255);
+
+        let canvas = frame.canvas(0);
+
+        let mut ui = Ui::new(-200.0, hh - 30.0, 400.0, (sw, sh)).with_focus(self.focus);
+        self.build_widgets(&mut ui);
+
+        ui.render(canvas, atlas);
+
+        canvas.text_aligned(
+            0.0,
+            -hh + 12.0,
+            "ESC: back | Mouse wheel: scroll | Arrows: navigate",
             10.0,
             Color::from_rgba8(140, 140, 140, 255),
             TextAlign::Center,


### PR DESCRIPTION
Adds scrollable UI containers with GPU-level scissor clipping.

**Canvas clipping**
- `push_clip(x, y, w, h)` / `pop_clip()` for scissor-rect clipping
- Segment-based render pass splits draw calls at clip boundaries
- `DrawSegment` tracks vertex ranges with optional scissor rects
- Fast path (single draw call) when no clips are used

**Mouse wheel input**
- `InputState::scroll_delta()` accumulates mouse wheel events per frame
- `handle_scroll(dx, dy)` wired into all 4 event loops (2D game, 2D scene, 3D game, 3D scene)
- `MouseWheel` with `LineDelta` and `PixelDelta` (normalized by /40) support

**ScrollRegion UI widget**
- `Ui::scroll(id, height, scroll_offset, children)` creates a clipped scrollable container
- Content is offset vertically by `scroll_offset`, clipped to the visible `height`
- Mouse wheel scrolling when cursor is within the scroll region bounds
- `UiResponse::scroll_for(id) -> Option<f32>` returns updated offsets
- Focusable rects inside scroll regions are clipped to the visible area
- Scroll region acts as a container in both hit-testing and rendering

**Sample**
- `ScrollScene` added to `feature-ui` sample with a scrollable list of 10 buttons