### PR TITLE
UI single-build pattern

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -841,11 +841,31 @@ Built on top of the existing single-font `FontAtlas` and `Canvas` text renderer:
 
 ### 6.7 Immediate-Mode Widget System ([`ui.rs`](https://github.com/justinwash/rengine/blob/master/engine/src/ui.rs))
 
-A lightweight immediate-mode widget builder for menus, pause screens, and HUDs. Each frame you create a `Ui`, add widgets, call `update()` for input handling, and `render()` to draw.
+A lightweight immediate-mode widget builder for menus, pause screens, and HUDs.
 
-- **`Ui::new(x, y, width, screen_size)`** — Create a new UI context anchored at `(x, y)` with the given column width.
+**Single-build pattern:** Store a `Ui` as a field on your scene struct (implements `Default`). Each frame, call `begin()` to reset widgets, add widgets, then call `update()` in `update()` and `render()` in `render()`. Focus and slider-drag state persist automatically across frames — no manual tracking needed.
+
+```rust
+struct MyScene { ui: Ui }
+
+impl Scene for MyScene {
+    fn update(&mut self, engine: &Engine, ..) -> SceneOp {
+        self.ui.begin(x, y, width);   // clears widgets, keeps focus/drag state
+        self.ui.button(0, "Play");
+        let resp = self.ui.update(engine.input(), atlas);
+        ..
+    }
+    fn render(&self, ..) {
+        self.ui.render(canvas, atlas); // just draws the last-built widget list
+    }
+}
+```
+
+- **`Ui::default()`** — Create a default UI context (position 0,0, width 200).
+- **`Ui::new(x, y, width, screen_size)`** — Create a UI context with explicit position and width. Prefer `Default` + `begin()`.
+- **`Ui::begin(x, y, width)`** — Reset widgets and position for the current frame. Preserves `style`, `focus_index`, and `dragging_slider` state.
 - **`Ui::with_style(style) -> Self`** — Apply a custom `UiStyle` (colors, sizes, padding).
-- **`Ui::with_focus(index) -> Self`** — Set the initially focused button index.
+- **`Ui::with_focus(index) -> Self`** — Override the focused button index.
 - **`Ui::label(text, size, color)`** / **`label_centered(text, size, color)`** — Static text (left-aligned or centered).
 - **`Ui::button(id, text)`** — Interactive button identified by a numeric `id`.
 - **`Ui::panel(color, padding, children)`** — Background panel that wraps the next `children` widgets with a colored rect and inward padding.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -843,12 +843,16 @@ Built on top of the existing single-font `FontAtlas` and `Canvas` text renderer:
 
 A lightweight immediate-mode widget builder for menus, pause screens, and HUDs.
 
-**Single-build pattern:** Store a `Ui` as a field on your scene struct (implements `Default`). Each frame, call `begin()` to reset widgets, add widgets, then call `update()` in `update()` and `render()` in `render()`. Focus and slider-drag state persist automatically across frames — no manual tracking needed.
+**Single-build pattern:** Store a `Ui` as a field on your scene struct (implements `Default`). Each frame, call `begin()` to reset widgets, add widgets, then call `update()` in `update()` and `render()` in `render()`. Focus and slider-drag state persist automatically across frames — no manual tracking needed. When using `run_with_scenes()`, also prime the widget list in `on_enter()`: a newly pushed or switched scene is rendered before its first `update()`, so building only in `update()` would produce a one-frame blank UI.
 
 ```rust
 struct MyScene { ui: Ui }
 
 impl Scene for MyScene {
+    fn on_enter(&mut self, engine: &mut Engine, ..) {
+        self.ui.begin(x, y, width);   // prime widgets for the first render
+        self.ui.button(0, "Play");
+    }
     fn update(&mut self, engine: &Engine, ..) -> SceneOp {
         self.ui.begin(x, y, width);   // clears widgets, keeps focus/drag state
         self.ui.button(0, "Play");

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -537,7 +537,7 @@ Tracked against the build order. Crossed-off items are done.
 12. ~~Colored text spans~~ ✓
 13. ~~UI widgets (checkbox, slider, progress bar)~~ ✓
 14. ~~Mouse hover/click on widgets~~ ✓
-15. ~~UI single-build pattern — stop duplicating widget trees in update() and render()~~
+15. ~~UI single-build pattern — stop duplicating widget trees in update() and render()~~ ✓
 16. Screen-space sprites / UI image widget — card artwork, driver portraits, facility icons
 17. Tooltip widget — card descriptions, stat explanations
 18. Widget animation hooks — card flip, slide-in, highlight pulse
@@ -546,4 +546,4 @@ Tracked against the build order. Crossed-off items are done.
 21. Animation state machines — car sprite states
 22. Rebindable controls — player key remapping
 
-Items 1-14 done. Items 15-16 unblock productive game development. Items 17-18 make it feel real. Items 19-22 are polish.
+Items 1-15 done. Item 16 unblocks productive game development. Items 17-18 make it feel real. Items 19-22 are polish.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -461,3 +461,89 @@ That means the highest-value work is:
 - import tools
 
 Those are the features that make an engine pleasant to build games in, rather than merely possible to build games in.
+
+---
+
+## Personal End-Goal: Loop Hero-Inspired Motorsport Simulator
+
+The target game that drives engine development priorities. Everything below describes what the engine must eventually support so a human can sit down and build this game without fighting the tooling.
+
+### Concept
+
+Loop Hero meets the entire history of Formula 1 compressed into one race. Cars drive themselves around a track based on driver/car stats. The player makes management decisions between laps — hiring drivers, allocating R&D, playing cards, building facilities — to win both the Drivers' and Constructors' Championships. Each lap advances 3-4 years through motorsport history (1950s → present), with cars naturally evolving as eras progress.
+
+### Core Loop
+
+1. Create/choose a team (engine supplier, car parts, two drivers from a market)
+2. Race starts in the 1950s
+3. Cars race autonomously based on stats
+4. Each lap = 3-4 years of progress through ~7-10 regulatory eras
+5. Between laps: 3-5 decisions (cards, tech tree, staff, strategy)
+6. Goal: win Drivers' Championship, then Constructors' Championship
+
+### Key Mechanics
+
+- **Tech Tree**: Permanent progression branches (aero vs engine vs chassis vs reliability). Long-term strategic bets — picking aero early peaks in the ground-effect era but struggles in the turbo era.
+- **Cards**: Random tactical per-lap draws (3-5 drawn, play 1-2). Examples: Wind Tunnel Breakthrough (+15% aero for 2 laps), Engine Blow (opponent DNF), Rain Dance (wet lap), Miraculous Save (cancel crash), Poaching (steal rival engineer), Regulation Change (reset a tech branch), Budget Cap (spend limit for 3 laps).
+- **Card Rarity**: Common (small stat buffs), Rare (significant advantages), Legendary (game-changers like "Regulation Loophole" — ignore one regulation change).
+- **Regulation Changes**: Periodic bans that wipe overspecialized teams and create catch-up opportunities. Scripted per era or card-driven.
+- **Drivers**: Two per team. Traits: consistent, aggressive, wet-weather specialist, tyre whisperer, team player vs maverick. Contract length/cost. Hidden "potential" stat — young rookies may bloom into champions or plateau after 2-3 eras.
+- **Staff**: Race engineer affects stat-to-laptime translation. Team principal decisions: team orders, pit strategy, risk tolerance.
+- **Qualifying**: Mini-decision phase before each era determines grid position (spend tokens for practice, risk crash for speed, or play safe).
+- **Points System**: Evolves with era (1950s: 8-6-4-3-2 → modern: 25-18-15-etc).
+- **Rival AI Archetypes**: Conservative (reliability), Aggressive (aero), Budget (poach staff). Gives personality to the field.
+- **Heritage Bonus**: Staying with the same engine supplier across eras builds a relationship bonus.
+- **Pit Crew**: Upgradeable facility — a 1.8-second stop creates drama.
+- **Weather Cards**: Affect multiple laps ("Monsoon Season" = 3 wet laps, forces planning).
+- **Scandal Events**: Cheating, illegal parts, political interference — narrative chaos.
+- **End-of-Era Draft**: When regulations change, worse-performing teams pick first from the new era's tech tree.
+
+### Facilities (3-5 upgrade levels each)
+
+- Factory — manufacturing quality (chassis, engine parts)
+- Wind Tunnel / CFD Suite — aero development speed
+- Training Center — driver development rate
+- Sponsorship Office — passive income
+
+### Race Visualization
+
+- Top-down or isometric track, cars as colored dots/sprites
+- Commentary/event log for drama ("Lap 3 (1962): Your driver Stirling takes the lead!")
+- Incidents based on reliability + RNG (crashes, mechanical failures, weather, safety cars)
+- Abstracted pit stops (push hard / conserve / pit early)
+
+### Win Conditions
+
+- Easy: win Drivers' title
+- Normal: win both titles
+- Hard: win both with budget constraint
+- Nightmare: start in 1970 (miss easy early eras)
+
+### Engine Features Still Needed
+
+Tracked against the build order. Crossed-off items are done.
+
+1. ~~Canvas stores screen_size~~ ✓
+2. ~~UI layout containers (Row, Grid)~~ ✓
+3. ~~UI scroll region~~ ✓
+4. ~~Nine-slice rendering~~ ✓
+5. ~~Particles~~ ✓
+6. ~~Post-processing (CRT/bloom/vignette for era filters)~~ ✓
+7. ~~Resolution scaling~~ ✓
+8. ~~Audio fades/crossfades~~ ✓
+9. ~~Scene transitions~~ ✓
+10. ~~Timer + EventQueue~~ ✓
+11. ~~Canvas drawing primitives~~ ✓
+12. ~~Colored text spans~~ ✓
+13. ~~UI widgets (checkbox, slider, progress bar)~~ ✓
+14. ~~Mouse hover/click on widgets~~ ✓
+15. ~~UI single-build pattern — stop duplicating widget trees in update() and render()~~
+16. Screen-space sprites / UI image widget — card artwork, driver portraits, facility icons
+17. Tooltip widget — card descriptions, stat explanations
+18. Widget animation hooks — card flip, slide-in, highlight pulse
+19. Multiple font support — headers, body, commentary, HUD
+20. Text input widget — team naming
+21. Animation state machines — car sprite states
+22. Rebindable controls — player key remapping
+
+Items 1-14 done. Items 15-16 unblock productive game development. Items 17-18 make it feel real. Items 19-22 are polish.

--- a/engine/src/assets/spritesheet.rs
+++ b/engine/src/assets/spritesheet.rs
@@ -49,7 +49,6 @@ impl SpriteSheet {
 
 #[derive(Debug, Clone)]
 pub struct Animation {
-
     pub frames: Vec<(u32, u32)>,
 
     pub frame_time: f32,

--- a/engine/src/math/rng.rs
+++ b/engine/src/math/rng.rs
@@ -29,7 +29,9 @@ impl Rng {
     }
 
     pub fn next_u64(&mut self) -> u64 {
-        let result = (self.state[1].wrapping_mul(5)).rotate_left(7).wrapping_mul(9);
+        let result = (self.state[1].wrapping_mul(5))
+            .rotate_left(7)
+            .wrapping_mul(9);
         let t = self.state[1] << 17;
 
         self.state[2] ^= self.state[0];

--- a/engine/src/math/tween.rs
+++ b/engine/src/math/tween.rs
@@ -358,14 +358,8 @@ mod tests {
         ] {
             let v0 = easing.apply(0.0);
             let v1 = easing.apply(1.0);
-            assert!(
-                (v0 - 0.0).abs() < 0.001,
-                "{easing:?} at t=0 was {v0}"
-            );
-            assert!(
-                (v1 - 1.0).abs() < 0.001,
-                "{easing:?} at t=1 was {v1}"
-            );
+            assert!((v0 - 0.0).abs() < 0.001, "{easing:?} at t=0 was {v0}");
+            assert!((v1 - 1.0).abs() < 0.001, "{easing:?} at t=1 was {v1}");
         }
     }
 

--- a/engine/src/renderer3d/mesh.rs
+++ b/engine/src/renderer3d/mesh.rs
@@ -25,19 +25,16 @@ impl Vertex3D {
             array_stride: std::mem::size_of::<Self>() as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &[
-
                 wgpu::VertexAttribute {
                     offset: 0,
                     shader_location: 0,
                     format: wgpu::VertexFormat::Float32x3,
                 },
-
                 wgpu::VertexAttribute {
                     offset: 12,
                     shader_location: 1,
                     format: wgpu::VertexFormat::Float32x3,
                 },
-
                 wgpu::VertexAttribute {
                     offset: 24,
                     shader_location: 2,
@@ -60,7 +57,11 @@ pub fn cube_mesh(sx: f32, sy: f32, sz: f32, color: Color) -> (Vec<Vertex3D>, Vec
     let mut add_face = |positions: [[f32; 3]; 4], normal: [f32; 3]| {
         let base = verts.len() as u32;
         for p in &positions {
-            verts.push(Vertex3D { position: *p, normal, color: c });
+            verts.push(Vertex3D {
+                position: *p,
+                normal,
+                color: c,
+            });
         }
         idxs.extend_from_slice(&[base + 2, base + 1, base, base, base + 3, base + 2]);
     };
@@ -71,7 +72,12 @@ pub fn cube_mesh(sx: f32, sy: f32, sz: f32, color: Color) -> (Vec<Vertex3D>, Vec
     );
 
     add_face(
-        [[-hx, -hy, hz], [hx, -hy, hz], [hx, -hy, -hz], [-hx, -hy, -hz]],
+        [
+            [-hx, -hy, hz],
+            [hx, -hy, hz],
+            [hx, -hy, -hz],
+            [-hx, -hy, -hz],
+        ],
         [0.0, -1.0, 0.0],
     );
 
@@ -81,7 +87,12 @@ pub fn cube_mesh(sx: f32, sy: f32, sz: f32, color: Color) -> (Vec<Vertex3D>, Vec
     );
 
     add_face(
-        [[hx, -hy, -hz], [hx, hy, -hz], [-hx, hy, -hz], [-hx, -hy, -hz]],
+        [
+            [hx, -hy, -hz],
+            [hx, hy, -hz],
+            [-hx, hy, -hz],
+            [-hx, -hy, -hz],
+        ],
         [0.0, 0.0, -1.0],
     );
 
@@ -91,7 +102,12 @@ pub fn cube_mesh(sx: f32, sy: f32, sz: f32, color: Color) -> (Vec<Vertex3D>, Vec
     );
 
     add_face(
-        [[-hx, -hy, -hz], [-hx, hy, -hz], [-hx, hy, hz], [-hx, -hy, hz]],
+        [
+            [-hx, -hy, -hz],
+            [-hx, hy, -hz],
+            [-hx, hy, hz],
+            [-hx, -hy, hz],
+        ],
         [-1.0, 0.0, 0.0],
     );
 
@@ -104,10 +120,26 @@ pub fn floor_quad(width: f32, depth: f32, y: f32, color: Color) -> (Vec<Vertex3D
     let c = color.to_array();
     let n = [0.0, 1.0, 0.0];
     let verts = vec![
-        Vertex3D { position: [-hw, y, -hd], normal: n, color: c },
-        Vertex3D { position: [hw, y, -hd], normal: n, color: c },
-        Vertex3D { position: [hw, y, hd], normal: n, color: c },
-        Vertex3D { position: [-hw, y, hd], normal: n, color: c },
+        Vertex3D {
+            position: [-hw, y, -hd],
+            normal: n,
+            color: c,
+        },
+        Vertex3D {
+            position: [hw, y, -hd],
+            normal: n,
+            color: c,
+        },
+        Vertex3D {
+            position: [hw, y, hd],
+            normal: n,
+            color: c,
+        },
+        Vertex3D {
+            position: [-hw, y, hd],
+            normal: n,
+            color: c,
+        },
     ];
     let idxs = vec![2, 1, 0, 0, 3, 2];
     (verts, idxs)
@@ -127,10 +159,26 @@ pub fn wall_quad(
     let n = [-dz / len, 0.0, dx / len];
 
     let verts = vec![
-        Vertex3D { position: p0, normal: n, color: c },
-        Vertex3D { position: p1, normal: n, color: c },
-        Vertex3D { position: [p1[0], p1[1] + height, p1[2]], normal: n, color: c },
-        Vertex3D { position: [p0[0], p0[1] + height, p0[2]], normal: n, color: c },
+        Vertex3D {
+            position: p0,
+            normal: n,
+            color: c,
+        },
+        Vertex3D {
+            position: p1,
+            normal: n,
+            color: c,
+        },
+        Vertex3D {
+            position: [p1[0], p1[1] + height, p1[2]],
+            normal: n,
+            color: c,
+        },
+        Vertex3D {
+            position: [p0[0], p0[1] + height, p0[2]],
+            normal: n,
+            color: c,
+        },
     ];
     let idxs = vec![0, 1, 2, 2, 3, 0];
     (verts, idxs)

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -157,6 +157,23 @@ pub struct Ui {
     dragging_slider: Option<usize>,
 }
 
+impl Default for Ui {
+    fn default() -> Self {
+        Self {
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            style: UiStyle::default(),
+            widgets: Vec::new(),
+            focusable_ids: Vec::new(),
+            focus_index: 0,
+            activated: None,
+            mouse_focus: false,
+            dragging_slider: None,
+        }
+    }
+}
+
 impl Ui {
     pub fn new(x: f32, y: f32, width: f32, _screen_size: (u32, u32)) -> Self {
         Self {
@@ -171,6 +188,16 @@ impl Ui {
             mouse_focus: false,
             dragging_slider: None,
         }
+    }
+
+    pub fn begin(&mut self, x: f32, y: f32, width: f32) {
+        self.x = x;
+        self.y = y;
+        self.width = width;
+        self.widgets.clear();
+        self.focusable_ids.clear();
+        self.activated = None;
+        self.mouse_focus = false;
     }
 
     pub fn with_style(mut self, style: UiStyle) -> Self {

--- a/engine/src/world/tilemap.rs
+++ b/engine/src/world/tilemap.rs
@@ -1,6 +1,6 @@
-use glam::Vec2;
 use crate::assets::Color;
 use crate::renderer::{DrawParams, Frame, TextureId};
+use glam::Vec2;
 
 pub struct TileMap {
     pub width: usize,
@@ -42,7 +42,6 @@ impl TileDef {
 }
 
 impl TileMap {
-
     pub fn new(width: usize, height: usize, tile_size: f32) -> Self {
         Self {
             width,
@@ -133,9 +132,13 @@ impl TileMap {
 
         let half_w = 600.0;
         let half_h = 400.0;
-        let left = ((cam.position.x - half_w) / self.tile_size).floor().max(0.0) as usize;
+        let left = ((cam.position.x - half_w) / self.tile_size)
+            .floor()
+            .max(0.0) as usize;
         let right = ((cam.position.x + half_w) / self.tile_size).ceil() as usize;
-        let bottom = ((cam.position.y - half_h) / self.tile_size).floor().max(0.0) as usize;
+        let bottom = ((cam.position.y - half_h) / self.tile_size)
+            .floor()
+            .max(0.0) as usize;
         let top = ((cam.position.y + half_h) / self.tile_size).ceil() as usize;
 
         let right = right.min(self.width);

--- a/samples/features/feature-animation/src/main.rs
+++ b/samples/features/feature-animation/src/main.rs
@@ -135,7 +135,14 @@ impl Game for AnimationDemo {
 
         let hud = frame.canvas(0);
         hud.rect(-hw, hh - 40.0, sw, 40.0, Color::new(0.08, 0.07, 0.1, 0.95));
-        hud.text(-hw + 16.0, hh - 10.0, "SpriteSheet + Animation Demo", 18.0, Color::WHITE, atlas);
+        hud.text(
+            -hw + 16.0,
+            hh - 10.0,
+            "SpriteSheet + Animation Demo",
+            18.0,
+            Color::WHITE,
+            atlas,
+        );
 
         let animations: [(&str, &Animation); 8] = [
             ("Walk Right (8fps)", &self.walk_right),
@@ -173,14 +180,35 @@ impl Game for AnimationDemo {
             );
 
             let labels = frame.canvas(0);
-            labels.text(x, y - 6.0, label, 12.0, Color::new(0.7, 0.8, 0.9, 1.0), atlas);
+            labels.text(
+                x,
+                y - 6.0,
+                label,
+                12.0,
+                Color::new(0.7, 0.8, 0.9, 1.0),
+                atlas,
+            );
 
             let frame_text = format!("frame: ({},{})", fc, fr);
-            labels.text(x, y - 22.0, &frame_text, 11.0, Color::new(0.5, 0.6, 0.7, 1.0), atlas);
+            labels.text(
+                x,
+                y - 22.0,
+                &frame_text,
+                11.0,
+                Color::new(0.5, 0.6, 0.7, 1.0),
+                atlas,
+            );
         }
 
         let sheet_label = frame.canvas(0);
-        sheet_label.text(start_x, start_y - y_spacing - 44.0, "Sprite sheet (4x4 grid, 16x16 cells):", 13.0, Color::new(0.6, 0.7, 0.8, 1.0), atlas);
+        sheet_label.text(
+            start_x,
+            start_y - y_spacing - 44.0,
+            "Sprite sheet (4x4 grid, 16x16 cells):",
+            13.0,
+            Color::new(0.6, 0.7, 0.8, 1.0),
+            atlas,
+        );
 
         let sheet_y = start_y + 2.0 * y_spacing + 30.0;
         let preview_scale = 4.0;

--- a/samples/features/feature-audio/src/main.rs
+++ b/samples/features/feature-audio/src/main.rs
@@ -116,9 +116,16 @@ impl Game for AudioDemo {
         }
 
         if engine.input().is_key_pressed(KeyCode::KeyI) {
-            let clip = if self.on_track_a { &self.track_a } else { &self.track_b };
+            let clip = if self.on_track_a {
+                &self.track_a
+            } else {
+                &self.track_b
+            };
             let _ = engine.fade_in_music(clip, 2.0, Easing::OutQuad);
-            self.status = format!("Fade in: track {} (2s)", if self.on_track_a { "A" } else { "B" });
+            self.status = format!(
+                "Fade in: track {} (2s)",
+                if self.on_track_a { "A" } else { "B" }
+            );
         }
 
         if engine.input().is_key_pressed(KeyCode::Space) {
@@ -144,16 +151,52 @@ impl Game for AudioDemo {
         let c = frame.canvas(10);
         let hh = h as f32 / 2.0;
 
-        c.text_aligned(0.0, hh - 60.0, "Audio Fades Demo", 28.0, Color::WHITE, TextAlign::Center, &font);
+        c.text_aligned(
+            0.0,
+            hh - 60.0,
+            "Audio Fades Demo",
+            28.0,
+            Color::WHITE,
+            TextAlign::Center,
+            &font,
+        );
 
-        c.text_aligned(0.0, hh - 20.0, &self.status, 20.0, Color::YELLOW, TextAlign::Center, &font);
+        c.text_aligned(
+            0.0,
+            hh - 20.0,
+            &self.status,
+            20.0,
+            Color::YELLOW,
+            TextAlign::Center,
+            &font,
+        );
 
-        let fading = if engine.is_audio_fading() { "fading..." } else { "idle" };
-        c.text_aligned(0.0, hh + 10.0, fading, 16.0, Color::from_rgba8(150, 150, 150, 255), TextAlign::Center, &font);
+        let fading = if engine.is_audio_fading() {
+            "fading..."
+        } else {
+            "idle"
+        };
+        c.text_aligned(
+            0.0,
+            hh + 10.0,
+            fading,
+            16.0,
+            Color::from_rgba8(150, 150, 150, 255),
+            TextAlign::Center,
+            &font,
+        );
 
         if !self.demo_mode {
             let help = "[F] crossfade  [I] fade in  [O] fade out  [Space] SFX  [Up/Down] bus vol";
-            c.text_aligned(0.0, -hh + 30.0, help, 14.0, Color::from_rgba8(120, 120, 120, 255), TextAlign::Center, &font);
+            c.text_aligned(
+                0.0,
+                -hh + 30.0,
+                help,
+                14.0,
+                Color::from_rgba8(120, 120, 120, 255),
+                TextAlign::Center,
+                &font,
+            );
         }
     }
 

--- a/samples/features/feature-canvas/src/main.rs
+++ b/samples/features/feature-canvas/src/main.rs
@@ -82,21 +82,9 @@ impl Game for CanvasDemo {
         let bar_h = 24.0;
         let bar_x = -hw + 260.0;
         let bar_y = hh - 110.0 - bar_h;
-        hud.rect(
-            bar_x,
-            bar_y,
-            bar_w,
-            bar_h,
-            Color::new(0.2, 0.2, 0.2, 1.0),
-        );
+        hud.rect(bar_x, bar_y, bar_w, bar_h, Color::new(0.2, 0.2, 0.2, 1.0));
         let fill = ((self.time * 0.3).sin() * 0.5 + 0.5) * bar_w;
-        hud.rect(
-            bar_x,
-            bar_y,
-            fill,
-            bar_h,
-            Color::new(0.3, 0.8, 0.4, 1.0),
-        );
+        hud.rect(bar_x, bar_y, fill, bar_h, Color::new(0.3, 0.8, 0.4, 1.0));
         hud.text(
             bar_x + 8.0,
             bar_y + 18.0,

--- a/samples/features/feature-nineslice/src/main.rs
+++ b/samples/features/feature-nineslice/src/main.rs
@@ -179,14 +179,7 @@ impl Game for NineSliceDemo {
         let p = |sx: f32, sy: f32, _size: f32| -> (f32, f32) { (sx - hw, hh - sy) };
 
         let (tx, ty) = p(20.0, 10.0, 28.0);
-        canvas.text(
-            tx,
-            ty,
-            "NineSlice Feature Demo",
-            28.0,
-            Color::WHITE,
-            atlas,
-        );
+        canvas.text(tx, ty, "NineSlice Feature Demo", 28.0, Color::WHITE, atlas);
         let (tx, ty) = p(20.0, 42.0, 14.0);
         canvas.text(
             tx,
@@ -221,32 +214,11 @@ impl Game for NineSliceDemo {
         );
 
         let (tx, ty) = p(20.0, r3_lbl_y, ls);
-        canvas.text(
-            tx,
-            ty,
-            "Animated (resizing)",
-            ls,
-            anim_label_color,
-            atlas,
-        );
+        canvas.text(tx, ty, "Animated (resizing)", ls, anim_label_color, atlas);
         let (tx, ty) = p(220.0, r3_lbl_y, ls);
-        canvas.text(
-            tx,
-            ty,
-            "Animated (width)",
-            ls,
-            anim_label_color,
-            atlas,
-        );
+        canvas.text(tx, ty, "Animated (width)", ls, anim_label_color, atlas);
         let (tx, ty) = p(600.0, r3_lbl_y, ls);
-        canvas.text(
-            tx,
-            ty,
-            "Animated (breathing)",
-            ls,
-            anim_label_color,
-            atlas,
-        );
+        canvas.text(tx, ty, "Animated (breathing)", ls, anim_label_color, atlas);
 
         let (tx, ty) = p(20.0, sh as f32 - 24.0, 14.0);
         canvas.text(

--- a/samples/features/feature-pixelart/src/main.rs
+++ b/samples/features/feature-pixelart/src/main.rs
@@ -111,7 +111,14 @@ impl Game for PixelArtDemo {
 
         let hud = frame.canvas(0);
         hud.rect(-hw, hh - 40.0, sw, 40.0, Color::new(0.08, 0.07, 0.1, 0.95));
-        hud.text(-hw + 16.0, hh - 10.0, "PixelCanvas Procedural Textures", 18.0, Color::WHITE, atlas);
+        hud.text(
+            -hw + 16.0,
+            hh - 10.0,
+            "PixelCanvas Procedural Textures",
+            18.0,
+            Color::WHITE,
+            atlas,
+        );
 
         let cols = 3;
         let spacing = 180.0;
@@ -137,7 +144,14 @@ impl Game for PixelArtDemo {
             frame.draw(*tex, Vec2::new(x, y), size);
 
             let labels = frame.canvas(0);
-            labels.text(x, y - 8.0, label, 13.0, Color::new(0.7, 0.8, 0.9, 1.0), atlas);
+            labels.text(
+                x,
+                y - 8.0,
+                label,
+                13.0,
+                Color::new(0.7, 0.8, 0.9, 1.0),
+                atlas,
+            );
         }
     }
 }

--- a/samples/features/feature-postfx/src/main.rs
+++ b/samples/features/feature-postfx/src/main.rs
@@ -199,14 +199,7 @@ impl Game for PostFxDemo {
             self.effect_index + 1,
             names.len()
         );
-        canvas.text(
-            -hw + 8.0,
-            hh - 8.0,
-            &info,
-            14.0,
-            Color::WHITE,
-            atlas,
-        );
+        canvas.text(-hw + 8.0, hh - 8.0, &info, 14.0, Color::WHITE, atlas);
     }
 
     fn should_exit(&self) -> bool {

--- a/samples/features/feature-resolution/src/main.rs
+++ b/samples/features/feature-resolution/src/main.rs
@@ -29,7 +29,11 @@ impl Game for ResolutionDemo {
             checker_b: engine.create_color_texture(1, 1, Color::from_rgba8(60, 90, 160, 255)),
             border: engine.create_color_texture(1, 1, Color::from_rgba8(255, 200, 50, 255)),
             mode_index: 1,
-            modes: [ScaleMode::Stretch, ScaleMode::Letterbox, ScaleMode::PixelPerfect],
+            modes: [
+                ScaleMode::Stretch,
+                ScaleMode::Letterbox,
+                ScaleMode::PixelPerfect,
+            ],
             frame_count: 0,
             demo,
             max_frames,
@@ -77,15 +81,35 @@ impl Game for ResolutionDemo {
         }
 
         let b = 2.0;
-        frame.draw(self.border, Vec2::new(-half_w, -half_h), Vec2::new(GAME_W as f32, b));
-        frame.draw(self.border, Vec2::new(-half_w, half_h - b), Vec2::new(GAME_W as f32, b));
-        frame.draw(self.border, Vec2::new(-half_w, -half_h), Vec2::new(b, GAME_H as f32));
-        frame.draw(self.border, Vec2::new(half_w - b, -half_h), Vec2::new(b, GAME_H as f32));
+        frame.draw(
+            self.border,
+            Vec2::new(-half_w, -half_h),
+            Vec2::new(GAME_W as f32, b),
+        );
+        frame.draw(
+            self.border,
+            Vec2::new(-half_w, half_h - b),
+            Vec2::new(GAME_W as f32, b),
+        );
+        frame.draw(
+            self.border,
+            Vec2::new(-half_w, -half_h),
+            Vec2::new(b, GAME_H as f32),
+        );
+        frame.draw(
+            self.border,
+            Vec2::new(half_w - b, -half_h),
+            Vec2::new(b, GAME_H as f32),
+        );
 
         let t = self.frame_count as f32 * 0.02;
         let marker_x = t.sin() * 100.0;
         let marker_y = t.cos() * 60.0;
-        frame.draw(self.border, Vec2::new(marker_x - 4.0, marker_y - 4.0), Vec2::new(8.0, 8.0));
+        frame.draw(
+            self.border,
+            Vec2::new(marker_x - 4.0, marker_y - 4.0),
+            Vec2::new(8.0, 8.0),
+        );
 
         let (ww, wh) = engine.window_size();
         let (gw, gh) = engine.game_size();
@@ -104,7 +128,13 @@ impl Game for ResolutionDemo {
         );
 
         let canvas = frame.canvas(0);
-        canvas.rect(-hw + 4.0, hh - 4.0 - 22.0, 400.0, 22.0, Color::from_rgba8(0, 0, 0, 180));
+        canvas.rect(
+            -hw + 4.0,
+            hh - 4.0 - 22.0,
+            400.0,
+            22.0,
+            Color::from_rgba8(0, 0, 0, 180),
+        );
         canvas.text(-hw + 8.0, hh - 8.0, &info, 14.0, Color::WHITE, atlas);
     }
 

--- a/samples/features/feature-rng/src/main.rs
+++ b/samples/features/feature-rng/src/main.rs
@@ -25,7 +25,9 @@ impl Game for RngDemo {
         let floats: Vec<String> = (0..5).map(|_| format!("{:.3}", rng.f32())).collect();
         results.push(format!("5 f32 [0,1): [{}]", floats.join(", ")));
 
-        let coins: Vec<&str> = (0..10).map(|_| if rng.chance(0.5) { "H" } else { "T" }).collect();
+        let coins: Vec<&str> = (0..10)
+            .map(|_| if rng.chance(0.5) { "H" } else { "T" })
+            .collect();
         results.push(format!("10 coin flips: {}", coins.join("")));
 
         let options = ["Common", "Uncommon", "Rare", "Legendary"];
@@ -36,7 +38,14 @@ impl Game for RngDemo {
         }
         results.push(format!(
             "1000 weighted draws: {}={}, {}={}, {}={}, {}={}",
-            options[0], counts[0], options[1], counts[1], options[2], counts[2], options[3], counts[3]
+            options[0],
+            counts[0],
+            options[1],
+            counts[1],
+            options[2],
+            counts[2],
+            options[3],
+            counts[3]
         ));
 
         let mut deck: Vec<i32> = (1..=10).collect();
@@ -73,7 +82,11 @@ impl Game for RngDemo {
         let engine_roll = engine.rng().range(1, 100);
         results.push(format!("engine.rng().range(1,100) = {engine_roll}"));
 
-        Self { seed, results, quit: false }
+        Self {
+            seed,
+            results,
+            quit: false,
+        }
     }
 
     fn update(&mut self, engine: &Engine, _frame: &mut Frame) {
@@ -90,26 +103,51 @@ impl Game for RngDemo {
         let canvas = frame.canvas(0);
 
         canvas.rect(
-            -hw, -hh,
-            sw as f32, sh as f32,
+            -hw,
+            -hh,
+            sw as f32,
+            sh as f32,
             Color::from_rgba8(20, 20, 30, 255),
         );
 
-        canvas.text(-hw + 20.0, hh - 20.0, "Rng Feature Demo", 28.0, Color::WHITE, atlas);
         canvas.text(
-            -hw + 20.0, hh - 52.0 - 18.0,
+            -hw + 20.0,
+            hh - 20.0,
+            "Rng Feature Demo",
+            28.0,
+            Color::WHITE,
+            atlas,
+        );
+        canvas.text(
+            -hw + 20.0,
+            hh - 52.0 - 18.0,
             &format!("Seed: {}", self.seed),
             18.0,
-            Color::from_rgba8(180, 180, 180, 255), atlas,
+            Color::from_rgba8(180, 180, 180, 255),
+            atlas,
         );
 
         let mut y = hh - 90.0;
         for line in &self.results {
-            canvas.text(-hw + 20.0, y, line, 16.0, Color::from_rgba8(200, 220, 255, 255), atlas);
+            canvas.text(
+                -hw + 20.0,
+                y,
+                line,
+                16.0,
+                Color::from_rgba8(200, 220, 255, 255),
+                atlas,
+            );
             y -= 22.0;
         }
 
-        canvas.text(-hw + 20.0, y - 20.0, "ESC to quit", 14.0, Color::from_rgba8(120, 120, 120, 255), atlas);
+        canvas.text(
+            -hw + 20.0,
+            y - 20.0,
+            "ESC to quit",
+            14.0,
+            Color::from_rgba8(120, 120, 120, 255),
+            atlas,
+        );
     }
 
     fn should_exit(&self) -> bool {

--- a/samples/features/feature-scenes/src/main.rs
+++ b/samples/features/feature-scenes/src/main.rs
@@ -10,14 +10,7 @@ fn draw_label(frame: &mut Frame, engine: &Engine, y: f32, size: f32, color: Colo
     let hw = screen.0 as f32 / 2.0;
     let hh = screen.1 as f32 / 2.0;
     let canvas = frame.canvas(0);
-    canvas.text(
-        -hw + 20.0,
-        hh - y,
-        text,
-        size,
-        color,
-        engine.font_atlas(),
-    );
+    canvas.text(-hw + 20.0, hh - y, text, size, color, engine.font_atlas());
 }
 
 struct ColorScene {
@@ -145,13 +138,7 @@ impl Scene for PauseOverlay {
         let hw = w as f32 / 2.0;
         let hh = h as f32 / 2.0;
         let canvas = frame.canvas(1);
-        canvas.rect(
-            -hw,
-            -hh,
-            w as f32,
-            h as f32,
-            Color::new(0.0, 0.0, 0.0, 0.6),
-        );
+        canvas.rect(-hw, -hh, w as f32, h as f32, Color::new(0.0, 0.0, 0.0, 0.6));
         canvas.text(
             -hw + 20.0,
             hh - 200.0,

--- a/samples/features/feature-text/src/main.rs
+++ b/samples/features/feature-text/src/main.rs
@@ -96,12 +96,34 @@ impl Game for TextDemo {
             let lh = atlas.line_height(body);
             let block_h = lines.len() as f32 * lh;
 
-            canvas.rect(bx - 2.0, by - block_h + 2.0, max_w + 4.0, block_h + 4.0, Color::from_rgba8(50, 50, 60, 255));
-            canvas.text_block(bx, by, paragraph, body, text_color, max_w, TextAlign::Left, atlas);
+            canvas.rect(
+                bx - 2.0,
+                by - block_h + 2.0,
+                max_w + 4.0,
+                block_h + 4.0,
+                Color::from_rgba8(50, 50, 60, 255),
+            );
+            canvas.text_block(
+                bx,
+                by,
+                paragraph,
+                body,
+                text_color,
+                max_w,
+                TextAlign::Left,
+                atlas,
+            );
         }
 
         y -= 120.0;
-        canvas.text(col_x, y, "text_block() with alignment", heading, label_color, atlas);
+        canvas.text(
+            col_x,
+            y,
+            "text_block() with alignment",
+            heading,
+            label_color,
+            atlas,
+        );
         y -= 30.0;
 
         let short_text = "Short lines\nshow alignment\nclearly across\nmultiple lines.";
@@ -119,7 +141,13 @@ impl Game for TextDemo {
             canvas.text(bx, y, name, 11.0, dim_color, atlas);
             let by = y - 18.0;
 
-            canvas.rect(bx - 2.0, by - 70.0, block_w + 4.0, 74.0, Color::from_rgba8(50, 50, 60, 255));
+            canvas.rect(
+                bx - 2.0,
+                by - 70.0,
+                block_w + 4.0,
+                74.0,
+                Color::from_rgba8(50, 50, 60, 255),
+            );
 
             let ax = match align {
                 TextAlign::Left => bx,
@@ -130,7 +158,8 @@ impl Game for TextDemo {
         }
 
         y -= 120.0;
-        let features = "Features: measure_text, line_height, TextAlign, wrap_text, text_aligned, text_block";
+        let features =
+            "Features: measure_text, line_height, TextAlign, wrap_text, text_aligned, text_block";
         canvas.text(col_x, y, features, 11.0, dim_color, atlas);
     }
 

--- a/samples/features/feature-tilemap/src/main.rs
+++ b/samples/features/feature-tilemap/src/main.rs
@@ -158,14 +158,35 @@ impl Game for TileMapDemo {
         let atlas = engine.font_atlas();
         let hud = frame.canvas(0);
         hud.rect(-hw, hh - 36.0, sw, 36.0, Color::new(0.08, 0.07, 0.1, 0.85));
-        hud.text(-hw + 12.0, hh - 8.0, "TileMap Demo - WASD/Arrows to move", 16.0, Color::WHITE, atlas);
+        hud.text(
+            -hw + 12.0,
+            hh - 8.0,
+            "TileMap Demo - WASD/Arrows to move",
+            16.0,
+            Color::WHITE,
+            atlas,
+        );
 
         let pos_text = format!("pos: ({:.0}, {:.0})", self.player_pos.x, self.player_pos.y);
         let col = (self.player_pos.x / TILE_SIZE) as usize;
         let row = (self.player_pos.y / TILE_SIZE) as usize;
         let cell_text = format!("cell: ({}, {})", col, row);
-        hud.text(-hw + 12.0, -hh + 40.0, &pos_text, 13.0, Color::YELLOW, atlas);
-        hud.text(-hw + 12.0, -hh + 22.0, &cell_text, 13.0, Color::new(0.6, 0.8, 1.0, 1.0), atlas);
+        hud.text(
+            -hw + 12.0,
+            -hh + 40.0,
+            &pos_text,
+            13.0,
+            Color::YELLOW,
+            atlas,
+        );
+        hud.text(
+            -hw + 12.0,
+            -hh + 22.0,
+            &cell_text,
+            13.0,
+            Color::new(0.6, 0.8, 1.0, 1.0),
+            atlas,
+        );
     }
 }
 

--- a/samples/features/feature-tween/src/main.rs
+++ b/samples/features/feature-tween/src/main.rs
@@ -71,8 +71,21 @@ impl Game for TweenDemo {
         let atlas = engine.font_atlas();
         let canvas = frame.canvas(0);
 
-        canvas.rect(-hw, -hh, sw as f32, sh as f32, Color::from_rgba8(20, 20, 30, 255));
-        canvas.text(-hw + 20.0, hh - 24.0, "Tween / Easing Demo", 24.0, Color::WHITE, atlas);
+        canvas.rect(
+            -hw,
+            -hh,
+            sw as f32,
+            sh as f32,
+            Color::from_rgba8(20, 20, 30, 255),
+        );
+        canvas.text(
+            -hw + 20.0,
+            hh - 24.0,
+            "Tween / Easing Demo",
+            24.0,
+            Color::WHITE,
+            atlas,
+        );
 
         let label_x = -hw + 20.0;
         let bar_x = -hw + 160.0;
@@ -88,21 +101,49 @@ impl Game for TweenDemo {
             let y = top - i as f32 * row_h;
             let val = tw.value();
 
-            canvas.text(label_x, y, name, 13.0, Color::from_rgba8(180, 180, 180, 255), atlas);
+            canvas.text(
+                label_x,
+                y,
+                name,
+                13.0,
+                Color::from_rgba8(180, 180, 180, 255),
+                atlas,
+            );
             canvas.rect(bar_x, y - 2.0, BAR_WIDTH, bar_h, track_color);
             canvas.rect(bar_x, y - 2.0, val, bar_h, fill_color);
             canvas.rect(bar_x + val - 3.0, y - 4.0, 6.0, bar_h + 4.0, dot_color);
         }
 
         let bounce_y = top - self.tweens.len() as f32 * row_h - 40.0;
-        let bounce_val = ease(0.0, 200.0, (self.elapsed * 1.5 % 2.0) / 2.0, Easing::OutBounce);
-        canvas.rect(-hw + 200.0, bounce_y + bounce_val - 10.0, 20.0, 20.0, Color::from_rgba8(255, 100, 100, 255));
-        canvas.text(-hw + 20.0, bounce_y - 10.0, "OutBounce ball:", 13.0, Color::from_rgba8(180, 180, 180, 255), atlas);
+        let bounce_val = ease(
+            0.0,
+            200.0,
+            (self.elapsed * 1.5 % 2.0) / 2.0,
+            Easing::OutBounce,
+        );
+        canvas.rect(
+            -hw + 200.0,
+            bounce_y + bounce_val - 10.0,
+            20.0,
+            20.0,
+            Color::from_rgba8(255, 100, 100, 255),
+        );
+        canvas.text(
+            -hw + 20.0,
+            bounce_y - 10.0,
+            "OutBounce ball:",
+            13.0,
+            Color::from_rgba8(180, 180, 180, 255),
+            atlas,
+        );
 
         canvas.text(
-            -hw + 20.0, -hh + 16.0,
+            -hw + 20.0,
+            -hh + 16.0,
             "ESC to quit | tweens ping-pong automatically",
-            12.0, Color::from_rgba8(100, 100, 100, 255), atlas,
+            12.0,
+            Color::from_rgba8(100, 100, 100, 255),
+            atlas,
         );
     }
 

--- a/samples/features/feature-ui/src/main.rs
+++ b/samples/features/feature-ui/src/main.rs
@@ -19,7 +19,12 @@ impl MenuScene {
 }
 
 impl Scene for MenuScene {
-    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
+    fn on_enter(&mut self, engine: &mut Engine, _globals: &mut Globals) {
+        let (_sw, sh) = engine.window_size();
+        let hh = sh as f32 / 2.0;
+        self.ui.begin(-120.0, hh - 80.0, 240.0);
+        Self::build_menu(&mut self.ui);
+    }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
         let (_sw, sh) = engine.window_size();
@@ -105,8 +110,12 @@ impl OptionsScene {
 }
 
 impl Scene for OptionsScene {
-    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {
+    fn on_enter(&mut self, engine: &mut Engine, _globals: &mut Globals) {
         self.ui = Ui::default().with_style(Self::options_style());
+        let (_sw, sh) = engine.window_size();
+        let hh = sh as f32 / 2.0;
+        self.ui.begin(-100.0, hh - 60.0, 200.0);
+        Self::build_options(&mut self.ui);
     }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
@@ -207,7 +216,20 @@ impl DemoScene {
 }
 
 impl Scene for DemoScene {
-    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
+    fn on_enter(&mut self, engine: &mut Engine, _globals: &mut Globals) {
+        let (_sw, sh) = engine.window_size();
+        let hh = sh as f32 / 2.0;
+        self.ui.begin(-180.0, hh - 40.0, 360.0);
+        Self::build_widgets(
+            &mut self.ui,
+            self.health,
+            self.fuel,
+            self.fullscreen,
+            self.vsync,
+            self.speed,
+            self.volume,
+        );
+    }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
         let (_sw, sh) = engine.window_size();
@@ -344,7 +366,12 @@ impl LayoutScene {
 }
 
 impl Scene for LayoutScene {
-    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
+    fn on_enter(&mut self, engine: &mut Engine, _globals: &mut Globals) {
+        let (_sw, sh) = engine.window_size();
+        let hh = sh as f32 / 2.0;
+        self.ui.begin(-200.0, hh - 30.0, 400.0);
+        Self::build_widgets(&mut self.ui);
+    }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
         let (_sw, sh) = engine.window_size();
@@ -423,7 +450,12 @@ impl ScrollScene {
 }
 
 impl Scene for ScrollScene {
-    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
+    fn on_enter(&mut self, engine: &mut Engine, _globals: &mut Globals) {
+        let (_sw, sh) = engine.window_size();
+        let hh = sh as f32 / 2.0;
+        self.ui.begin(-200.0, hh - 30.0, 400.0);
+        Self::build_widgets(&mut self.ui, self.scroll_offset);
+    }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
         let (_sw, sh) = engine.window_size();

--- a/samples/features/feature-ui/src/main.rs
+++ b/samples/features/feature-ui/src/main.rs
@@ -1,7 +1,7 @@
 use rengine::*;
 
 struct MenuScene {
-    focus: usize,
+    ui: Ui,
     message: String,
 }
 
@@ -22,34 +22,24 @@ impl Scene for MenuScene {
     fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (sw, sh) = engine.window_size();
-        let atlas = engine.font_atlas();
+        let (_sw, sh) = engine.window_size();
         let hh = sh as f32 / 2.0;
+        let atlas = engine.font_atlas();
 
-        let mut ui = Ui::new(-120.0, hh - 80.0, 240.0, (sw, sh)).with_focus(self.focus);
-        Self::build_menu(&mut ui);
-
-        let response = ui.update(engine.input(), atlas);
-        if let Some(f) = response.focused {
-            self.focus = f;
-        }
+        self.ui.begin(-120.0, hh - 80.0, 240.0);
+        Self::build_menu(&mut self.ui);
+        let response = self.ui.update(engine.input(), atlas);
 
         if let Some(id) = response.activated {
             match id {
                 0 => return SceneOp::Switch(Box::new(GameScene::new())),
                 1 => {
                     self.message = "Options not implemented".into();
-                    return SceneOp::Push(Box::new(OptionsScene { focus: 0 }));
+                    return SceneOp::Push(Box::new(OptionsScene { ui: Ui::default() }));
                 }
-                2 => {
-                    return SceneOp::Push(Box::new(DemoScene::new()));
-                }
-                3 => {
-                    return SceneOp::Push(Box::new(LayoutScene::new()));
-                }
-                5 => {
-                    return SceneOp::Push(Box::new(ScrollScene::new()));
-                }
+                2 => return SceneOp::Push(Box::new(DemoScene::new())),
+                3 => return SceneOp::Push(Box::new(LayoutScene::new())),
+                5 => return SceneOp::Push(Box::new(ScrollScene::new())),
                 4 => return SceneOp::Quit,
                 _ => {}
             }
@@ -59,17 +49,13 @@ impl Scene for MenuScene {
     }
 
     fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
-        let (sw, sh) = engine.window_size();
+        let (_sw, sh) = engine.window_size();
         let hh = sh as f32 / 2.0;
         let atlas = engine.font_atlas();
         frame.clear_color = Color::from_rgba8(25, 25, 40, 255);
 
         let canvas = frame.canvas(0);
-
-        let mut ui = Ui::new(-120.0, hh - 80.0, 240.0, (sw, sh)).with_focus(self.focus);
-        Self::build_menu(&mut ui);
-
-        ui.render(canvas, atlas);
+        self.ui.render(canvas, atlas);
 
         if !self.message.is_empty() {
             canvas.text_aligned(
@@ -96,7 +82,7 @@ impl Scene for MenuScene {
 }
 
 struct OptionsScene {
-    focus: usize,
+    ui: Ui,
 }
 
 impl OptionsScene {
@@ -119,22 +105,18 @@ impl OptionsScene {
 }
 
 impl Scene for OptionsScene {
-    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
+    fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {
+        self.ui = Ui::default().with_style(Self::options_style());
+    }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (sw, sh) = engine.window_size();
-        let atlas = engine.font_atlas();
+        let (_sw, sh) = engine.window_size();
         let hh = sh as f32 / 2.0;
+        let atlas = engine.font_atlas();
 
-        let mut ui = Ui::new(-100.0, hh - 60.0, 200.0, (sw, sh))
-            .with_style(Self::options_style())
-            .with_focus(self.focus);
-        Self::build_options(&mut ui);
-
-        let response = ui.update(engine.input(), atlas);
-        if let Some(f) = response.focused {
-            self.focus = f;
-        }
+        self.ui.begin(-100.0, hh - 60.0, 200.0);
+        Self::build_options(&mut self.ui);
+        let response = self.ui.update(engine.input(), atlas);
 
         if let Some(id) = response.activated {
             if id == 2 {
@@ -157,20 +139,9 @@ impl Scene for OptionsScene {
         let canvas = frame.canvas(1);
         let fw = sw as f32;
         let fh = sh as f32;
-        canvas.rect(
-            -fw / 2.0,
-            -hh,
-            fw,
-            fh,
-            Color::new(0.0, 0.0, 0.0, 0.6),
-        );
+        canvas.rect(-fw / 2.0, -hh, fw, fh, Color::new(0.0, 0.0, 0.0, 0.6));
 
-        let mut ui = Ui::new(-100.0, hh - 60.0, 200.0, (sw, sh))
-            .with_style(Self::options_style())
-            .with_focus(self.focus);
-        Self::build_options(&mut ui);
-
-        ui.render(canvas, atlas);
+        self.ui.render(canvas, atlas);
 
         canvas.text_aligned(
             0.0,
@@ -185,8 +156,7 @@ impl Scene for OptionsScene {
 }
 
 struct DemoScene {
-    focus: usize,
-    dragging: Option<usize>,
+    ui: Ui,
     speed: f32,
     volume: f32,
     fullscreen: bool,
@@ -198,8 +168,7 @@ struct DemoScene {
 impl DemoScene {
     fn new() -> Self {
         Self {
-            focus: 0,
-            dragging: None,
+            ui: Ui::default(),
             speed: 1.5,
             volume: 0.75,
             fullscreen: false,
@@ -209,20 +178,28 @@ impl DemoScene {
         }
     }
 
-    fn build_widgets(&self, ui: &mut Ui) {
+    fn build_widgets(
+        ui: &mut Ui,
+        health: f32,
+        fuel: f32,
+        fullscreen: bool,
+        vsync: bool,
+        speed: f32,
+        volume: f32,
+    ) {
         ui.label_centered("Widget Demo", 24.0, Color::WHITE);
         ui.separator(8.0);
 
         ui.panel(8);
         ui.label("Stats", 18.0, Color::from_rgba8(180, 200, 255, 255));
         ui.separator(4.0);
-        ui.progress_bar("Health", self.health);
-        ui.progress_bar_colored("Fuel", self.fuel, Color::from_rgba8(220, 160, 40, 255));
+        ui.progress_bar("Health", health);
+        ui.progress_bar_colored("Fuel", fuel, Color::from_rgba8(220, 160, 40, 255));
         ui.separator(4.0);
-        ui.checkbox(10, "Fullscreen", self.fullscreen);
-        ui.checkbox(11, "VSync", self.vsync);
-        ui.slider(20, "Game Speed", self.speed, 0.5, 3.0);
-        ui.slider(21, "Volume", self.volume, 0.0, 1.0);
+        ui.checkbox(10, "Fullscreen", fullscreen);
+        ui.checkbox(11, "VSync", vsync);
+        ui.slider(20, "Game Speed", speed, 0.5, 3.0);
+        ui.slider(21, "Volume", volume, 0.0, 1.0);
 
         ui.separator(8.0);
         ui.button(99, "Back");
@@ -233,20 +210,21 @@ impl Scene for DemoScene {
     fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (sw, sh) = engine.window_size();
-        let atlas = engine.font_atlas();
+        let (_sw, sh) = engine.window_size();
         let hh = sh as f32 / 2.0;
+        let atlas = engine.font_atlas();
 
-        let mut ui = Ui::new(-180.0, hh - 40.0, 360.0, (sw, sh))
-            .with_focus(self.focus)
-            .with_dragging(self.dragging);
-        self.build_widgets(&mut ui);
-
-        let response = ui.update(engine.input(), atlas);
-        if let Some(f) = response.focused {
-            self.focus = f;
-        }
-        self.dragging = response.dragging;
+        self.ui.begin(-180.0, hh - 40.0, 360.0);
+        Self::build_widgets(
+            &mut self.ui,
+            self.health,
+            self.fuel,
+            self.fullscreen,
+            self.vsync,
+            self.speed,
+            self.volume,
+        );
+        let response = self.ui.update(engine.input(), atlas);
 
         if response.was_toggled(10) {
             self.fullscreen = !self.fullscreen;
@@ -272,19 +250,13 @@ impl Scene for DemoScene {
     }
 
     fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
-        let (sw, sh) = engine.window_size();
+        let (_sw, sh) = engine.window_size();
         let hh = sh as f32 / 2.0;
         let atlas = engine.font_atlas();
         frame.clear_color = Color::from_rgba8(20, 20, 35, 255);
 
         let canvas = frame.canvas(0);
-
-        let mut ui = Ui::new(-180.0, hh - 40.0, 360.0, (sw, sh))
-            .with_focus(self.focus)
-            .with_dragging(self.dragging);
-        self.build_widgets(&mut ui);
-
-        ui.render(canvas, atlas);
+        self.ui.render(canvas, atlas);
 
         let mouse = engine.mouse_screen_pos();
         canvas.text_aligned(
@@ -310,28 +282,34 @@ impl Scene for DemoScene {
 }
 
 struct LayoutScene {
-    focus: usize,
+    ui: Ui,
 }
 
 impl LayoutScene {
     fn new() -> Self {
-        Self { focus: 0 }
+        Self { ui: Ui::default() }
     }
 
-    fn build_widgets(&self, ui: &mut Ui) {
+    fn build_widgets(ui: &mut Ui) {
         ui.label_centered("Layout Demo", 24.0, Color::WHITE);
         ui.separator(8.0);
 
-        // Row: two buttons side by side
-        ui.label("Row (2 buttons):", 14.0, Color::from_rgba8(180, 200, 255, 255));
+        ui.label(
+            "Row (2 buttons):",
+            14.0,
+            Color::from_rgba8(180, 200, 255, 255),
+        );
         ui.row(2);
         ui.button(0, "Left");
         ui.button(1, "Right");
 
         ui.separator(6.0);
 
-        // Row with spacing: three buttons
-        ui.label("Row spaced (3 buttons):", 14.0, Color::from_rgba8(180, 200, 255, 255));
+        ui.label(
+            "Row spaced (3 buttons):",
+            14.0,
+            Color::from_rgba8(180, 200, 255, 255),
+        );
         ui.row_spaced(8.0, 3);
         ui.button(2, "A");
         ui.button(3, "B");
@@ -339,7 +317,6 @@ impl LayoutScene {
 
         ui.separator(6.0);
 
-        // Grid: 2 columns, 4 items
         ui.label("Grid 2x2:", 14.0, Color::from_rgba8(180, 200, 255, 255));
         ui.grid_spaced(2, 4.0, 4);
         ui.button(5, "One");
@@ -349,8 +326,11 @@ impl LayoutScene {
 
         ui.separator(6.0);
 
-        // Grid: 3 columns, 5 items (last row partial)
-        ui.label("Grid 3-col (5 items):", 14.0, Color::from_rgba8(180, 200, 255, 255));
+        ui.label(
+            "Grid 3-col (5 items):",
+            14.0,
+            Color::from_rgba8(180, 200, 255, 255),
+        );
         ui.grid_spaced(3, 4.0, 5);
         ui.button(9, "1");
         ui.button(10, "2");
@@ -367,17 +347,13 @@ impl Scene for LayoutScene {
     fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (sw, sh) = engine.window_size();
-        let atlas = engine.font_atlas();
+        let (_sw, sh) = engine.window_size();
         let hh = sh as f32 / 2.0;
+        let atlas = engine.font_atlas();
 
-        let mut ui = Ui::new(-200.0, hh - 30.0, 400.0, (sw, sh)).with_focus(self.focus);
-        self.build_widgets(&mut ui);
-
-        let response = ui.update(engine.input(), atlas);
-        if let Some(f) = response.focused {
-            self.focus = f;
-        }
+        self.ui.begin(-200.0, hh - 30.0, 400.0);
+        Self::build_widgets(&mut self.ui);
+        let response = self.ui.update(engine.input(), atlas);
 
         if response.was_activated(99) || engine.input().is_key_pressed(KeyCode::Escape) {
             return SceneOp::Pop;
@@ -387,17 +363,13 @@ impl Scene for LayoutScene {
     }
 
     fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
-        let (sw, sh) = engine.window_size();
+        let (_sw, sh) = engine.window_size();
         let hh = sh as f32 / 2.0;
         let atlas = engine.font_atlas();
         frame.clear_color = Color::from_rgba8(25, 20, 35, 255);
 
         let canvas = frame.canvas(0);
-
-        let mut ui = Ui::new(-200.0, hh - 30.0, 400.0, (sw, sh)).with_focus(self.focus);
-        self.build_widgets(&mut ui);
-
-        ui.render(canvas, atlas);
+        self.ui.render(canvas, atlas);
 
         canvas.text_aligned(
             0.0,
@@ -412,24 +384,28 @@ impl Scene for LayoutScene {
 }
 
 struct ScrollScene {
-    focus: usize,
+    ui: Ui,
     scroll_offset: f32,
 }
 
 impl ScrollScene {
     fn new() -> Self {
         Self {
-            focus: 0,
+            ui: Ui::default(),
             scroll_offset: 0.0,
         }
     }
 
-    fn build_widgets(&self, ui: &mut Ui) {
+    fn build_widgets(ui: &mut Ui, scroll_offset: f32) {
         ui.label_centered("Scroll Demo", 24.0, Color::WHITE);
         ui.separator(8.0);
 
-        ui.label("Scrollable list:", 14.0, Color::from_rgba8(180, 200, 255, 255));
-        ui.scroll(100, 150.0, self.scroll_offset, 10);
+        ui.label(
+            "Scrollable list:",
+            14.0,
+            Color::from_rgba8(180, 200, 255, 255),
+        );
+        ui.scroll(100, 150.0, scroll_offset, 10);
         ui.button(10, "Item 1");
         ui.button(11, "Item 2");
         ui.button(12, "Item 3");
@@ -450,17 +426,13 @@ impl Scene for ScrollScene {
     fn on_enter(&mut self, _engine: &mut Engine, _globals: &mut Globals) {}
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (sw, sh) = engine.window_size();
-        let atlas = engine.font_atlas();
+        let (_sw, sh) = engine.window_size();
         let hh = sh as f32 / 2.0;
+        let atlas = engine.font_atlas();
 
-        let mut ui = Ui::new(-200.0, hh - 30.0, 400.0, (sw, sh)).with_focus(self.focus);
-        self.build_widgets(&mut ui);
-
-        let response = ui.update(engine.input(), atlas);
-        if let Some(f) = response.focused {
-            self.focus = f;
-        }
+        self.ui.begin(-200.0, hh - 30.0, 400.0);
+        Self::build_widgets(&mut self.ui, self.scroll_offset);
+        let response = self.ui.update(engine.input(), atlas);
 
         if let Some(offset) = response.scroll_for(100) {
             self.scroll_offset = offset;
@@ -474,17 +446,13 @@ impl Scene for ScrollScene {
     }
 
     fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
-        let (sw, sh) = engine.window_size();
+        let (_sw, sh) = engine.window_size();
         let hh = sh as f32 / 2.0;
         let atlas = engine.font_atlas();
         frame.clear_color = Color::from_rgba8(25, 20, 35, 255);
 
         let canvas = frame.canvas(0);
-
-        let mut ui = Ui::new(-200.0, hh - 30.0, 400.0, (sw, sh)).with_focus(self.focus);
-        self.build_widgets(&mut ui);
-
-        ui.render(canvas, atlas);
+        self.ui.render(canvas, atlas);
 
         canvas.text_aligned(
             0.0,
@@ -515,7 +483,7 @@ impl Scene for GameScene {
         self.time += engine.dt();
         if engine.input().is_key_pressed(KeyCode::Escape) {
             return SceneOp::Switch(Box::new(MenuScene {
-                focus: 0,
+                ui: Ui::default(),
                 message: String::new(),
             }));
         }
@@ -566,7 +534,7 @@ fn main() {
     };
     let _ = rengine::run_with_scenes(config, |_engine, _globals| -> Box<dyn Scene> {
         Box::new(MenuScene {
-            focus: 0,
+            ui: Ui::default(),
             message: String::new(),
         })
     });

--- a/samples/games/game-everything/src/countdown.rs
+++ b/samples/games/game-everything/src/countdown.rs
@@ -1,5 +1,5 @@
-use rengine::*;
 use crate::game::GameScene;
+use rengine::*;
 
 pub struct CountdownScene {
     timer: f32,

--- a/samples/games/game-everything/src/game.rs
+++ b/samples/games/game-everything/src/game.rs
@@ -579,7 +579,6 @@ impl Scene for GameScene {
                         println!("[GameScene] demo: pushing PauseOverlay at frame {f}");
                         return SceneOp::Push(Box::new(PauseOverlay {
                             demo_frames: 0,
-                            focus: 0,
                             ui: Ui::default(),
                         }));
                     }
@@ -649,7 +648,6 @@ impl Scene for GameScene {
             if engine.action_pressed("pause") {
                 return SceneOp::Push(Box::new(PauseOverlay {
                     demo_frames: 0,
-                    focus: 0,
                     ui: Ui::default(),
                 }));
             }

--- a/samples/games/game-everything/src/game.rs
+++ b/samples/games/game-everything/src/game.rs
@@ -1,6 +1,6 @@
-use rengine::*;
 use crate::pause::PauseOverlay;
 use crate::state::*;
+use rengine::*;
 
 pub struct GameScene {
     config: Option<GameConfig>,
@@ -580,6 +580,7 @@ impl Scene for GameScene {
                         return SceneOp::Push(Box::new(PauseOverlay {
                             demo_frames: 0,
                             focus: 0,
+                            ui: Ui::default(),
                         }));
                     }
                     if prev < 500 && f >= 500 {
@@ -649,6 +650,7 @@ impl Scene for GameScene {
                 return SceneOp::Push(Box::new(PauseOverlay {
                     demo_frames: 0,
                     focus: 0,
+                    ui: Ui::default(),
                 }));
             }
         }

--- a/samples/games/game-everything/src/pause.rs
+++ b/samples/games/game-everything/src/pause.rs
@@ -4,6 +4,7 @@ use rengine::*;
 pub struct PauseOverlay {
     pub demo_frames: u32,
     pub focus: usize,
+    pub ui: Ui,
 }
 
 impl PauseOverlay {
@@ -42,13 +43,13 @@ impl Scene for PauseOverlay {
             return SceneOp::Continue;
         }
 
-        let (sw, sh) = engine.window_size();
+        let (_sw, sh) = engine.window_size();
         let hh = sh as f32 / 2.0;
         let atlas = engine.font_atlas();
 
-        let mut ui = Ui::new(-100.0, hh - 40.0, 200.0, (sw, sh)).with_focus(self.focus);
-        Self::build_pause_ui(&mut ui);
-        let resp = ui.update(engine.input(), atlas);
+        self.ui.begin(-100.0, hh - 40.0, 200.0);
+        Self::build_pause_ui(&mut self.ui);
+        let resp = self.ui.update(engine.input(), atlas);
         self.focus = resp.focused.unwrap_or(self.focus);
 
         if let Some(id) = resp.activated {
@@ -80,9 +81,7 @@ impl Scene for PauseOverlay {
             Color::new(0.0, 0.0, 0.0, 0.65),
         );
 
-        let mut ui = Ui::new(-100.0, hh - 40.0, 200.0, (sw, sh)).with_focus(self.focus);
-        Self::build_pause_ui(&mut ui);
-        ui.render(overlay, atlas);
+        self.ui.render(overlay, atlas);
 
         if let Some(stats) = globals.get::<PlayerStats>() {
             overlay.text(

--- a/samples/games/game-everything/src/pause.rs
+++ b/samples/games/game-everything/src/pause.rs
@@ -3,7 +3,6 @@ use rengine::*;
 
 pub struct PauseOverlay {
     pub demo_frames: u32,
-    pub focus: usize,
     pub ui: Ui,
 }
 
@@ -17,7 +16,7 @@ impl PauseOverlay {
 }
 
 impl Scene for PauseOverlay {
-    fn on_enter(&mut self, _engine: &mut Engine, globals: &mut Globals) {
+    fn on_enter(&mut self, engine: &mut Engine, globals: &mut Globals) {
         if let Some(counter) = globals.get_mut::<TransitionCounter>() {
             counter.0 += 1;
         }
@@ -26,9 +25,19 @@ impl Scene for PauseOverlay {
             demo.log_feature("Scene::on_enter");
             demo.log_feature("Ui (widget system)");
         }
+        let (_sw, sh) = engine.window_size();
+        let hh = sh as f32 / 2.0;
+        self.ui.begin(-100.0, hh - 40.0, 200.0);
+        Self::build_pause_ui(&mut self.ui);
     }
 
     fn update(&mut self, engine: &Engine, globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
+        let (_sw, sh) = engine.window_size();
+        let hh = sh as f32 / 2.0;
+
+        self.ui.begin(-100.0, hh - 40.0, 200.0);
+        Self::build_pause_ui(&mut self.ui);
+
         let is_demo = globals.get::<DemoConfig>().map_or(false, |d| d.enabled);
 
         if is_demo {
@@ -43,14 +52,8 @@ impl Scene for PauseOverlay {
             return SceneOp::Continue;
         }
 
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
         let atlas = engine.font_atlas();
-
-        self.ui.begin(-100.0, hh - 40.0, 200.0);
-        Self::build_pause_ui(&mut self.ui);
         let resp = self.ui.update(engine.input(), atlas);
-        self.focus = resp.focused.unwrap_or(self.focus);
 
         if let Some(id) = resp.activated {
             match id {

--- a/samples/games/game-everything/src/title.rs
+++ b/samples/games/game-everything/src/title.rs
@@ -1,6 +1,6 @@
-use rengine::*;
 use crate::game::GameScene;
 use crate::state::*;
+use rengine::*;
 
 pub struct TitleScene {
     blink_timer: f32,

--- a/samples/games/game-fight/src/bot.rs
+++ b/samples/games/game-fight/src/bot.rs
@@ -92,10 +92,8 @@ mod tests {
     #[test]
     fn save_load_determinism() {
         let mut sim_base = FightSim::new();
-        let mut all_inputs: Vec<[FightInput; 2]> =
-            Vec::with_capacity(SIXTY_SECONDS as usize);
-        let mut baseline_checksums: Vec<u64> =
-            Vec::with_capacity(SIXTY_SECONDS as usize);
+        let mut all_inputs: Vec<[FightInput; 2]> = Vec::with_capacity(SIXTY_SECONDS as usize);
+        let mut baseline_checksums: Vec<u64> = Vec::with_capacity(SIXTY_SECONDS as usize);
 
         for f in 0..SIXTY_SECONDS {
             let inputs = bot_inputs(&sim_base, f);
@@ -124,10 +122,8 @@ mod tests {
     #[test]
     fn rollback_packet_loss_determinism() {
         let mut sim_base = FightSim::new();
-        let mut all_inputs: Vec<[FightInput; 2]> =
-            Vec::with_capacity(SIXTY_SECONDS as usize);
-        let mut baseline_checksums: Vec<u64> =
-            Vec::with_capacity(SIXTY_SECONDS as usize);
+        let mut all_inputs: Vec<[FightInput; 2]> = Vec::with_capacity(SIXTY_SECONDS as usize);
+        let mut baseline_checksums: Vec<u64> = Vec::with_capacity(SIXTY_SECONDS as usize);
 
         for f in 0..SIXTY_SECONDS {
             let inputs = bot_inputs(&sim_base, f);

--- a/samples/games/game-fight/src/main.rs
+++ b/samples/games/game-fight/src/main.rs
@@ -50,8 +50,28 @@ impl Game for FightGame {
 
         let actions = engine.actions_mut();
         for (prefix, keys) in [
-            ("p1", [KeyCode::KeyA, KeyCode::KeyD, KeyCode::KeyW, KeyCode::KeyS, KeyCode::KeyF, KeyCode::KeyG]),
-            ("p2", [KeyCode::ArrowLeft, KeyCode::ArrowRight, KeyCode::ArrowUp, KeyCode::ArrowDown, KeyCode::KeyK, KeyCode::KeyL]),
+            (
+                "p1",
+                [
+                    KeyCode::KeyA,
+                    KeyCode::KeyD,
+                    KeyCode::KeyW,
+                    KeyCode::KeyS,
+                    KeyCode::KeyF,
+                    KeyCode::KeyG,
+                ],
+            ),
+            (
+                "p2",
+                [
+                    KeyCode::ArrowLeft,
+                    KeyCode::ArrowRight,
+                    KeyCode::ArrowUp,
+                    KeyCode::ArrowDown,
+                    KeyCode::KeyK,
+                    KeyCode::KeyL,
+                ],
+            ),
         ] {
             actions.bind_axis(
                 &format!("{prefix}_move_x"),
@@ -70,13 +90,25 @@ impl Game for FightGame {
                 },
             );
             actions.bind(&format!("{prefix}_jump"), Binding::Key(keys[2]));
-            actions.bind(&format!("{prefix}_jump"), Binding::GamepadButton(GamepadButton::DPadUp));
+            actions.bind(
+                &format!("{prefix}_jump"),
+                Binding::GamepadButton(GamepadButton::DPadUp),
+            );
             actions.bind(&format!("{prefix}_crouch"), Binding::Key(keys[3]));
-            actions.bind(&format!("{prefix}_crouch"), Binding::GamepadButton(GamepadButton::DPadDown));
+            actions.bind(
+                &format!("{prefix}_crouch"),
+                Binding::GamepadButton(GamepadButton::DPadDown),
+            );
             actions.bind(&format!("{prefix}_punch"), Binding::Key(keys[4]));
-            actions.bind(&format!("{prefix}_punch"), Binding::GamepadButton(GamepadButton::South));
+            actions.bind(
+                &format!("{prefix}_punch"),
+                Binding::GamepadButton(GamepadButton::South),
+            );
             actions.bind(&format!("{prefix}_kick"), Binding::Key(keys[5]));
-            actions.bind(&format!("{prefix}_kick"), Binding::GamepadButton(GamepadButton::West));
+            actions.bind(
+                &format!("{prefix}_kick"),
+                Binding::GamepadButton(GamepadButton::West),
+            );
         }
 
         let blue_sheet = engine
@@ -203,7 +235,10 @@ impl Game for FightGame {
             if prev_round_pause <= 0.0 && self.sim.round_pause > 0.0 {
                 engine.pause_music();
                 let _ = engine.play_sound_on_bus(AudioBus::Ui, &self.hit_sfx, 0.55);
-            } else if prev_round_pause > 0.0 && self.sim.round_pause <= 0.0 && self.sim.winner().is_none() {
+            } else if prev_round_pause > 0.0
+                && self.sim.round_pause <= 0.0
+                && self.sim.winner().is_none()
+            {
                 engine.resume_music();
             }
         }

--- a/samples/games/game-fight/src/render.rs
+++ b/samples/games/game-fight/src/render.rs
@@ -225,13 +225,7 @@ fn draw_hud(game: &FightGame, hud: &mut Canvas, atlas: &FontAtlas) {
     );
     let p2_fill = (game.sim.p2.hp.max(0) as f32 / MAX_HP as f32) * bar_w;
     let p2_color = hp_color(game.sim.p2.hp);
-    hud.rect(
-        p2_bar_x + bar_w - p2_fill,
-        bar_y,
-        p2_fill,
-        bar_h,
-        p2_color,
-    );
+    hud.rect(p2_bar_x + bar_w - p2_fill, bar_y, p2_fill, bar_h, p2_color);
 
     hud.text(
         p1_bar_x,

--- a/samples/games/game-fps-mp/src/main.rs
+++ b/samples/games/game-fps-mp/src/main.rs
@@ -9,7 +9,7 @@ use rengine::{
     Engine3D, EngineConfig, Frame3D, Game3D, OnlineConfig, RollbackConfig, RollbackSession,
     SessionMode,
 };
-use state::{FpsMpGame, FpsInput, FpsSim};
+use state::{FpsInput, FpsMpGame, FpsSim};
 
 pub const MOVE_SPEED: f32 = 6.0;
 pub const MOUSE_SENSITIVITY: f32 = 0.002;
@@ -35,8 +35,7 @@ impl Game3D for FpsMpGame {
         let port: u16 = arg_value("--port")
             .and_then(|p| p.parse().ok())
             .unwrap_or(7000);
-        let remote: String =
-            arg_value("--remote").unwrap_or_else(|| "127.0.0.1:7001".to_string());
+        let remote: String = arg_value("--remote").unwrap_or_else(|| "127.0.0.1:7001".to_string());
         let player: usize = arg_value("--player")
             .and_then(|p| p.parse().ok())
             .unwrap_or(0);

--- a/samples/games/game-fps-mp/src/render.rs
+++ b/samples/games/game-fps-mp/src/render.rs
@@ -45,20 +45,8 @@ pub fn draw(game: &FpsMpGame, engine: &Engine3D, frame: &mut Frame3D) {
     let size = 10.0_f32;
     let thickness = 2.0_f32;
     let crosshair = frame.canvas(0);
-    crosshair.rect(
-        -size,
-        -thickness / 2.0,
-        size * 2.0,
-        thickness,
-        Color::WHITE,
-    );
-    crosshair.rect(
-        -thickness / 2.0,
-        -size,
-        thickness,
-        size * 2.0,
-        Color::WHITE,
-    );
+    crosshair.rect(-size, -thickness / 2.0, size * 2.0, thickness, Color::WHITE);
+    crosshair.rect(-thickness / 2.0, -size, thickness, size * 2.0, Color::WHITE);
 
     let hp_frac = player.hp.max(0) as f32 / crate::MAX_HP as f32;
     let bar_w = 200.0_f32;

--- a/samples/games/game-fps/src/input.rs
+++ b/samples/games/game-fps/src/input.rs
@@ -21,10 +21,18 @@ pub fn move_dir(engine: &Engine3D, yaw: f32) -> Vec3 {
     let right = Vec3::new(yaw.cos(), 0.0, yaw.sin()).normalize();
 
     let mut dir = Vec3::ZERO;
-    if input.is_key_down(KeyCode::KeyW) { dir += forward; }
-    if input.is_key_down(KeyCode::KeyS) { dir -= forward; }
-    if input.is_key_down(KeyCode::KeyD) { dir += right; }
-    if input.is_key_down(KeyCode::KeyA) { dir -= right; }
+    if input.is_key_down(KeyCode::KeyW) {
+        dir += forward;
+    }
+    if input.is_key_down(KeyCode::KeyS) {
+        dir -= forward;
+    }
+    if input.is_key_down(KeyCode::KeyD) {
+        dir += right;
+    }
+    if input.is_key_down(KeyCode::KeyA) {
+        dir -= right;
+    }
 
     if dir.length_squared() > 0.0 {
         dir = dir.normalize();

--- a/samples/games/game-iso/src/main.rs
+++ b/samples/games/game-iso/src/main.rs
@@ -36,10 +36,7 @@ impl Game for IsoGame {
                     Binding::Key(KeyCode::KeyS),
                     Binding::Key(KeyCode::ArrowDown),
                 ],
-                negative: vec![
-                    Binding::Key(KeyCode::KeyW),
-                    Binding::Key(KeyCode::ArrowUp),
-                ],
+                negative: vec![Binding::Key(KeyCode::KeyW), Binding::Key(KeyCode::ArrowUp)],
                 gamepad_axis: None,
             },
         );

--- a/samples/games/game-iso/src/render.rs
+++ b/samples/games/game-iso/src/render.rs
@@ -6,8 +6,7 @@ use crate::{MAP_SIZE, TILE_H, TILE_W};
 pub fn draw(game: &IsoGame, frame: &mut Frame) {
     frame.clear_color = Color::from_rgba8(30, 30, 50, 255);
 
-    let player_screen =
-        iso_to_screen_frac(game.player_col, game.player_row, TILE_W, TILE_H);
+    let player_screen = iso_to_screen_frac(game.player_col, game.player_row, TILE_W, TILE_H);
     frame.camera.position = player_screen;
 
     for row in 0..MAP_SIZE {
@@ -41,8 +40,7 @@ pub fn draw(game: &IsoGame, frame: &mut Frame) {
         frame.draw(game.tree_tex, draw_pos, Vec2::new(32.0, 48.0));
     }
 
-    let player_screen =
-        iso_to_screen_frac(game.player_col, game.player_row, TILE_W, TILE_H);
+    let player_screen = iso_to_screen_frac(game.player_col, game.player_row, TILE_W, TILE_H);
     let draw_pos = Vec2::new(player_screen.x - 8.0, player_screen.y - 8.0);
     frame.draw(game.player_tex, draw_pos, Vec2::new(16.0, 24.0));
 }

--- a/samples/games/game-platformer/src/physics.rs
+++ b/samples/games/game-platformer/src/physics.rs
@@ -4,7 +4,6 @@ use crate::state::{Platform, Player};
 use crate::{GRAVITY, PLAYER_H, PLAYER_W};
 
 pub fn update(player: &mut Player, platforms: &[Platform], dt: f32) {
-
     player.vel.y += GRAVITY * dt;
 
     player.sprite.position += player.vel * dt;
@@ -18,11 +17,9 @@ pub fn update(player: &mut Player, platforms: &[Platform], dt: f32) {
             player.sprite.position += mtv;
 
             if mtv.y > 0.0 {
-
                 player.vel.y = 0.0;
                 player.on_ground = true;
             } else if mtv.y < 0.0 {
-
                 player.vel.y = 0.0;
             }
         }

--- a/samples/games/game-topdown/src/level.rs
+++ b/samples/games/game-topdown/src/level.rs
@@ -20,9 +20,15 @@ pub fn build(engine: &mut Engine) -> TopDown {
     let stone_uv = world_sheet.uv_rect(2, 0);
     let water_uv = world_sheet.uv_rect(3, 0);
 
-    let player_tex = assets.texture_id("player").expect("manifest missing player texture");
-    let enemy_tex = assets.texture_id("enemy").expect("manifest missing enemy texture");
-    let gem_tex = assets.texture_id("gem").expect("manifest missing gem texture");
+    let player_tex = assets
+        .texture_id("player")
+        .expect("manifest missing player texture");
+    let enemy_tex = assets
+        .texture_id("enemy")
+        .expect("manifest missing enemy texture");
+    let gem_tex = assets
+        .texture_id("gem")
+        .expect("manifest missing gem texture");
 
     let scene = engine
         .load_scene2d(&assets, "world.scene.json")

--- a/samples/games/game-topdown/src/main.rs
+++ b/samples/games/game-topdown/src/main.rs
@@ -34,10 +34,7 @@ impl Game for TopDown {
         actions.bind_axis(
             "move_y",
             AxisMapping {
-                positive: vec![
-                    Binding::Key(KeyCode::KeyW),
-                    Binding::Key(KeyCode::ArrowUp),
-                ],
+                positive: vec![Binding::Key(KeyCode::KeyW), Binding::Key(KeyCode::ArrowUp)],
                 negative: vec![
                     Binding::Key(KeyCode::KeyS),
                     Binding::Key(KeyCode::ArrowDown),

--- a/samples/games/game-topdown/src/physics.rs
+++ b/samples/games/game-topdown/src/physics.rs
@@ -5,7 +5,6 @@ use crate::state::{Enemy, TopDown};
 use crate::{MAP_H, MAP_W, PLAYER_SIZE, PLAYER_SPEED, TILE_SIZE};
 
 pub fn move_player(game: &mut TopDown, dir: Vec2, dt: f32) {
-
     game.player.pos.x += dir.x * PLAYER_SPEED * dt;
     let rect = Rect::from_pos_size(game.player.pos, Vec2::splat(PLAYER_SIZE));
     if let Some(mtv) = collide_stone(&game.tilemap, &rect) {
@@ -68,12 +67,7 @@ pub fn collide_stone(tilemap: &TileMap, rect: &Rect) -> Option<Vec2> {
                     TILE_SIZE,
                     TILE_SIZE,
                 );
-                let adj = Rect::new(
-                    rect.x + total.x,
-                    rect.y + total.y,
-                    rect.width,
-                    rect.height,
-                );
+                let adj = Rect::new(rect.x + total.x, rect.y + total.y, rect.width, rect.height);
                 if let Some(mtv) = aabb_overlap(&adj, &tile_rect) {
                     total += mtv;
                     hit = true;
@@ -82,5 +76,9 @@ pub fn collide_stone(tilemap: &TileMap, rect: &Rect) -> Option<Vec2> {
         }
     }
 
-    if hit { Some(total) } else { None }
+    if hit {
+        Some(total)
+    } else {
+        None
+    }
 }


### PR DESCRIPTION
Add `impl Default for Ui` and `pub fn begin(&mut self, x, y, width)` so scenes can store a `Ui` field and avoid rebuilding the widget tree in both `update()` and `render()`.

**Engine changes (`ui.rs`):**
- `impl Default for Ui` — sensible defaults (position 0,0, width 200)
- `Ui::begin(x, y, width)` — resets widgets/position each frame while preserving `style`, `focus_index`, and `dragging_slider` across frames

**Sample updates:**
- `feature-ui`: all 5 UI scenes rewritten to use `ui: Ui` field + `begin()` pattern instead of double `Ui::new()` construction
- `game-everything/pause.rs`: `PauseOverlay` gains `ui: Ui` field, single-build in update, render-only in render

**Docs:**
- ARCHITECTURE.md section 6.7 updated with single-build pattern docs and code example
- ROADMAP.md item 15 marked done