### PR TITLE
UI methods take &Engine instead of individual params

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -247,6 +247,7 @@ All fields are `pub(crate)` — the game only interacts through accessor methods
 - [`engine.time()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L63) / [`engine.dt()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L67) → `&TimeState` / `f32`
 - [`engine.rng()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs) → `&mut Rng`
 - [`engine.window_size()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L70) → `(u32, u32)`
+- [`engine.half_size()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs) → `(f32, f32)` — half of window dimensions, handy for screen-edge positioning
 - [`engine.gamepad(player)`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L74) → `&GamepadState`
 - [`engine.gamepads_connected()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L78) → `usize`
 - [`engine.asset_root()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L82) / [`engine.set_asset_root()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L86)
@@ -845,29 +846,32 @@ A lightweight immediate-mode widget builder for menus, pause screens, and HUDs.
 
 **Single-build pattern:** Store a `Ui` as a field on your scene struct (implements `Default`). Each frame, call `begin()` to reset widgets, add widgets, then call `update()` in `update()` and `render()` in `render()`. Focus and slider-drag state persist automatically across frames — no manual tracking needed. When using `run_with_scenes()`, also prime the widget list in `on_enter()`: a newly pushed or switched scene is rendered before its first `update()`, so building only in `update()` would produce a one-frame blank UI.
 
+`begin()` takes `&Engine` so the Ui can resolve screen-relative positioning internally — game code never needs to call `window_size()` for UI layout. The `top` parameter is an offset from the top of the screen (0 = flush with top edge). Similarly, `update()` and `render()` take `&Engine` to access input and the font atlas, so game code doesn't pass those around.
+
 ```rust
 struct MyScene { ui: Ui }
 
 impl Scene for MyScene {
     fn on_enter(&mut self, engine: &mut Engine, ..) {
-        self.ui.begin(x, y, width);   // prime widgets for the first render
+        self.ui.begin(engine, -120.0, 80.0, 240.0); // x, top-offset, width
         self.ui.button(0, "Play");
     }
     fn update(&mut self, engine: &Engine, ..) -> SceneOp {
-        self.ui.begin(x, y, width);   // clears widgets, keeps focus/drag state
+        self.ui.begin(engine, -120.0, 80.0, 240.0);
         self.ui.button(0, "Play");
-        let resp = self.ui.update(engine.input(), atlas);
+        let resp = self.ui.update(engine);   // input + atlas handled internally
         ..
     }
-    fn render(&self, ..) {
-        self.ui.render(canvas, atlas); // just draws the last-built widget list
+    fn render(&self, engine: &Engine, .., frame: &mut Frame) {
+        let canvas = frame.canvas(0);
+        self.ui.render(canvas, engine);      // atlas handled internally
     }
 }
 ```
 
 - **`Ui::default()`** — Create a default UI context (position 0,0, width 200).
-- **`Ui::new(x, y, width, screen_size)`** — Create a UI context with explicit position and width. Prefer `Default` + `begin()`.
-- **`Ui::begin(x, y, width)`** — Reset widgets and position for the current frame. Preserves `style`, `focus_index`, and `dragging_slider` state.
+- **`Ui::begin(engine, x, top, width)`** — Reset widgets and position for the current frame. `top` is the offset from the top of the screen; the engine provides the screen height. Preserves `style`, `focus_index`, and `dragging_slider` state.
+- **`Ui::begin_at(x, y, width)`** — Same as `begin()` but with an absolute y coordinate instead of a top-offset. Use when you need raw positioning.
 - **`Ui::with_style(style) -> Self`** — Apply a custom `UiStyle` (colors, sizes, padding).
 - **`Ui::with_focus(index) -> Self`** — Override the focused button index.
 - **`Ui::label(text, size, color)`** / **`label_centered(text, size, color)`** — Static text (left-aligned or centered).
@@ -880,13 +884,13 @@ impl Scene for MyScene {
 - **`Ui::slider(id, label, value, min, max)`** — Horizontal slider. Arrow keys adjust by 5% of range; mouse drag maps x position to value.
 - **`Ui::scroll(id, height, scroll_offset, children)`** — Scrollable container. The next `children` widgets are rendered inside a clipped region of the given `height`. Content is offset vertically by `scroll_offset` (0.0 = top). Mouse wheel scrolling updates the offset, returned via `UiResponse::scroll_for(id)`. Uses Canvas `push_clip`/`pop_clip` for GPU scissor-rect clipping. Focusable rects inside the region are clipped to the visible area.
 - **`Ui::separator(height)`** — Vertical gap between widgets.
-- **`Ui::update(input, mouse_pos) -> UiResponse`** — Process keyboard/gamepad/mouse input:
+- **`Ui::update(engine) -> UiResponse`** — Process keyboard/gamepad/mouse input (fetched from engine internally):
   - Arrow Up / W → focus previous; Arrow Down / S → focus next (wraps).
   - Enter / Space → activate focused button, toggle checkbox, or confirm slider.
   - Mouse hover sets focus; mouse click activates.
   - Returns `UiResponse { focused, activated, hovered, toggled, changed_values, scroll_offsets }`.
   - Convenience: `response.was_activated(id)`, `was_toggled(id)`, `value_for(id) -> Option<f32>`, `scroll_for(id) -> Option<f32>`.
-- **`Ui::render(canvas)`** — Draw all widgets into a `Canvas` layer.
+- **`Ui::render(canvas, engine)`** — Draw all widgets into a `Canvas` layer (font atlas fetched from engine internally).
 - **`UiStyle`** — Configurable struct with fields for text, button, panel, progress bar, checkbox, and slider colors/sizes/padding.
 
 ---
@@ -1395,6 +1399,7 @@ Key API:
 
 - `engine.game_size()` — returns `(render_width, render_height)` when set, else `window_size()`
 - `engine.window_size()` — always returns the OS window dimensions
+- `engine.half_size()` — convenience `(w/2.0, h/2.0)` for screen-edge math
 - `engine.set_scale_mode(mode)` — change the scaling policy at runtime
 
 Both `Renderer` (2D) and `Renderer3D` support offscreen targets.
@@ -2076,7 +2081,7 @@ It is a 2D platformer with:
 | [`create_color_texture`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L256)                                                                                                            | `engine.create_color_texture(32, 32, Color::RED)`                                                                                   |
 | [`white_texture()`](https://github.com/justinwash/rengine/blob/master/engine/src/app.rs#L270)                                                                                                                 | `engine.white_texture()` for solid rectangles without a texture file                                                                |
 | Mouse input                                                                                                                                                                                                   | `engine.input().mouse_delta()`, `is_mouse_down(0)`, `is_mouse_pressed(1)`                                                           |
-| [`Ui`](https://github.com/justinwash/rengine/blob/master/engine/src/ui.rs)                                                                                                                                    | `let mut ui = Ui::new(x, y, w, screen); ui.button(0, "Play"); let resp = ui.update(input, atlas); ui.render(canvas, atlas);`        |
+| [`Ui`](https://github.com/justinwash/rengine/blob/master/engine/src/ui.rs)                                                                                                                                    | `ui.begin(engine, x, top, w); ui.button(0, "Play"); let resp = ui.update(engine); ui.render(canvas, engine);`                       |
 
 ---
 

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -103,6 +103,13 @@ impl Engine {
         (self.window_width, self.window_height)
     }
 
+    pub fn half_size(&self) -> (f32, f32) {
+        (
+            self.window_width as f32 / 2.0,
+            self.window_height as f32 / 2.0,
+        )
+    }
+
     pub fn game_size(&self) -> (u32, u32) {
         self.render_resolution
             .unwrap_or((self.window_width, self.window_height))
@@ -1035,6 +1042,13 @@ impl Engine3D {
     }
     pub fn window_size(&self) -> (u32, u32) {
         (self.window_width, self.window_height)
+    }
+
+    pub fn half_size(&self) -> (f32, f32) {
+        (
+            self.window_width as f32 / 2.0,
+            self.window_height as f32 / 2.0,
+        )
     }
 
     pub fn game_size(&self) -> (u32, u32) {

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -1,6 +1,6 @@
+use crate::app::Engine;
 use crate::assets::Color;
 use crate::canvas::{Canvas, TextAlign};
-use crate::input::InputState;
 use crate::text::FontAtlas;
 use winit::keyboard::KeyCode;
 
@@ -175,22 +175,18 @@ impl Default for Ui {
 }
 
 impl Ui {
-    pub fn new(x: f32, y: f32, width: f32, _screen_size: (u32, u32)) -> Self {
-        Self {
-            x,
-            y,
-            width,
-            style: UiStyle::default(),
-            widgets: Vec::new(),
-            focusable_ids: Vec::new(),
-            focus_index: 0,
-            activated: None,
-            mouse_focus: false,
-            dragging_slider: None,
-        }
+    pub fn begin(&mut self, engine: &Engine, x: f32, top: f32, width: f32) {
+        let (_, sh) = engine.window_size();
+        self.x = x;
+        self.y = (sh as f32 / 2.0) - top;
+        self.width = width;
+        self.widgets.clear();
+        self.focusable_ids.clear();
+        self.activated = None;
+        self.mouse_focus = false;
     }
 
-    pub fn begin(&mut self, x: f32, y: f32, width: f32) {
+    pub fn begin_at(&mut self, x: f32, y: f32, width: f32) {
         self.x = x;
         self.y = y;
         self.width = width;
@@ -660,7 +656,9 @@ impl Ui {
         rects
     }
 
-    pub fn update(&mut self, input: &InputState, atlas: &FontAtlas) -> UiResponse {
+    pub fn update(&mut self, engine: &Engine) -> UiResponse {
+        let input = engine.input();
+        let atlas = engine.font_atlas();
         let mut toggled = Vec::new();
         let mut changed_values = Vec::new();
         let mut hovered = None;
@@ -849,7 +847,8 @@ impl Ui {
         }
     }
 
-    pub fn render(&self, canvas: &mut Canvas, atlas: &FontAtlas) {
+    pub fn render(&self, canvas: &mut Canvas, engine: &Engine) {
+        let atlas = engine.font_atlas();
         let mut cursor_y = self.y;
         let mut base_x = self.x;
         let mut current_width = self.width;

--- a/samples/features/feature-ui/src/main.rs
+++ b/samples/features/feature-ui/src/main.rs
@@ -20,20 +20,14 @@ impl MenuScene {
 
 impl Scene for MenuScene {
     fn on_enter(&mut self, engine: &mut Engine, _globals: &mut Globals) {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        self.ui.begin(-120.0, hh - 80.0, 240.0);
+        self.ui.begin(engine, -120.0, 80.0, 240.0);
         Self::build_menu(&mut self.ui);
     }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        let atlas = engine.font_atlas();
-
-        self.ui.begin(-120.0, hh - 80.0, 240.0);
+        self.ui.begin(engine, -120.0, 80.0, 240.0);
         Self::build_menu(&mut self.ui);
-        let response = self.ui.update(engine.input(), atlas);
+        let response = self.ui.update(engine);
 
         if let Some(id) = response.activated {
             match id {
@@ -54,13 +48,12 @@ impl Scene for MenuScene {
     }
 
     fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
+        let (_, hh) = engine.half_size();
         let atlas = engine.font_atlas();
         frame.clear_color = Color::from_rgba8(25, 25, 40, 255);
 
         let canvas = frame.canvas(0);
-        self.ui.render(canvas, atlas);
+        self.ui.render(canvas, engine);
 
         if !self.message.is_empty() {
             canvas.text_aligned(
@@ -112,20 +105,14 @@ impl OptionsScene {
 impl Scene for OptionsScene {
     fn on_enter(&mut self, engine: &mut Engine, _globals: &mut Globals) {
         self.ui = Ui::default().with_style(Self::options_style());
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        self.ui.begin(-100.0, hh - 60.0, 200.0);
+        self.ui.begin(engine, -100.0, 60.0, 200.0);
         Self::build_options(&mut self.ui);
     }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        let atlas = engine.font_atlas();
-
-        self.ui.begin(-100.0, hh - 60.0, 200.0);
+        self.ui.begin(engine, -100.0, 60.0, 200.0);
         Self::build_options(&mut self.ui);
-        let response = self.ui.update(engine.input(), atlas);
+        let response = self.ui.update(engine);
 
         if let Some(id) = response.activated {
             if id == 2 {
@@ -141,16 +128,13 @@ impl Scene for OptionsScene {
     }
 
     fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
-        let (sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
+        let (hw, hh) = engine.half_size();
         let atlas = engine.font_atlas();
 
         let canvas = frame.canvas(1);
-        let fw = sw as f32;
-        let fh = sh as f32;
-        canvas.rect(-fw / 2.0, -hh, fw, fh, Color::new(0.0, 0.0, 0.0, 0.6));
+        canvas.rect(-hw, -hh, hw * 2.0, hh * 2.0, Color::new(0.0, 0.0, 0.0, 0.6));
 
-        self.ui.render(canvas, atlas);
+        self.ui.render(canvas, engine);
 
         canvas.text_aligned(
             0.0,
@@ -217,9 +201,7 @@ impl DemoScene {
 
 impl Scene for DemoScene {
     fn on_enter(&mut self, engine: &mut Engine, _globals: &mut Globals) {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        self.ui.begin(-180.0, hh - 40.0, 360.0);
+        self.ui.begin(engine, -180.0, 40.0, 360.0);
         Self::build_widgets(
             &mut self.ui,
             self.health,
@@ -232,11 +214,7 @@ impl Scene for DemoScene {
     }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        let atlas = engine.font_atlas();
-
-        self.ui.begin(-180.0, hh - 40.0, 360.0);
+        self.ui.begin(engine, -180.0, 40.0, 360.0);
         Self::build_widgets(
             &mut self.ui,
             self.health,
@@ -246,7 +224,7 @@ impl Scene for DemoScene {
             self.speed,
             self.volume,
         );
-        let response = self.ui.update(engine.input(), atlas);
+        let response = self.ui.update(engine);
 
         if response.was_toggled(10) {
             self.fullscreen = !self.fullscreen;
@@ -272,13 +250,12 @@ impl Scene for DemoScene {
     }
 
     fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
+        let (_, hh) = engine.half_size();
         let atlas = engine.font_atlas();
         frame.clear_color = Color::from_rgba8(20, 20, 35, 255);
 
         let canvas = frame.canvas(0);
-        self.ui.render(canvas, atlas);
+        self.ui.render(canvas, engine);
 
         let mouse = engine.mouse_screen_pos();
         canvas.text_aligned(
@@ -367,20 +344,14 @@ impl LayoutScene {
 
 impl Scene for LayoutScene {
     fn on_enter(&mut self, engine: &mut Engine, _globals: &mut Globals) {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        self.ui.begin(-200.0, hh - 30.0, 400.0);
+        self.ui.begin(engine, -200.0, 30.0, 400.0);
         Self::build_widgets(&mut self.ui);
     }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        let atlas = engine.font_atlas();
-
-        self.ui.begin(-200.0, hh - 30.0, 400.0);
+        self.ui.begin(engine, -200.0, 30.0, 400.0);
         Self::build_widgets(&mut self.ui);
-        let response = self.ui.update(engine.input(), atlas);
+        let response = self.ui.update(engine);
 
         if response.was_activated(99) || engine.input().is_key_pressed(KeyCode::Escape) {
             return SceneOp::Pop;
@@ -390,13 +361,12 @@ impl Scene for LayoutScene {
     }
 
     fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
+        let (_, hh) = engine.half_size();
         let atlas = engine.font_atlas();
         frame.clear_color = Color::from_rgba8(25, 20, 35, 255);
 
         let canvas = frame.canvas(0);
-        self.ui.render(canvas, atlas);
+        self.ui.render(canvas, engine);
 
         canvas.text_aligned(
             0.0,
@@ -451,20 +421,14 @@ impl ScrollScene {
 
 impl Scene for ScrollScene {
     fn on_enter(&mut self, engine: &mut Engine, _globals: &mut Globals) {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        self.ui.begin(-200.0, hh - 30.0, 400.0);
+        self.ui.begin(engine, -200.0, 30.0, 400.0);
         Self::build_widgets(&mut self.ui, self.scroll_offset);
     }
 
     fn update(&mut self, engine: &Engine, _globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        let atlas = engine.font_atlas();
-
-        self.ui.begin(-200.0, hh - 30.0, 400.0);
+        self.ui.begin(engine, -200.0, 30.0, 400.0);
         Self::build_widgets(&mut self.ui, self.scroll_offset);
-        let response = self.ui.update(engine.input(), atlas);
+        let response = self.ui.update(engine);
 
         if let Some(offset) = response.scroll_for(100) {
             self.scroll_offset = offset;
@@ -478,13 +442,12 @@ impl Scene for ScrollScene {
     }
 
     fn render(&self, engine: &Engine, _globals: &Globals, frame: &mut Frame) {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
+        let (_, hh) = engine.half_size();
         let atlas = engine.font_atlas();
         frame.clear_color = Color::from_rgba8(25, 20, 35, 255);
 
         let canvas = frame.canvas(0);
-        self.ui.render(canvas, atlas);
+        self.ui.render(canvas, engine);
 
         canvas.text_aligned(
             0.0,

--- a/samples/games/game-everything/src/pause.rs
+++ b/samples/games/game-everything/src/pause.rs
@@ -25,17 +25,12 @@ impl Scene for PauseOverlay {
             demo.log_feature("Scene::on_enter");
             demo.log_feature("Ui (widget system)");
         }
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-        self.ui.begin(-100.0, hh - 40.0, 200.0);
+        self.ui.begin(engine, -100.0, 40.0, 200.0);
         Self::build_pause_ui(&mut self.ui);
     }
 
     fn update(&mut self, engine: &Engine, globals: &mut Globals, _frame: &mut Frame) -> SceneOp {
-        let (_sw, sh) = engine.window_size();
-        let hh = sh as f32 / 2.0;
-
-        self.ui.begin(-100.0, hh - 40.0, 200.0);
+        self.ui.begin(engine, -100.0, 40.0, 200.0);
         Self::build_pause_ui(&mut self.ui);
 
         let is_demo = globals.get::<DemoConfig>().map_or(false, |d| d.enabled);
@@ -52,8 +47,7 @@ impl Scene for PauseOverlay {
             return SceneOp::Continue;
         }
 
-        let atlas = engine.font_atlas();
-        let resp = self.ui.update(engine.input(), atlas);
+        let resp = self.ui.update(engine);
 
         if let Some(id) = resp.activated {
             match id {
@@ -70,21 +64,19 @@ impl Scene for PauseOverlay {
     }
 
     fn render(&self, engine: &Engine, globals: &Globals, frame: &mut Frame) {
-        let (sw, sh) = engine.window_size();
-        let hw = sw as f32 / 2.0;
-        let hh = sh as f32 / 2.0;
+        let (hw, hh) = engine.half_size();
         let atlas = engine.font_atlas();
         let overlay = frame.canvas(1);
 
         overlay.rect(
             -hw,
             -hh,
-            sw as f32,
-            sh as f32,
+            hw * 2.0,
+            hh * 2.0,
             Color::new(0.0, 0.0, 0.0, 0.65),
         );
 
-        self.ui.render(overlay, atlas);
+        self.ui.render(overlay, engine);
 
         if let Some(stats) = globals.get::<PlayerStats>() {
             overlay.text(


### PR DESCRIPTION
## What

`Ui::begin()`, `Ui::update()`, and `Ui::render()` now take `&Engine` instead of requiring game code to extract and pass window_size, input, and font_atlas every frame.

### Engine changes

- **`begin(engine, x, top, width)`** — `top` is offset from top of screen; engine provides screen height internally. No more `let hh = sh as f32 / 2.0` boilerplate.
- **`begin_at(x, y, width)`** — absolute positioning override for cases that need raw coords.
- **`update(engine)`** — fetches input + font atlas from engine internally.
- **`render(canvas, engine)`** — fetches font atlas from engine internally.
- **`Engine::half_size()`** — convenience `(w/2.0, h/2.0)` for screen-edge positioning (useful for non-UI code like fullscreen overlay rects).
- Removed `Ui::new(x, y, width, screen_size)` — `Default + begin()` is the pattern.

### Game-side impact

Before:
```rust
let (_sw, sh) = engine.window_size();
let hh = sh as f32 / 2.0;
let atlas = engine.font_atlas();
self.ui.begin(-120.0, hh - 80.0, 240.0);
Self::build_menu(&mut self.ui);
let resp = self.ui.update(engine.input(), atlas);
// ...
self.ui.render(canvas, atlas);
```

After:
```rust
self.ui.begin(engine, -120.0, 80.0, 240.0);
Self::build_menu(&mut self.ui);
let resp = self.ui.update(engine);
// ...
self.ui.render(canvas, engine);
```

### Files changed

- `engine/src/ui.rs` — API changes
- `engine/src/app.rs` — add `half_size()` to Engine and Engine3D
- `samples/features/feature-ui/src/main.rs` — all 5 UI scenes updated
- `samples/games/game-everything/src/pause.rs` — PauseOverlay updated
- `ARCHITECTURE.md` — docs updated