### PR TITLE
Add UI container transitions and drag drop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -892,7 +892,7 @@ impl Scene for MyScene {
 ```
 
 - **`Ui::default()`** — Create a default UI context (position 0,0, width 200).
-- **`Ui::begin(engine, x, top, width)`** — Reset widgets and position for the current frame. `top` is the offset from the top of the screen; the engine provides the screen height. Preserves `style`, `focus_index`, and `dragging_slider` state.
+- **`Ui::begin(engine, x, top, width)`** — Reset widgets and position for the current frame. `top` is the offset from the top of the screen; the engine provides the screen height. Preserves `style`, `focus_index`, slider dragging, and any active drag/drop carry state across frames.
 - **`Ui::begin_at(x, y, width)`** — Same as `begin()` but with an absolute y coordinate instead of a top-offset. Use when you need raw positioning.
 - **`Ui::with_style(style) -> Self`** — Apply a custom `UiStyle` (colors, sizes, padding).
 - **`Ui::style()` / `style_mut()`** — Read or mutate the current `UiStyle` after construction. This is the main runtime path for things like tooltip delay or animation tuning.
@@ -902,9 +902,11 @@ impl Scene for MyScene {
 - **`Ui::image(texture, size)`** / **`image_colored(texture, size, color)`** / **`image_region(texture, size, uv_rect)`** — Non-interactive image widgets backed by the canvas image API. These render centered within the current layout width and participate in panels, rows, grids, and scroll regions like any other widget.
 - **`Ui::tooltip(text)`** / **`tooltip_sized(text, width)`** / **`tooltip_with(text, options)`** — Attach a tooltip to the most recently added widget. `tooltip_with()` takes a `TooltipOptions` builder for per-widget overrides like delay, fixed size, placement, animation, advanced expanded text, and custom expand triggers. Tooltips currently attach only to widgets that emit a concrete rect during render: labels, images, buttons, text inputs, panels, progress bars, checkboxes, sliders, and scroll regions.
 - **`Ui::animate_with(options)`** — Attach draw-time animation hooks to the most recently added widget. `UiAnimationOptions` exposes `with_hover()`, `with_focus()`, `with_press()`, and `with_appear()` builders, each taking a `UiAnimation` with duration, easing, offset, scale, and alpha. Hooks currently support labels, images, buttons, text inputs, progress bars, checkboxes, and sliders.
+- **`Ui::animate_container_with(id, visible, options) -> bool`** — Attach enter/exit transition hooks to the next panel, row, grid, or scroll region. The returned bool tells game code whether to keep emitting that container this frame; when `visible` flips false, the container stays alive until its exit animation reaches zero progress.
 - **`Ui::button(id, text)`** — Interactive button identified by a numeric `id`.
 - **`Ui::text_input(id, text, placeholder)`** — Single-line text field. The string is owned by game code; the widget consumes committed text plus IME preedit state from `InputState`, supports caret movement with Left/Right/Home/End, Backspace/Delete editing, placeholder text, and reports changes via `UiResponse::text_for(id)`.
 - **`Ui::text_cursor(id)`** / **`set_text_cursor(id, cursor)`** — Read or override a text field caret position from game code. This is primarily useful for sample/game-layer compositions like an on-screen keyboard that inserts text into the engine-level field.
+- **`Ui::draggable()`** / **`drop_target()`** — Mark the most recently added focusable widget as a drag source or drop target. This is the new engine-level path for card/tray reordering or slot-based menu flows without hard-coding drag semantics into individual widget types.
 - **`Ui::panel(color, padding, children)`** — Background panel that wraps the next `children` widgets with a colored rect and inward padding.
 - **`Ui::row(children)`** / **`row_spaced(spacing, children)`** — Horizontal layout container. The next `children` widgets are placed side-by-side, each getting an equal share of the available width. `row_spaced` adds horizontal gaps between columns.
 - **`Ui::grid(columns, children)`** / **`grid_spaced(columns, spacing, children)`** — Grid layout container. The next `children` widgets wrap into rows of `columns` columns. Each row's height is the tallest child in that row. `grid_spaced` adds horizontal gaps between columns.
@@ -918,9 +920,10 @@ impl Scene for MyScene {
   - Enter / Space → activate focused buttons or toggle focused checkboxes.
   - Focused text inputs consume `InputState::committed_text()`, show `InputState::ime_preedit()` during composition, and support Left/Right/Home/End plus Backspace/Delete editing.
   - Mouse hover sets focus; mouse click activates buttons, sliders, and checkboxes or focuses a text field.
-  - Returns `UiResponse { focused, activated, hovered, toggled, changed_values, changed_text, scroll_offsets }`, where `focused` is the current focusable slot index rather than a widget id.
-  - Convenience: `response.was_activated(id)`, `was_toggled(id)`, `value_for(id) -> Option<f32>`, `text_for(id) -> Option<&str>`, `scroll_for(id) -> Option<f32>`.
-- **`Ui::render(canvas, engine)`** — Draw all widgets into a `Canvas` layer (font atlas fetched from engine internally) and emit any active tooltip after the rest of the UI so it stays on top. Tooltip visibility is driven by persistent UI runtime state, which is what enables delayed popups and prevents stale tooltips from lingering after the active widget clears. Widget animation hooks also run here: render combines appear, hover, focus, and press transforms each frame, reusing persistent per-widget runtime state so animated widgets remain stable across frames, text-input carets inherit the same transforms, and tooltip hit rects follow the transformed widget.
+    - Drag/drop piggybacks on the same focusable ids as button activation: mouse press starts a drag from a marked source, mouse release drops onto a marked hovered target, and keyboard focus plus Enter/Space provides the same carry/drop loop without requiring the mouse.
+    - Returns `UiResponse { focused, activated, hovered, toggled, changed_values, changed_text, dragging, drag_target, dropped, scroll_offsets }`, where `focused` is the current focusable slot index rather than a widget id.
+    - Convenience: `response.was_activated(id)`, `was_toggled(id)`, `value_for(id) -> Option<f32>`, `text_for(id) -> Option<&str>`, `drop_for(id) -> Option<usize>`, `scroll_for(id) -> Option<f32>`.
+- **`Ui::render(canvas, engine)`** — Draw all widgets into a `Canvas` layer (font atlas fetched from engine internally) and emit any active tooltip after the rest of the UI so it stays on top. Tooltip visibility is driven by persistent UI runtime state, which is what enables delayed popups and prevents stale tooltips from lingering after the active widget clears. Widget animation hooks also run here: render combines appear, hover, focus, and press transforms each frame, reusing persistent per-widget runtime state so animated widgets remain stable across frames, text-input carets inherit the same transforms, and tooltip hit rects follow the transformed widget. Container animation hooks run here too: panels, rows, grids, and scroll regions apply their transition offset to the whole subtree until the exit runtime reaches zero.
 - **`UiStyle`** — Configurable struct with fields for text, text input, button, panel, progress bar, checkbox, slider, and tooltip colors/sizes/padding, plus default tooltip delay, placement, animation, and expand-trigger behavior.
 
 Supporting tooltip types:
@@ -934,14 +937,14 @@ Supporting animation types:
 
 - **`UiAnimation`** — Builder-style per-state transform description: `new(duration)`, `with_easing()`, `with_offset()`, `with_scale()`, `with_alpha()`.
 - **`UiAnimationOptions`** — Per-widget animation hooks: `with_hover()`, `with_focus()`, `with_press()`, `with_appear()`.
+- **`UiContainerAnimation`** — Builder-style container transition: `new(duration)`, `with_easing()`, `with_offset()`.
+- **`UiContainerAnimationOptions`** — Per-container transition hooks: `with_appear()`, `with_exit()`.
 
 ### 6.8 Remaining UI-Heavy Gaps
 
-The current UI/canvas stack is strong enough for menus, HUDs, stat panels, scrollable management screens, screen-space card art/iconography, inline hover explanations, and light widget motion, but a few gaps still matter for card-heavy management games:
+The current UI/canvas stack is strong enough for menus, HUDs, stat panels, scrollable management screens, screen-space card art/iconography, inline hover explanations, container transitions, and slot-style drag/drop flows. The main remaining omission is still intentional:
 
-- **No container-level or exit animation hooks** — `Ui::animate_with()` now covers draw-time appear, hover, focus, and press motion for labels, images, buttons, text inputs, progress bars, checkboxes, and sliders, but panels, layout containers, scroll regions, and removal transitions are still static.
 - **No built-in on-screen keyboard** — intentionally. The engine now exposes text fields, explicit focus control, and caret accessors, while layout, localization, and confirmation flow stay game-specific. `feature-text-input` demonstrates the intended layering with a sample-level gamepad-friendly keyboard built entirely from regular Ui buttons.
-- **No general drag-and-drop** — only slider dragging is built into `Ui` right now.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,6 +80,7 @@ Recently completed or partially completed:
 - Completed: screen-space images — `Canvas::image()`, `image_colored()`, and `image_region()` for textured screen-space quads, generalized canvas draw segments that switch between font atlases and texture bind groups, `Ui::image()` / `image_colored()` / `image_region()` widget support, `feature-images` sample, kitchen-sink pause overlay integration, and matching Engine3D texture helpers for HUD canvases
 - Completed: tooltip widget — `Ui::tooltip()`, `tooltip_sized()`, and `tooltip_with()` attach explanatory text to the most recently added widget, with engine-level delay, fixed or auto sizing, mouse/widget/screen placement modes, built-in fade/fade-slide animation options, Shift-or-custom-key expansion for advanced text, and a runtime-state fix so tooltips disappear cleanly when no widget is active; includes `feature-tooltips` and kitchen-sink pause overlay coverage
 - Completed: widget animation hooks — `Ui::animate_with()` attaches `UiAnimationOptions` to the most recently added widget, with reusable `UiAnimation` builders for hover, focus, press, and appear states built on top of existing `Easing` curves. Hooks currently support labels, images, buttons, text inputs, progress bars, checkboxes, and sliders, compose offset/scale/alpha at render time, keep tooltip hit rects aligned with transformed widgets, and ship with the new `feature-ui-animations` sample plus kitchen-sink pause overlay coverage
+- Completed: UI polish follow-through — `Ui::animate_container_with(id, visible, options)` now gives panels, rows, grids, and scroll regions enter/exit slide hooks that keep a container alive until its exit animation finishes, while `Ui::draggable()` / `drop_target()` attach reusable drag/drop metadata to focusable widgets and expand `UiResponse` with `drag_target`, `dropped`, and `drop_for()`. `feature-ui-animations` now demonstrates both the container transition path and drag/drop reordering flow.
 - Completed: text input widget — `InputState` now carries per-frame committed text plus persistent IME preedit state from winit text events, `Ui::text_input()` adds a single-line editable field with caret movement and placeholder rendering, `UiResponse::text_for()` reports changed strings, and `feature-text-input` demonstrates both direct keyboard entry and a game/sample-layer gamepad-friendly on-screen keyboard built from regular Ui buttons
 - Completed: animation state machines — `Animation` now supports `Loop`, `Once`, and `PingPong` playback, while `AnimationStateMachine<State, Trigger>` layers named states, trigger-driven transitions, global transitions, and one-shot completion fallthrough on top of sprite-sheet clips. Includes the new `feature-animation-state-machines` sample with car launch, cruise, brake, and spin-out states
 
@@ -561,16 +562,15 @@ Tracked against the build order. Crossed-off items are done.
 21. ~~Animation state machines — car sprite states~~ ✓
 22. ~~Rebindable controls — player key remapping~~ ✓
 
-Items 1-22 are done. Asset-manager follow-through is now done too, so UI polish follow-through is the main remaining engine gap for the motorsport management game.
+Items 1-22 are done. UI polish follow-through is now done too, so render targets and offscreen textures are the main remaining engine gap for the motorsport management game.
 
 Current priority engine issues for this game:
 
-1. UI polish follow-through — container/exit animation hooks and drag/drop are still missing if the garage or deck-building flows start needing them.
-2. Render targets and offscreen textures — useful once the management game wants composited monitors, preview panels, or richer layered presentation.
+1. Render targets and offscreen textures — useful once the management game wants composited monitors, preview panels, or richer layered presentation.
 
 Deferred rollback follow-up after those higher-priority items:
 
 - Add built-in rollback-safe support or snapshot helpers for animation state, timers/tweens, and deterministic RNG progression.
 - Keep renderer, audio, and other presentation/runtime caches outside rollback while documenting the game-owned save/load boundary more explicitly.
 
-Unless a more urgent engine bug appears, the next engine work for the motorsport game should stay focused on those three items.
+Unless a more urgent engine bug appears, the next engine work for the motorsport game should stay focused on render targets first and the deferred rollback follow-up after that.

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -57,7 +57,7 @@ pub use text::FontAtlas;
 pub use text::FontId;
 pub use ui::{
     TooltipAnimation, TooltipExpandTrigger, TooltipOptions, TooltipPlacement, Ui, UiAnimation,
-    UiAnimationOptions, UiResponse, UiStyle,
+    UiAnimationOptions, UiContainerAnimation, UiContainerAnimationOptions, UiResponse, UiStyle,
 };
 
 pub use particle::{EmitShape, EmitterConfig, ParticleEmitter, RangeF32};

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -122,6 +122,68 @@ impl UiAnimationOptions {
     }
 }
 
+#[derive(Clone, Copy)]
+pub struct UiContainerAnimation {
+    pub duration: f32,
+    pub easing: Easing,
+    pub offset: Vec2,
+}
+
+impl Default for UiContainerAnimation {
+    fn default() -> Self {
+        Self {
+            duration: 0.2,
+            easing: Easing::OutQuad,
+            offset: Vec2::ZERO,
+        }
+    }
+}
+
+impl UiContainerAnimation {
+    pub fn new(duration: f32) -> Self {
+        Self {
+            duration: duration.max(0.0),
+            ..Self::default()
+        }
+    }
+
+    pub fn with_easing(mut self, easing: Easing) -> Self {
+        self.easing = easing;
+        self
+    }
+
+    pub fn with_offset(mut self, offset: Vec2) -> Self {
+        self.offset = offset;
+        self
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct UiContainerAnimationOptions {
+    pub appear: Option<UiContainerAnimation>,
+    pub exit: Option<UiContainerAnimation>,
+}
+
+impl UiContainerAnimationOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_appear(mut self, animation: UiContainerAnimation) -> Self {
+        self.appear = Some(animation);
+        self
+    }
+
+    pub fn with_exit(mut self, animation: UiContainerAnimation) -> Self {
+        self.exit = Some(animation);
+        self
+    }
+
+    fn is_empty(self) -> bool {
+        self.appear.is_none() && self.exit.is_none()
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct TooltipOptions {
     pub max_width: Option<f32>,
@@ -347,6 +409,21 @@ struct UiAnimationSpec {
 }
 
 #[derive(Clone, Copy)]
+struct UiContainerAnimationSpec {
+    widget_index: usize,
+    id: usize,
+    visible: bool,
+    options: UiContainerAnimationOptions,
+}
+
+#[derive(Clone, Copy)]
+struct PendingContainerAnimation {
+    id: usize,
+    visible: bool,
+    options: UiContainerAnimationOptions,
+}
+
+#[derive(Clone, Copy)]
 struct UiRect {
     x: f32,
     y: f32,
@@ -382,6 +459,12 @@ struct ActiveTooltip<'a> {
 struct TooltipRuntime {
     widget_index: Option<usize>,
     elapsed: f32,
+}
+
+#[derive(Clone, Copy, Default)]
+struct ContainerAnimationRuntime {
+    progress: f32,
+    last_seen_frame: u64,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -446,6 +529,27 @@ fn widget_supports_animation(widget: &Widget) -> bool {
             | Widget::Checkbox { .. }
             | Widget::Slider { .. }
     )
+}
+
+fn widget_supports_container_animation(widget: &Widget) -> bool {
+    matches!(
+        widget,
+        Widget::Panel { .. }
+            | Widget::Row { .. }
+            | Widget::Grid { .. }
+            | Widget::ScrollRegion { .. }
+    )
+}
+
+fn widget_focus_id(widget: &Widget) -> Option<usize> {
+    match widget {
+        Widget::Button { id, .. }
+        | Widget::TextInput { id, .. }
+        | Widget::Checkbox { id, .. }
+        | Widget::Slider { id, .. }
+        | Widget::ScrollRegion { id, .. } => Some(*id),
+        _ => None,
+    }
 }
 
 fn point_visible(point: Vec2, rect: UiRect, clip_stack: &[UiRect]) -> bool {
@@ -563,6 +667,70 @@ fn apply_widget_animation(
     render_animation.offset += animation.offset * eased;
     render_animation.scale *= 1.0 + (animation.scale - 1.0) * eased;
     render_animation.alpha *= 1.0 + (animation.alpha - 1.0) * eased;
+}
+
+fn container_animation_duration(animation: Option<UiContainerAnimation>) -> f32 {
+    animation.map(|animation| animation.duration).unwrap_or(0.0)
+}
+
+fn apply_container_animation_offset(
+    offset: &mut Vec2,
+    animation: UiContainerAnimation,
+    progress: f32,
+) {
+    if progress <= 0.0 {
+        return;
+    }
+
+    let eased = animation.easing.apply(progress);
+    *offset += animation.offset * eased;
+}
+
+fn resolve_container_animation(
+    id: usize,
+    visible: bool,
+    options: UiContainerAnimationOptions,
+    animation_runtime: &RefCell<HashMap<usize, ContainerAnimationRuntime>>,
+    frame_index: u64,
+    dt: f32,
+) -> Vec2 {
+    let mut runtimes = animation_runtime.borrow_mut();
+    let runtime = runtimes.entry(id).or_default();
+    let is_new = runtime.last_seen_frame == 0 || runtime.last_seen_frame + 1 != frame_index;
+    if is_new {
+        runtime.progress = 0.0;
+    }
+    runtime.last_seen_frame = frame_index;
+
+    if visible {
+        advance_animation_progress(
+            &mut runtime.progress,
+            1.0,
+            container_animation_duration(options.appear),
+            dt,
+        );
+    } else {
+        advance_animation_progress(
+            &mut runtime.progress,
+            0.0,
+            container_animation_duration(options.exit),
+            dt,
+        );
+    }
+
+    let progress = runtime.progress;
+    drop(runtimes);
+
+    let mut offset = Vec2::ZERO;
+    if visible {
+        if let Some(animation) = options.appear {
+            apply_container_animation_offset(&mut offset, animation, 1.0 - progress);
+        }
+    } else if let Some(animation) = options.exit {
+        apply_container_animation_offset(&mut offset, animation, 1.0 - progress);
+    }
+
+    offset
 }
 
 fn resolve_widget_animation(
@@ -880,6 +1048,47 @@ fn draw_tooltip(
     canvas.pop_clip();
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn container_animation_offsets_enter_and_exit() {
+        let runtime = RefCell::new(HashMap::new());
+        let options = UiContainerAnimationOptions::new()
+            .with_appear(UiContainerAnimation::new(0.4).with_offset(Vec2::new(0.0, -24.0)))
+            .with_exit(UiContainerAnimation::new(0.4).with_offset(Vec2::new(0.0, 24.0)));
+
+        let entering = resolve_container_animation(7, true, options, &runtime, 1, 0.1);
+        assert!(entering.y < 0.0);
+
+        let settled = resolve_container_animation(7, true, options, &runtime, 2, 1.0);
+        assert_eq!(settled, Vec2::ZERO);
+
+        let exiting = resolve_container_animation(7, false, options, &runtime, 3, 0.1);
+        assert!(exiting.y > 0.0);
+    }
+
+    #[test]
+    fn drop_for_reports_matching_source() {
+        let response = UiResponse {
+            focused: None,
+            activated: None,
+            hovered: None,
+            toggled: Vec::new(),
+            changed_values: Vec::new(),
+            changed_text: Vec::new(),
+            dragging: Some(3),
+            drag_target: Some(9),
+            dropped: Some((3, 9)),
+            scroll_offsets: Vec::new(),
+        };
+
+        assert_eq!(response.drop_for(9), Some(3));
+        assert_eq!(response.drop_for(2), None);
+    }
+}
+
 pub struct UiResponse {
     pub focused: Option<usize>,
     pub activated: Option<usize>,
@@ -888,6 +1097,8 @@ pub struct UiResponse {
     pub changed_values: Vec<(usize, f32)>,
     pub changed_text: Vec<(usize, String)>,
     pub dragging: Option<usize>,
+    pub drag_target: Option<usize>,
+    pub dropped: Option<(usize, usize)>,
     pub scroll_offsets: Vec<(usize, f32)>,
 }
 
@@ -920,6 +1131,11 @@ impl UiResponse {
             .find(|(sid, _)| *sid == id)
             .map(|(_, v)| *v)
     }
+
+    pub fn drop_for(&self, target: usize) -> Option<usize> {
+        self.dropped
+            .and_then(|(source, drop_target)| (drop_target == target).then_some(source))
+    }
 }
 
 pub struct Ui {
@@ -930,13 +1146,19 @@ pub struct Ui {
     widgets: Vec<Widget>,
     tooltips: Vec<TooltipSpec>,
     animations: Vec<UiAnimationSpec>,
+    container_animations: Vec<UiContainerAnimationSpec>,
+    pending_container_animation: Option<PendingContainerAnimation>,
     focusable_ids: Vec<usize>,
+    drag_sources: HashSet<usize>,
+    drop_targets: HashSet<usize>,
     focus_index: usize,
     activated: Option<usize>,
     mouse_focus: bool,
     dragging_slider: Option<usize>,
+    active_drag: Option<usize>,
     tooltip_runtime: Cell<TooltipRuntime>,
     animation_runtime: RefCell<HashMap<WidgetRuntimeKey, WidgetAnimationRuntime>>,
+    container_animation_runtime: RefCell<HashMap<usize, ContainerAnimationRuntime>>,
     animation_frame: Cell<u64>,
     text_input_cursor: RefCell<HashMap<usize, usize>>,
 }
@@ -951,13 +1173,19 @@ impl Default for Ui {
             widgets: Vec::new(),
             tooltips: Vec::new(),
             animations: Vec::new(),
+            container_animations: Vec::new(),
+            pending_container_animation: None,
             focusable_ids: Vec::new(),
+            drag_sources: HashSet::new(),
+            drop_targets: HashSet::new(),
             focus_index: 0,
             activated: None,
             mouse_focus: false,
             dragging_slider: None,
+            active_drag: None,
             tooltip_runtime: Cell::new(TooltipRuntime::default()),
             animation_runtime: RefCell::new(HashMap::new()),
+            container_animation_runtime: RefCell::new(HashMap::new()),
             animation_frame: Cell::new(0),
             text_input_cursor: RefCell::new(HashMap::new()),
         }
@@ -975,7 +1203,11 @@ impl Ui {
         self.widgets.clear();
         self.tooltips.clear();
         self.animations.clear();
+        self.container_animations.clear();
+        self.pending_container_animation = None;
         self.focusable_ids.clear();
+        self.drag_sources.clear();
+        self.drop_targets.clear();
         self.activated = None;
         self.mouse_focus = false;
     }
@@ -989,7 +1221,11 @@ impl Ui {
         self.widgets.clear();
         self.tooltips.clear();
         self.animations.clear();
+        self.container_animations.clear();
+        self.pending_container_animation = None;
         self.focusable_ids.clear();
+        self.drag_sources.clear();
+        self.drop_targets.clear();
         self.activated = None;
         self.mouse_focus = false;
     }
@@ -1005,6 +1241,30 @@ impl Ui {
 
     pub fn style_mut(&mut self) -> &mut UiStyle {
         &mut self.style
+    }
+
+    fn push_widget(&mut self, widget: Widget) {
+        let supports_container_animation = widget_supports_container_animation(&widget);
+        self.widgets.push(widget);
+        if supports_container_animation {
+            if let (Some(widget_index), Some(pending)) = (
+                self.widgets.len().checked_sub(1),
+                self.pending_container_animation.take(),
+            ) {
+                self.container_animations.push(UiContainerAnimationSpec {
+                    widget_index,
+                    id: pending.id,
+                    visible: pending.visible,
+                    options: pending.options,
+                });
+            }
+        } else {
+            self.pending_container_animation = None;
+        }
+    }
+
+    fn last_widget_focus_id(&self) -> Option<usize> {
+        self.widgets.last().and_then(widget_focus_id)
     }
 
     fn normalize_text_cursor(&self, id: usize, cursor: usize) -> usize {
@@ -1045,11 +1305,12 @@ impl Ui {
 
     pub fn with_dragging(mut self, dragging: Option<usize>) -> Self {
         self.dragging_slider = dragging;
+        self.active_drag = dragging;
         self
     }
 
     pub fn label(&mut self, text: &str, size: f32, color: Color) {
-        self.widgets.push(Widget::Label {
+        self.push_widget(Widget::Label {
             text: text.to_string(),
             size,
             color,
@@ -1058,7 +1319,7 @@ impl Ui {
     }
 
     pub fn label_centered(&mut self, text: &str, size: f32, color: Color) {
-        self.widgets.push(Widget::Label {
+        self.push_widget(Widget::Label {
             text: text.to_string(),
             size,
             color,
@@ -1067,7 +1328,7 @@ impl Ui {
     }
 
     pub fn image(&mut self, texture: TextureId, size: Vec2) {
-        self.widgets.push(Widget::Image {
+        self.push_widget(Widget::Image {
             texture,
             size,
             color: Color::WHITE,
@@ -1076,7 +1337,7 @@ impl Ui {
     }
 
     pub fn image_colored(&mut self, texture: TextureId, size: Vec2, color: Color) {
-        self.widgets.push(Widget::Image {
+        self.push_widget(Widget::Image {
             texture,
             size,
             color,
@@ -1085,7 +1346,7 @@ impl Ui {
     }
 
     pub fn image_region(&mut self, texture: TextureId, size: Vec2, uv_rect: [f32; 4]) {
-        self.widgets.push(Widget::Image {
+        self.push_widget(Widget::Image {
             texture,
             size,
             color: Color::WHITE,
@@ -1140,9 +1401,37 @@ impl Ui {
         }
     }
 
+    pub fn animate_container_with(
+        &mut self,
+        id: usize,
+        visible: bool,
+        options: UiContainerAnimationOptions,
+    ) -> bool {
+        self.pending_container_animation = None;
+        if options.is_empty() {
+            return visible;
+        }
+
+        let progress = self
+            .container_animation_runtime
+            .borrow()
+            .get(&id)
+            .map(|runtime| runtime.progress)
+            .unwrap_or(if visible { 1.0 } else { 0.0 });
+        let should_render = visible || progress > 0.0;
+        if should_render {
+            self.pending_container_animation = Some(PendingContainerAnimation {
+                id,
+                visible,
+                options,
+            });
+        }
+        should_render
+    }
+
     pub fn button(&mut self, id: usize, text: &str) {
         self.focusable_ids.push(id);
-        self.widgets.push(Widget::Button {
+        self.push_widget(Widget::Button {
             id,
             text: text.to_string(),
         });
@@ -1150,7 +1439,7 @@ impl Ui {
 
     pub fn text_input(&mut self, id: usize, text: &str, placeholder: &str) {
         self.focusable_ids.push(id);
-        self.widgets.push(Widget::TextInput {
+        self.push_widget(Widget::TextInput {
             id,
             text: text.to_string(),
             placeholder: placeholder.to_string(),
@@ -1158,7 +1447,7 @@ impl Ui {
     }
 
     pub fn separator(&mut self, height: f32) {
-        self.widgets.push(Widget::Separator { height });
+        self.push_widget(Widget::Separator { height });
     }
 
     pub fn panel(&mut self, children: usize) {
@@ -1166,7 +1455,7 @@ impl Ui {
     }
 
     pub fn panel_colored(&mut self, color: Color, padding: f32, children: usize) {
-        self.widgets.push(Widget::Panel {
+        self.push_widget(Widget::Panel {
             color,
             padding,
             children,
@@ -1174,7 +1463,7 @@ impl Ui {
     }
 
     pub fn progress_bar(&mut self, label: &str, value: f32) {
-        self.widgets.push(Widget::ProgressBar {
+        self.push_widget(Widget::ProgressBar {
             label: label.to_string(),
             value: value.clamp(0.0, 1.0),
             color: None,
@@ -1182,7 +1471,7 @@ impl Ui {
     }
 
     pub fn progress_bar_colored(&mut self, label: &str, value: f32, fill_color: Color) {
-        self.widgets.push(Widget::ProgressBar {
+        self.push_widget(Widget::ProgressBar {
             label: label.to_string(),
             value: value.clamp(0.0, 1.0),
             color: Some(fill_color),
@@ -1191,7 +1480,7 @@ impl Ui {
 
     pub fn checkbox(&mut self, id: usize, label: &str, checked: bool) {
         self.focusable_ids.push(id);
-        self.widgets.push(Widget::Checkbox {
+        self.push_widget(Widget::Checkbox {
             id,
             label: label.to_string(),
             checked,
@@ -1200,7 +1489,7 @@ impl Ui {
 
     pub fn slider(&mut self, id: usize, label: &str, value: f32, min: f32, max: f32) {
         self.focusable_ids.push(id);
-        self.widgets.push(Widget::Slider {
+        self.push_widget(Widget::Slider {
             id,
             label: label.to_string(),
             value: value.clamp(min, max),
@@ -1210,18 +1499,18 @@ impl Ui {
     }
 
     pub fn row(&mut self, children: usize) {
-        self.widgets.push(Widget::Row {
+        self.push_widget(Widget::Row {
             spacing: self.style.spacing,
             children,
         });
     }
 
     pub fn row_spaced(&mut self, spacing: f32, children: usize) {
-        self.widgets.push(Widget::Row { spacing, children });
+        self.push_widget(Widget::Row { spacing, children });
     }
 
     pub fn grid(&mut self, columns: usize, children: usize) {
-        self.widgets.push(Widget::Grid {
+        self.push_widget(Widget::Grid {
             columns: columns.max(1),
             spacing: self.style.spacing,
             children,
@@ -1229,7 +1518,7 @@ impl Ui {
     }
 
     pub fn grid_spaced(&mut self, columns: usize, spacing: f32, children: usize) {
-        self.widgets.push(Widget::Grid {
+        self.push_widget(Widget::Grid {
             columns: columns.max(1),
             spacing,
             children,
@@ -1237,12 +1526,24 @@ impl Ui {
     }
 
     pub fn scroll(&mut self, id: usize, height: f32, scroll_offset: f32, children: usize) {
-        self.widgets.push(Widget::ScrollRegion {
+        self.push_widget(Widget::ScrollRegion {
             id,
             height,
             scroll_offset,
             children,
         });
+    }
+
+    pub fn draggable(&mut self) {
+        if let Some(id) = self.last_widget_focus_id() {
+            self.drag_sources.insert(id);
+        }
+    }
+
+    pub fn drop_target(&mut self) {
+        if let Some(id) = self.last_widget_focus_id() {
+            self.drop_targets.insert(id);
+        }
     }
 
     fn compute_widget_height(
@@ -1612,7 +1913,14 @@ impl Ui {
             .borrow_mut()
             .retain(|id, _| active_text_input_ids.contains(id));
 
+        if let Some(source) = self.active_drag {
+            if !self.drag_sources.contains(&source) {
+                self.active_drag = None;
+            }
+        }
+
         if self.focusable_ids.is_empty() {
+            self.active_drag = None;
             return UiResponse {
                 focused: None,
                 activated: None,
@@ -1621,6 +1929,8 @@ impl Ui {
                 changed_values,
                 changed_text,
                 dragging: None,
+                drag_target: None,
+                dropped: None,
                 scroll_offsets: Vec::new(),
             };
         }
@@ -1669,8 +1979,54 @@ impl Ui {
         let keyboard_activate =
             input.is_key_pressed(KeyCode::Enter) || input.is_key_pressed(KeyCode::Space);
         let mouse_activate = input.is_mouse_pressed(0) && hovered.is_some();
+        let release_drag = input.is_mouse_released(0)
+            || input.is_key_released(KeyCode::Enter)
+            || input.is_key_released(KeyCode::Space);
+        let keyboard_drag_candidate = (!self.mouse_focus && keyboard_activate)
+            .then_some(focused_id)
+            .filter(|id| self.drag_sources.contains(id));
+        let mouse_drag_candidate =
+            hovered.filter(|id| mouse_activate && self.drag_sources.contains(id));
+        let mut drag_target = self.active_drag.and_then(|_| {
+            if self.mouse_focus {
+                hovered.filter(|id| self.drop_targets.contains(id))
+            } else {
+                self.drop_targets
+                    .contains(&focused_id)
+                    .then_some(focused_id)
+            }
+        });
+        let mut dropped = None;
+        let mut started_drag = false;
 
-        if keyboard_activate || mouse_activate {
+        if let Some(source) = self.active_drag {
+            if input.is_key_pressed(KeyCode::Escape) {
+                self.active_drag = None;
+                drag_target = None;
+            } else if release_drag {
+                if let Some(target) = drag_target.filter(|target| *target != source) {
+                    dropped = Some((source, target));
+                }
+                self.active_drag = None;
+                drag_target = None;
+            }
+        }
+
+        if self.active_drag.is_none() {
+            if let Some(source) = mouse_drag_candidate.or(keyboard_drag_candidate) {
+                self.active_drag = Some(source);
+                drag_target = if self.mouse_focus {
+                    hovered.filter(|id| self.drop_targets.contains(id))
+                } else {
+                    self.drop_targets
+                        .contains(&focused_id)
+                        .then_some(focused_id)
+                };
+                started_drag = true;
+            }
+        }
+
+        if (keyboard_activate || mouse_activate) && !started_drag {
             for widget in &self.widgets {
                 match widget {
                     Widget::Checkbox { id, checked, .. } if *id == focused_id => {
@@ -1856,7 +2212,9 @@ impl Ui {
             toggled,
             changed_values,
             changed_text,
-            dragging: self.dragging_slider,
+            dragging: self.active_drag.or(self.dragging_slider),
+            drag_target,
+            dropped,
             scroll_offsets,
         }
     }
@@ -1891,6 +2249,12 @@ impl Ui {
                 animation_indices[animation.widget_index] = Some(animation.options);
             }
         }
+        let mut container_animation_indices = vec![None; self.widgets.len()];
+        for animation in &self.container_animations {
+            if animation.widget_index < container_animation_indices.len() {
+                container_animation_indices[animation.widget_index] = Some(*animation);
+            }
+        }
 
         struct RenderContainer {
             kind: u8,
@@ -1905,6 +2269,7 @@ impl Ui {
             row_start_y: f32,
             row_max_h: f32,
             scroll_height: f32,
+            offset: Vec2,
         }
         let mut stack: Vec<RenderContainer> = Vec::new();
 
@@ -1915,6 +2280,7 @@ impl Ui {
             let mut tooltip_focus_id = None;
             let tooltip = tooltip_indices[i].map(|tooltip_index| &self.tooltips[tooltip_index]);
             let animation = animation_indices[i];
+            let container_animation = container_animation_indices[i];
             let has_tooltip = tooltip.is_some();
             let has_animation = animation.is_some();
 
@@ -2282,6 +2648,18 @@ impl Ui {
                     padding,
                     children,
                 } => {
+                    let container_offset = container_animation
+                        .map(|animation| {
+                            resolve_container_animation(
+                                animation.id,
+                                animation.visible,
+                                animation.options,
+                                &self.container_animation_runtime,
+                                animation_frame,
+                                dt,
+                            )
+                        })
+                        .unwrap_or(Vec2::ZERO);
                     let total_h = {
                         let end = (i + 1 + *children).min(self.widgets.len());
                         let child_slice = &self.widgets[i + 1..end];
@@ -2301,15 +2679,15 @@ impl Ui {
                     let panel_h = total_h + *padding * 2.0;
                     if has_tooltip {
                         tooltip_rect = Some(UiRect {
-                            x: base_x,
-                            y: cursor_y - panel_h + *padding,
+                            x: base_x + container_offset.x,
+                            y: cursor_y + container_offset.y - panel_h + *padding,
                             w: current_width,
                             h: panel_h,
                         });
                     }
                     canvas.rect(
-                        base_x,
-                        cursor_y - panel_h + *padding,
+                        base_x + container_offset.x,
+                        cursor_y + container_offset.y - panel_h + *padding,
                         current_width,
                         panel_h,
                         *color,
@@ -2328,9 +2706,22 @@ impl Ui {
                         row_start_y: 0.0,
                         row_max_h: 0.0,
                         scroll_height: 0.0,
+                        offset: container_offset,
                     });
                 }
                 Widget::Row { spacing, children } => {
+                    let container_offset = container_animation
+                        .map(|animation| {
+                            resolve_container_animation(
+                                animation.id,
+                                animation.visible,
+                                animation.options,
+                                &self.container_animation_runtime,
+                                animation_frame,
+                                dt,
+                            )
+                        })
+                        .unwrap_or(Vec2::ZERO);
                     let cols = (*children).max(1);
                     let total_gap = *spacing * (cols as f32 - 1.0).max(0.0);
                     let cw = (current_width - total_gap) / cols as f32;
@@ -2344,9 +2735,10 @@ impl Ui {
                         col_count: cols,
                         col_width: cw,
                         col_spacing: *spacing,
-                        row_start_y: cursor_y,
+                        row_start_y: cursor_y + container_offset.y,
                         row_max_h: 0.0,
                         scroll_height: 0.0,
+                        offset: container_offset,
                     });
                 }
                 Widget::Grid {
@@ -2354,6 +2746,18 @@ impl Ui {
                     spacing,
                     children,
                 } => {
+                    let container_offset = container_animation
+                        .map(|animation| {
+                            resolve_container_animation(
+                                animation.id,
+                                animation.visible,
+                                animation.options,
+                                &self.container_animation_runtime,
+                                animation_frame,
+                                dt,
+                            )
+                        })
+                        .unwrap_or(Vec2::ZERO);
                     let cols = (*columns).max(1);
                     let total_gap = *spacing * (cols as f32 - 1.0).max(0.0);
                     let cw = (current_width - total_gap) / cols as f32;
@@ -2367,9 +2771,10 @@ impl Ui {
                         col_count: cols,
                         col_width: cw,
                         col_spacing: *spacing,
-                        row_start_y: cursor_y,
+                        row_start_y: cursor_y + container_offset.y,
                         row_max_h: 0.0,
                         scroll_height: 0.0,
+                        offset: container_offset,
                     });
                 }
                 Widget::ProgressBar {
@@ -2937,15 +3342,32 @@ impl Ui {
                     children,
                     ..
                 } => {
+                    let container_offset = container_animation
+                        .map(|animation| {
+                            resolve_container_animation(
+                                animation.id,
+                                animation.visible,
+                                animation.options,
+                                &self.container_animation_runtime,
+                                animation_frame,
+                                dt,
+                            )
+                        })
+                        .unwrap_or(Vec2::ZERO);
                     if has_tooltip {
                         tooltip_rect = Some(UiRect {
-                            x: base_x,
-                            y: cursor_y - *height,
+                            x: base_x + container_offset.x,
+                            y: cursor_y + container_offset.y - *height,
                             w: current_width,
                             h: *height,
                         });
                     }
-                    canvas.push_clip(base_x, cursor_y - *height, current_width, *height);
+                    canvas.push_clip(
+                        base_x + container_offset.x,
+                        cursor_y + container_offset.y - *height,
+                        current_width,
+                        *height,
+                    );
                     pending = Some(RenderContainer {
                         kind: 3,
                         saved_x: base_x,
@@ -2956,11 +3378,12 @@ impl Ui {
                         col_count: 0,
                         col_width: 0.0,
                         col_spacing: 0.0,
-                        row_start_y: cursor_y,
+                        row_start_y: cursor_y + container_offset.y,
                         row_max_h: 0.0,
                         scroll_height: *height,
+                        offset: container_offset,
                     });
-                    cursor_y += *scroll_offset;
+                    cursor_y += container_offset.y + *scroll_offset;
                 }
             }
 
@@ -3000,7 +3423,7 @@ impl Ui {
                             cont.row_max_h = 0.0;
                             cont.col_index = 0;
                             cont.row_start_y = cursor_y;
-                            base_x = cont.saved_x;
+                            base_x = cont.saved_x + cont.offset.x;
                             current_width = cont.col_width;
                         } else {
                             cursor_y = cont.row_start_y;
@@ -3018,6 +3441,7 @@ impl Ui {
                 let cont = stack.remove(si);
                 match cont.kind {
                     0 => {
+                        cursor_y -= cont.offset.y;
                         cursor_y -= cont.padding;
                         base_x = cont.saved_x;
                         current_width = cont.saved_width;
@@ -3026,12 +3450,13 @@ impl Ui {
                     3 => {
                         canvas.pop_clip();
                         clip_stack.pop();
-                        cursor_y = cont.row_start_y - cont.scroll_height;
+                        cursor_y = cont.row_start_y - cont.scroll_height - cont.offset.y;
                         base_x = cont.saved_x;
                         current_width = cont.saved_width;
                         cursor_y -= self.style.spacing;
                     }
                     _ => {
+                        cursor_y -= cont.offset.y;
                         base_x = cont.saved_x;
                         current_width = cont.saved_width;
                         cursor_y -= self.style.spacing;
@@ -3042,19 +3467,21 @@ impl Ui {
             if let Some(mut cont) = pending {
                 match cont.kind {
                     0 => {
+                        cursor_y += cont.offset.y;
                         cursor_y -= cont.padding;
                         let pad = cont.padding;
                         let old_x = base_x;
                         let old_w = current_width;
-                        base_x += pad;
+                        base_x += cont.offset.x + pad;
                         current_width -= pad * 2.0;
                         cont.saved_x = old_x;
                         cont.saved_width = old_w;
                         stack.push(cont);
                     }
                     3 => {
+                        base_x += cont.offset.x;
                         clip_stack.push(UiRect {
-                            x: cont.saved_x,
+                            x: cont.saved_x + cont.offset.x,
                             y: cont.row_start_y - cont.scroll_height,
                             w: cont.saved_width,
                             h: cont.scroll_height,
@@ -3063,7 +3490,7 @@ impl Ui {
                     }
                     _ => {
                         cont.row_start_y = cursor_y;
-                        base_x = cont.saved_x;
+                        base_x = cont.saved_x + cont.offset.x;
                         current_width = cont.col_width;
                         stack.push(cont);
                     }
@@ -3076,6 +3503,11 @@ impl Ui {
         self.animation_runtime
             .borrow_mut()
             .retain(|_, runtime| runtime.last_seen_frame == animation_frame);
+        self.container_animation_runtime
+            .borrow_mut()
+            .retain(|_, runtime| {
+                runtime.last_seen_frame == animation_frame || runtime.progress > 0.0
+            });
 
         let mut runtime = self.tooltip_runtime.get();
         if let Some(tooltip) = hovered_tooltip.or(focused_tooltip) {

--- a/samples/features/feature-ui-animations/src/main.rs
+++ b/samples/features/feature-ui-animations/src/main.rs
@@ -7,7 +7,9 @@ struct UiAnimationDemo {
     tire_grip: f32,
     aggressive_undercut: bool,
     brake_bias: f32,
-    note: &'static str,
+    show_strategy_tray: bool,
+    pit_call_order: [usize; 3],
+    note: String,
 }
 
 impl UiAnimationDemo {
@@ -65,6 +67,21 @@ impl UiAnimationDemo {
             .with_easing(Easing::OutQuad)
             .with_scale(0.96)
             .with_alpha(0.9)
+    }
+
+    fn container_slide(offset_y: f32) -> UiContainerAnimation {
+        UiContainerAnimation::new(0.26)
+            .with_easing(Easing::OutQuad)
+            .with_offset(Vec2::new(0.0, offset_y))
+    }
+
+    fn pit_call_label(id: usize) -> &'static str {
+        match id {
+            10 => "Soft Start",
+            11 => "Cover Undercut",
+            12 => "Late Fuel Save",
+            _ => "Unknown Call",
+        }
     }
 
     fn build_ui(&mut self, engine: &Engine) {
@@ -135,6 +152,49 @@ impl UiAnimationDemo {
         );
         self.ui.button(4, "Swap Note");
         self.ui.animate_with(button_animation);
+
+        self.ui.separator(12.0);
+        self.ui.button(
+            5,
+            if self.show_strategy_tray {
+                "Hide Strategy Tray"
+            } else {
+                "Show Strategy Tray"
+            },
+        );
+        self.ui.animate_with(button_animation);
+        self.ui.tooltip(
+            "Container transitions keep a full panel alive while it slides out, instead of forcing game code to special-case the exit frame.",
+        );
+
+        if self.ui.animate_container_with(
+            200,
+            self.show_strategy_tray,
+            UiContainerAnimationOptions::new()
+                .with_appear(Self::container_slide(-28.0))
+                .with_exit(Self::container_slide(28.0)),
+        ) {
+            self.ui.panel(7);
+            self.ui
+                .label_centered("Strategy Tray", 18.0, Color::from_rgba8(220, 220, 240, 255));
+            self.ui.label_centered(
+                "Drag a call onto another call to reorder the tray.",
+                12.0,
+                Color::from_rgba8(165, 174, 196, 255),
+            );
+            self.ui.row_spaced(10.0, 3);
+            for id in self.pit_call_order {
+                self.ui.button(id, Self::pit_call_label(id));
+                self.ui.animate_with(button_animation);
+                self.ui.draggable();
+                self.ui.drop_target();
+            }
+            self.ui.label_centered(
+                "Mouse drag works directly; keyboard focus plus Enter/Space also carries a call between targets.",
+                11.0,
+                Color::from_rgba8(132, 142, 160, 255),
+            );
+        }
     }
 }
 
@@ -147,8 +207,11 @@ impl Game for UiAnimationDemo {
             tire_grip: 0.64,
             aggressive_undercut: false,
             brake_bias: 54.5,
+            show_strategy_tray: true,
+            pit_call_order: [10, 11, 12],
             note:
-                "Hover the badge and bars, then use arrow keys plus Enter on the focusable widgets.",
+                "Hover the badge and bars, then use arrow keys plus Enter on the focusable widgets."
+                    .into(),
         }
     }
 
@@ -162,7 +225,8 @@ impl Game for UiAnimationDemo {
                 "Focus and press hooks make keyboard-first flows feel less dead in management menus."
             } else {
                 "Hover hooks are useful even on passive readouts like badges and stat bars."
-            };
+            }
+            .into();
         }
         if let Some(value) = response.value_for(2) {
             self.brake_bias = value;
@@ -174,14 +238,38 @@ impl Game for UiAnimationDemo {
                 "Press hooks fire on mouse clicks and keyboard confirmation alike."
             } else {
                 "Appear hooks handle the first-frame slide-in without a separate tween system in game code."
-            };
+            }
+            .into();
         }
         if response.was_activated(4) {
             self.note = if self.note.contains("Hover") {
                 "Focus hooks give tabbed or d-pad navigation the same sense of motion as mouse hover."
             } else {
                 "Hover the badge and bars, then use arrow keys plus Enter on the focusable widgets."
-            };
+            }
+            .into();
+        }
+        if response.was_activated(5) {
+            self.show_strategy_tray = !self.show_strategy_tray;
+            self.note = if self.show_strategy_tray {
+                "Container transitions keep the strategy tray alive long enough to animate cleanly out and back in."
+            } else {
+                "Exit hooks now cover full containers, not just individual widgets."
+            }
+            .into();
+        }
+        if let Some((source, target)) = response.dropped {
+            if let (Some(source_index), Some(target_index)) = (
+                self.pit_call_order.iter().position(|id| *id == source),
+                self.pit_call_order.iter().position(|id| *id == target),
+            ) {
+                self.pit_call_order.swap(source_index, target_index);
+                self.note = format!(
+                    "Moved '{}' onto '{}'. Drag/drop responses are regular widget ids, so game code can remap them however it wants.",
+                    Self::pit_call_label(source),
+                    Self::pit_call_label(target),
+                );
+            }
         }
     }
 
@@ -194,7 +282,7 @@ impl Game for UiAnimationDemo {
         canvas.text_aligned(
             0.0,
             -hh + 34.0,
-            self.note,
+            &self.note,
             12.0,
             Color::from_rgba8(184, 192, 208, 255),
             TextAlign::Center,
@@ -202,7 +290,7 @@ impl Game for UiAnimationDemo {
         canvas.text_aligned(
             0.0,
             -hh + 16.0,
-            "Hover shows passive widget hooks; arrow keys plus Enter show focus and press hooks.",
+            "Hover shows passive widget hooks; the lower tray demonstrates container exit motion and drag/drop responses.",
             10.0,
             Color::from_rgba8(132, 142, 160, 255),
             TextAlign::Center,


### PR DESCRIPTION
## Summary
Add the missing UI polish hooks for container transitions and drag/drop.

## What changed
- add `UiContainerAnimation` and `UiContainerAnimationOptions`
- add `Ui::animate_container_with(id, visible, options)` for panel/row/grid/scroll enter and exit motion
- add `Ui::draggable()` and `Ui::drop_target()` plus drag/drop response fields on `UiResponse`
- expand `feature-ui-animations` to demonstrate container exit motion and tray reordering
- update ROADMAP.md and ARCHITECTURE.md for the new UI surface

## Validation
- cargo test -p rengine --lib ui::tests::container_animation_offsets_enter_and_exit
- cargo test -p rengine --lib ui::tests::drop_for_reports_matching_source
- cargo check -p rengine-feature-ui-animations
- cargo check -p rengine --all-targets --all-features