### PR TITLE
Add in-game debug overlay and console

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,6 +103,7 @@ rengine/
 │   └── src/
 │       ├── lib.rs         # public re-exports
 │       ├── app.rs         # Engine, Engine3D, Game, Game3D, run(), run3d(), scene runners
+│       ├── debug.rs       # in-game debug overlay, console, and ring-buffer logging
 │       ├── text.rs        # FontAtlas — glyph rasterization + GPU atlas
 │       ├── canvas/        # Canvas overlay: mod.rs + canvas.wgsl
 │       ├── input/         # keyboard.rs, gamepad.rs, action.rs, mod.rs
@@ -174,6 +175,7 @@ pub mod app;
 pub mod math;
 pub mod input;
 pub mod canvas;
+pub mod debug;
 pub mod renderer;
 pub mod renderer3d;
 pub mod scene;
@@ -195,6 +197,7 @@ Then selective re-exports:
 - **Scene:** [`Globals`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/globals.rs#L4), [`Prefab2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L61)/[`Prefab2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L26), [`PrefabSprite2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L50)/[`PrefabSprite2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L11), [`Scene`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L24), [`Scene2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L98)/[`Scene2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L42), [`SceneInstance2D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L67)/[`SceneInstance2DDef`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/data2d.rs#L32), [`SceneOp`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L16), [`Scene3D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L47), [`SceneOp3D`](https://github.com/justinwash/rengine/blob/master/engine/src/scene/mod.rs#L39)
 - **World:** [`tilemap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs), [`aabb_overlap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs), [`aabb_overlap_layered`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs), [`CollisionLayer`](https://github.com/justinwash/rengine/blob/master/engine/src/world/physics.rs), [`BodyId`](https://github.com/justinwash/rengine/blob/master/engine/src/world/trigger.rs), [`TriggerSystem`](https://github.com/justinwash/rengine/blob/master/engine/src/world/trigger.rs), [`TriggerZone`](https://github.com/justinwash/rengine/blob/master/engine/src/world/trigger.rs), [`TriggerZoneId`](https://github.com/justinwash/rengine/blob/master/engine/src/world/trigger.rs), [`OverlapEvent`](https://github.com/justinwash/rengine/blob/master/engine/src/world/trigger.rs), [`iso_to_screen`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L4), [`screen_to_iso`](https://github.com/justinwash/rengine/blob/master/engine/src/world/iso.rs#L11), [`TileDef`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L16), [`TileMap`](https://github.com/justinwash/rengine/blob/master/engine/src/world/tilemap.rs#L6)
 - **Canvas/Text:** [`screen_to_ndc`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L197), [`wrap_text`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L203), [`Canvas`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L49), [`CanvasVertex`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L13), [`TextAlign`](https://github.com/justinwash/rengine/blob/master/engine/src/canvas/mod.rs#L5), [`FontAtlas`](https://github.com/justinwash/rengine/blob/master/engine/src/text.rs#L17)
+- **Debug:** [`DebugLogEntry`](https://github.com/justinwash/rengine/blob/master/engine/src/debug.rs), [`DebugLogLevel`](https://github.com/justinwash/rengine/blob/master/engine/src/debug.rs), plus the public `debug` module for log capture, overlay controls, and console parsing helpers
 - **UI:** [`Ui`](https://github.com/justinwash/rengine/blob/master/engine/src/ui.rs), [`UiResponse`](https://github.com/justinwash/rengine/blob/master/engine/src/ui.rs), [`UiStyle`](https://github.com/justinwash/rengine/blob/master/engine/src/ui.rs)
 - **Pixel art:** [`pixelart`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs) (module-level re-export of [`PixelCanvas`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L3), [`darken`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L106), [`lighten`](https://github.com/justinwash/rengine/blob/master/engine/src/assets/pixelart.rs#L110))
 - **Math:** [`Rect`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rect.rs#L5), [`TimeState`](https://github.com/justinwash/rengine/blob/master/engine/src/math/time.rs#L4), [`Rng`](https://github.com/justinwash/rengine/blob/master/engine/src/math/rng.rs), [`Tween`](https://github.com/justinwash/rengine/blob/master/engine/src/math/tween.rs), [`Easing`](https://github.com/justinwash/rengine/blob/master/engine/src/math/tween.rs), [`LoopMode`](https://github.com/justinwash/rengine/blob/master/engine/src/math/tween.rs), [`ease`](https://github.com/justinwash/rengine/blob/master/engine/src/math/tween.rs), [`lerp`](https://github.com/justinwash/rengine/blob/master/engine/src/math/tween.rs), `Vec2`, `Vec3`, `Quat` (from glam)
@@ -216,12 +219,13 @@ pub struct EngineConfig {
     pub headless: bool,     // Skip window creation visibility + mute audio
     pub hot_reload: bool,   // File-watching for assets at runtime
     pub show_fps: bool,     // Render FPS counter overlay on canvas
+    pub show_debug_overlay: bool, // Start with the built-in debug overlay visible
     pub fixed_dt: f32,      // Fixed-timestep interval (default 1/60)
     pub gamepad_assign: GamepadAssignMode, // OnButtonPress (default) or OnConnect
 }
 ```
 
-Default: 800×600, no vsync, not headless, hot reload on, FPS shown, fixed_dt 1/60, gamepad assign on button press.
+Default: 800×600, no vsync, not headless, hot reload on, FPS shown, debug overlay hidden, fixed_dt 1/60, gamepad assign on button press.
 
 The `headless` flag is critical for testing:
 
@@ -243,9 +247,17 @@ pub struct Engine {
     pub(crate) window_height: u32,
     pub(crate) gamepads: GamepadSystem,   // gilrs-backed gamepad state
     pub(crate) hot_reload_enabled: bool,
+    pub(crate) debug_ui: DebugUiState,    // Built-in debug overlay + console state
     pub(crate) rng: Rng,                  // Seeded xoshiro256** PRNG
 }
 ```
+
+The engine now has a built-in debug surface shared by the 2D and 3D entry points:
+
+- `F3` toggles the overlay, `F4` / backquote toggles the console.
+- Keyboard, IME, mouse, and wheel events route through `DebugUiState` before game input, so the overlay can safely consume text entry, scrolling, and mouse clicks without leaking into gameplay input.
+- The console supports commands for overlay visibility, severity and target filtering, log follow mode, hot-reload toggling, and ad-hoc log emission.
+- `Engine` and `Engine3D` now expose helpers like `debug_overlay_visible()`, `set_debug_overlay_visible()`, `toggle_debug_console()`, `debug_logs()`, and the `log_trace` / `log_debug` / `log_info` / `log_warn` / `log_error` convenience methods.
 
 All fields are `pub(crate)` — the game only interacts through accessor methods:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,6 +86,7 @@ Recently completed or partially completed:
 - Completed: render targets and offscreen textures — the 2D renderer now exposes a public `RenderTarget` handle, `Engine::create_render_target()`, `Engine::resize_render_target()`, and `Frame::render_target()` for nested offscreen drawing into a texture that can immediately be reused as a sprite, UI image, or secondary preview surface later in the same frame. Added `feature-render-targets` as the reference sample for monitor/preview composition.
 - Completed: text input widget — `InputState` now carries per-frame committed text plus persistent IME preedit state from winit text events, `Ui::text_input()` adds a single-line editable field with caret movement and placeholder rendering, `UiResponse::text_for()` reports changed strings, and `feature-text-input` demonstrates both direct keyboard entry and a game/sample-layer gamepad-friendly on-screen keyboard built from regular Ui buttons
 - Completed: animation state machines — `Animation` now supports `Loop`, `Once`, and `PingPong` playback, while `AnimationStateMachine<State, Trigger>` layers named states, trigger-driven transitions, global transitions, and one-shot completion fallthrough on top of sprite-sheet clips. Includes the new `feature-animation-state-machines` sample with car launch, cruise, brake, and spin-out states
+- Completed: in-game debug overlay and console — the engine now ships a shared `debug` module with ring-buffer log capture, on-screen overlay stats, target and severity filters, a developer console with command parsing, mouse-accessible overlay controls, and engine-level helpers on both `Engine` and `Engine3D` for toggling the surface and writing trace/debug/info/warn/error entries
 - Completed: sample presentation polish — feature and game demos now reserve explicit header/footer space, wrap long copy, disable stray FPS overlays by default, and keep generic UI demos visually neutral unless the sample is intentionally game-specific
 
 Tooltip follow-up backlog after the current tooltip PR lands:
@@ -216,7 +217,7 @@ These features make 2D development substantially more practical.
     Collision bounds, path nodes, raycasts, contact normals, velocity vectors, and AI state overlays.
 
 35. Debug performance stats
-    Show frame time, batch count, texture binds, draw calls, and memory trends.
+    Partially done: the new in-game debug overlay now reports FPS, frame time, frame count, log volume, filter state, hot reload status, and mode-specific info, while the deeper renderer counters (batch count, texture binds, draw calls, memory trends) still need dedicated instrumentation.
 
 36. Hot reload for assets [done]
     Reload textures, shaders, and data files during development.

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -14,6 +14,7 @@ use crate::assets::{
     MeshAsset, SpriteSheet, TextureAsset,
 };
 use crate::canvas;
+use crate::debug::{self, DebugCommand, DebugLogLevel, DebugOverlayInfo, DebugUiState};
 use crate::input::{ActionMap, GamepadAssignMode, GamepadSystem, InputState};
 use crate::math::tween::Easing;
 use crate::math::{Rng, TimeState};
@@ -37,6 +38,55 @@ fn handle_ime_event(input: &mut InputState, event: Ime) {
     input.handle_ime_event(event);
 }
 
+fn route_debug_keyboard_event(input: &mut InputState, debug_ui: &mut DebugUiState, event: &KeyEvent) {
+    let consumed_text = if event.state == winit::event::ElementState::Pressed {
+        event.text
+            .as_deref()
+            .is_some_and(|text| debug_ui.handle_committed_text(text))
+    } else {
+        false
+    };
+    let consumed_key = debug_ui.handle_key_event(event);
+
+    if !consumed_text {
+        handle_text_event(input, event);
+    }
+
+    if !consumed_key {
+        if let PhysicalKey::Code(key) = event.physical_key {
+            input.handle_key_event(key, event.state);
+        }
+    }
+}
+
+fn route_debug_ime_event(input: &mut InputState, debug_ui: &mut DebugUiState, event: Ime) {
+    if !debug_ui.handle_ime_event(&event) {
+        handle_ime_event(input, event);
+    }
+}
+
+fn route_debug_scroll_event(input: &mut InputState, debug_ui: &mut DebugUiState, dx: f32, dy: f32) {
+    if !debug_ui.handle_scroll(dy) {
+        input.handle_scroll(dx, dy);
+    }
+}
+
+fn route_debug_mouse_button_event(
+    input: &mut InputState,
+    debug_ui: &mut DebugUiState,
+    window_size: (u32, u32),
+    button: usize,
+    state: winit::event::ElementState,
+) -> bool {
+    let mouse_position = input.mouse_position();
+    if debug_ui.handle_mouse_button(window_size, mouse_position, button, state) {
+        true
+    } else {
+        input.handle_mouse_button(button, state);
+        false
+    }
+}
+
 fn normalize_asset_bundle_dependencies(mut deps: Vec<PathBuf>) -> Vec<PathBuf> {
     deps.sort();
     deps.dedup();
@@ -54,6 +104,213 @@ fn evict_released_asset_paths(
         assets.unload_mesh(&path);
         assets.unload_data(&path);
         assets.unload_manifest(&path);
+    }
+}
+
+fn push_fps_overlay(
+    canvases: &mut Vec<canvas::Canvas>,
+    screen_size: (u32, u32),
+    atlas: *const text::FontAtlas,
+    fps: f32,
+) {
+    let mut fps_canvas = canvas::Canvas::new(screen_size, atlas);
+    canvas::draw_fps(&mut fps_canvas, fps);
+    canvases.push(fps_canvas);
+}
+
+fn push_debug_overlay(
+    canvases: &mut Vec<canvas::Canvas>,
+    screen_size: (u32, u32),
+    atlas: *const text::FontAtlas,
+    info: DebugOverlayInfo<'_>,
+    state: &DebugUiState,
+    mouse_position: (f32, f32),
+) {
+    let mut overlay = canvas::Canvas::new(screen_size, atlas);
+    debug::draw_overlay(&mut overlay, &info, state, Some(mouse_position));
+    debug::draw_console(&mut overlay, state);
+    canvases.push(overlay);
+}
+
+fn push_builtin_2d_overlays(frame: &mut Frame, engine: &Engine, show_fps: bool) {
+    let screen_size = engine.window_size();
+    let atlas = engine.font_atlas() as *const text::FontAtlas;
+
+    if show_fps {
+        push_fps_overlay(&mut frame.canvases, screen_size, atlas, engine.time.fps());
+    }
+
+    if engine.debug_ui.overlay_visible() {
+        push_debug_overlay(
+            &mut frame.canvases,
+            screen_size,
+            atlas,
+            DebugOverlayInfo {
+                mode: "2D",
+                fps: engine.time.fps(),
+                dt: engine.time.dt(),
+                frame_count: engine.time.frame_count(),
+                total_time: engine.time.total_time(),
+                window_size: engine.window_size(),
+                game_size: engine.game_size(),
+                hot_reload_enabled: engine.hot_reload_enabled,
+                gamepads_connected: Some(engine.gamepads_connected()),
+                mouse_captured: None,
+            },
+            &engine.debug_ui,
+            engine.input.mouse_position(),
+        );
+    }
+}
+
+fn push_builtin_3d_overlays(frame: &mut Frame3D, engine: &Engine3D, show_fps: bool) {
+    let screen_size = engine.window_size();
+    let atlas = engine.font_atlas() as *const text::FontAtlas;
+
+    if show_fps {
+        push_fps_overlay(&mut frame.canvases, screen_size, atlas, engine.time.fps());
+    }
+
+    if engine.debug_ui.overlay_visible() {
+        push_debug_overlay(
+            &mut frame.canvases,
+            screen_size,
+            atlas,
+            DebugOverlayInfo {
+                mode: "3D",
+                fps: engine.time.fps(),
+                dt: engine.time.dt(),
+                frame_count: engine.time.frame_count(),
+                total_time: engine.time.total_time(),
+                window_size: engine.window_size(),
+                game_size: engine.game_size(),
+                hot_reload_enabled: engine.hot_reload_enabled,
+                gamepads_connected: None,
+                mouse_captured: Some(engine.mouse_captured),
+            },
+            &engine.debug_ui,
+            engine.input.mouse_position(),
+        );
+    }
+}
+
+fn console_target() -> &'static str {
+    "rengine::debug::console"
+}
+
+fn log_console_line(level: DebugLogLevel, message: impl AsRef<str>) {
+    debug::log_message(level, console_target(), message.as_ref());
+}
+
+fn execute_debug_command(debug_ui: &mut DebugUiState, hot_reload_enabled: &mut bool, command_text: &str) {
+    match debug::parse_command(command_text) {
+        Ok(DebugCommand::Help) => {
+            log_console_line(DebugLogLevel::Debug, format!("> {command_text}"));
+            for line in debug::command_help_lines() {
+                log_console_line(DebugLogLevel::Info, *line);
+            }
+        }
+        Ok(DebugCommand::State) => {
+            log_console_line(DebugLogLevel::Debug, format!("> {command_text}"));
+            log_console_line(
+                DebugLogLevel::Info,
+                format!(
+                    "overlay={} console={} follow={} level={} target={} hot_reload={}",
+                    debug_ui.overlay_visible(),
+                    debug_ui.console_open(),
+                    debug_ui.follow_logs(),
+                    debug_ui.severity_filter().label(),
+                    if debug_ui.target_filter().is_empty() {
+                        "*"
+                    } else {
+                        debug_ui.target_filter()
+                    },
+                    *hot_reload_enabled,
+                ),
+            );
+        }
+        Ok(DebugCommand::Clear) => {
+            debug::clear_logs();
+            log_console_line(DebugLogLevel::Debug, "> clear");
+            log_console_line(DebugLogLevel::Info, "log buffer cleared");
+        }
+        Ok(DebugCommand::Overlay(toggle)) => {
+            log_console_line(DebugLogLevel::Debug, format!("> {command_text}"));
+            debug_ui.set_overlay_visible(toggle.apply(debug_ui.overlay_visible()));
+            log_console_line(
+                DebugLogLevel::Info,
+                format!("overlay {}", if debug_ui.overlay_visible() { "on" } else { "off" }),
+            );
+        }
+        Ok(DebugCommand::Console(toggle)) => {
+            log_console_line(DebugLogLevel::Debug, format!("> {command_text}"));
+            debug_ui.set_console_open(toggle.apply(debug_ui.console_open()));
+            log_console_line(
+                DebugLogLevel::Info,
+                format!("console {}", if debug_ui.console_open() { "on" } else { "off" }),
+            );
+        }
+        Ok(DebugCommand::Follow(toggle)) => {
+            log_console_line(DebugLogLevel::Debug, format!("> {command_text}"));
+            debug_ui.set_follow_logs(toggle.apply(debug_ui.follow_logs()));
+            log_console_line(
+                DebugLogLevel::Info,
+                format!(
+                    "log follow {}",
+                    if debug_ui.follow_logs() { "live" } else { "paused" }
+                ),
+            );
+        }
+        Ok(DebugCommand::Level(filter)) => {
+            log_console_line(DebugLogLevel::Debug, format!("> {command_text}"));
+            debug_ui.set_severity_filter(filter);
+            log_console_line(DebugLogLevel::Info, format!("severity filter {}", filter.label()));
+        }
+        Ok(DebugCommand::Target(target)) => {
+            log_console_line(DebugLogLevel::Debug, format!("> {command_text}"));
+            match target {
+                Some(target) => {
+                    debug_ui.set_target_filter(target);
+                    log_console_line(
+                        DebugLogLevel::Info,
+                        format!("target filter {}", debug_ui.target_filter()),
+                    );
+                }
+                None => {
+                    debug_ui.clear_target_filter();
+                    log_console_line(DebugLogLevel::Info, "target filter cleared");
+                }
+            }
+        }
+        Ok(DebugCommand::HotReload(toggle)) => {
+            log_console_line(DebugLogLevel::Debug, format!("> {command_text}"));
+            *hot_reload_enabled = toggle.apply(*hot_reload_enabled);
+            log_console_line(
+                DebugLogLevel::Info,
+                format!("hot reload {}", if *hot_reload_enabled { "on" } else { "off" }),
+            );
+        }
+        Ok(DebugCommand::Echo(level, message)) => {
+            log_console_line(DebugLogLevel::Debug, format!("> {command_text}"));
+            log_console_line(level, message);
+        }
+        Err(error) => {
+            log_console_line(DebugLogLevel::Error, format!("{error}; try 'help'"));
+        }
+    }
+}
+
+fn drain_debug_commands_2d(engine: &mut Engine) {
+    let commands = engine.debug_ui.drain_pending_commands();
+    for command in commands {
+        execute_debug_command(&mut engine.debug_ui, &mut engine.hot_reload_enabled, &command);
+    }
+}
+
+fn drain_debug_commands_3d(engine: &mut Engine3D) {
+    let commands = engine.debug_ui.drain_pending_commands();
+    for command in commands {
+        execute_debug_command(&mut engine.debug_ui, &mut engine.hot_reload_enabled, &command);
     }
 }
 
@@ -106,6 +363,7 @@ pub struct EngineConfig {
     pub headless: bool,
     pub hot_reload: bool,
     pub show_fps: bool,
+    pub show_debug_overlay: bool,
     pub fixed_dt: f32,
 
     pub render_width: Option<u32>,
@@ -124,6 +382,7 @@ impl Default for EngineConfig {
             headless: false,
             hot_reload: true,
             show_fps: true,
+            show_debug_overlay: false,
             fixed_dt: 1.0 / 60.0,
             render_width: None,
             render_height: None,
@@ -144,6 +403,7 @@ pub struct Engine {
     pub(crate) render_resolution: Option<(u32, u32)>,
     pub(crate) gamepads: GamepadSystem,
     pub(crate) hot_reload_enabled: bool,
+    pub(crate) debug_ui: DebugUiState,
     pub(crate) actions: ActionMap,
     pub(crate) rng: RefCell<Rng>,
     pub(crate) postfx_chain: PostFxChain,
@@ -271,6 +531,58 @@ impl Engine {
 
     pub fn set_hot_reload_enabled(&mut self, enabled: bool) {
         self.hot_reload_enabled = enabled;
+    }
+
+    pub fn debug_overlay_visible(&self) -> bool {
+        self.debug_ui.overlay_visible()
+    }
+
+    pub fn set_debug_overlay_visible(&mut self, visible: bool) {
+        self.debug_ui.set_overlay_visible(visible);
+    }
+
+    pub fn toggle_debug_overlay(&mut self) {
+        self.debug_ui.toggle_overlay();
+    }
+
+    pub fn debug_console_open(&self) -> bool {
+        self.debug_ui.console_open()
+    }
+
+    pub fn set_debug_console_open(&mut self, open: bool) {
+        self.debug_ui.set_console_open(open);
+    }
+
+    pub fn toggle_debug_console(&mut self) {
+        self.debug_ui.toggle_console();
+    }
+
+    pub fn debug_logs(&self, limit: usize) -> Vec<crate::debug::DebugLogEntry> {
+        crate::debug::recent_logs(limit)
+    }
+
+    pub fn clear_debug_logs(&self) {
+        crate::debug::clear_logs();
+    }
+
+    pub fn log_trace(&self, target: &str, message: impl AsRef<str>) {
+        crate::debug::log_message(DebugLogLevel::Trace, target, message.as_ref());
+    }
+
+    pub fn log_debug(&self, target: &str, message: impl AsRef<str>) {
+        crate::debug::log_message(DebugLogLevel::Debug, target, message.as_ref());
+    }
+
+    pub fn log_info(&self, target: &str, message: impl AsRef<str>) {
+        crate::debug::log_message(DebugLogLevel::Info, target, message.as_ref());
+    }
+
+    pub fn log_warn(&self, target: &str, message: impl AsRef<str>) {
+        crate::debug::log_message(DebugLogLevel::Warn, target, message.as_ref());
+    }
+
+    pub fn log_error(&self, target: &str, message: impl AsRef<str>) {
+        crate::debug::log_message(DebugLogLevel::Error, target, message.as_ref());
     }
 
     pub fn create_texture(&mut self, width: u32, height: u32, pixels: &[u8]) -> TextureId {
@@ -665,7 +977,7 @@ pub trait Game: 'static + Sized {
 }
 
 pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
+    debug::init_logging();
 
     let headless = config.headless;
     let show_fps = config.show_fps;
@@ -714,6 +1026,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
         render_resolution: render_res,
         gamepads: GamepadSystem::new(gamepad_assign),
         hot_reload_enabled: config.hot_reload,
+        debug_ui: DebugUiState::new(config.show_debug_overlay),
         actions: ActionMap::new(),
         rng: RefCell::new(Rng::from_time()),
         postfx_chain: PostFxChain::new(),
@@ -758,14 +1071,11 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                 }
 
                 WindowEvent::KeyboardInput { event, .. } => {
-                    handle_text_event(&mut engine.input, &event);
-                    if let PhysicalKey::Code(key) = event.physical_key {
-                        engine.input.handle_key_event(key, event.state);
-                    }
+                    route_debug_keyboard_event(&mut engine.input, &mut engine.debug_ui, &event);
                 }
 
                 WindowEvent::Ime(event) => {
-                    handle_ime_event(&mut engine.input, event);
+                    route_debug_ime_event(&mut engine.input, &mut engine.debug_ui, event);
                 }
 
                 WindowEvent::CursorMoved { position, .. } => {
@@ -781,7 +1091,14 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                         MouseButton::Middle => 2,
                         _ => return,
                     };
-                    engine.input.handle_mouse_button(idx, state);
+                    let window_size = engine.window_size();
+                    route_debug_mouse_button_event(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        window_size,
+                        idx,
+                        state,
+                    );
                 }
 
                 WindowEvent::MouseWheel { delta, .. } => {
@@ -791,7 +1108,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                             (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
                         }
                     };
-                    engine.input.handle_scroll(dx, dy);
+                    route_debug_scroll_event(&mut engine.input, &mut engine.debug_ui, dx, dy);
                 }
 
                 WindowEvent::RedrawRequested => {
@@ -799,6 +1116,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                     engine.gamepads.update();
                     engine.reload_assets_if_changed();
                     engine.audio.update(engine.time.dt());
+                    drain_debug_commands_2d(&mut engine);
 
                     while engine.time.consume_fixed_step() {
                         game.fixed_update(&engine);
@@ -813,13 +1131,7 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
 
                     game.render(&engine, &mut frame);
 
-                    if show_fps {
-                        let screen_size = engine.window_size();
-                        let atlas: *const text::FontAtlas = &engine.renderer.fonts[0];
-                        let mut fps_canvas = canvas::Canvas::new(screen_size, atlas);
-                        canvas::draw_fps(&mut fps_canvas, engine.time.fps());
-                        frame.canvases.push(fps_canvas);
-                    }
+                    push_builtin_2d_overlays(&mut frame, &engine, show_fps);
                     engine
                         .renderer
                         .render_frame(&mut frame, &engine.postfx_chain);
@@ -845,7 +1157,7 @@ pub fn run_with_scenes<F>(config: EngineConfig, init: F) -> Result<(), Box<dyn s
 where
     F: FnOnce(&mut Engine, &mut Globals) -> Box<dyn Scene>,
 {
-    env_logger::init();
+    debug::init_logging();
 
     let headless = config.headless;
     let show_fps = config.show_fps;
@@ -884,6 +1196,7 @@ where
         render_resolution: render_res,
         gamepads: GamepadSystem::new(gamepad_assign),
         hot_reload_enabled: config.hot_reload,
+        debug_ui: DebugUiState::new(config.show_debug_overlay),
         actions: ActionMap::new(),
         rng: RefCell::new(Rng::from_time()),
         postfx_chain: PostFxChain::new(),
@@ -946,14 +1259,11 @@ where
                 }
 
                 WindowEvent::KeyboardInput { event, .. } => {
-                    handle_text_event(&mut engine.input, &event);
-                    if let PhysicalKey::Code(key) = event.physical_key {
-                        engine.input.handle_key_event(key, event.state);
-                    }
+                    route_debug_keyboard_event(&mut engine.input, &mut engine.debug_ui, &event);
                 }
 
                 WindowEvent::Ime(event) => {
-                    handle_ime_event(&mut engine.input, event);
+                    route_debug_ime_event(&mut engine.input, &mut engine.debug_ui, event);
                 }
 
                 WindowEvent::CursorMoved { position, .. } => {
@@ -969,7 +1279,14 @@ where
                         MouseButton::Middle => 2,
                         _ => return,
                     };
-                    engine.input.handle_mouse_button(idx, state);
+                    let window_size = engine.window_size();
+                    route_debug_mouse_button_event(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        window_size,
+                        idx,
+                        state,
+                    );
                 }
 
                 WindowEvent::MouseWheel { delta, .. } => {
@@ -979,7 +1296,7 @@ where
                             (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
                         }
                     };
-                    engine.input.handle_scroll(dx, dy);
+                    route_debug_scroll_event(&mut engine.input, &mut engine.debug_ui, dx, dy);
                 }
 
                 WindowEvent::RedrawRequested => {
@@ -987,6 +1304,7 @@ where
                     engine.gamepads.update();
                     engine.reload_assets_if_changed();
                     engine.audio.update(engine.time.dt());
+                    drain_debug_commands_2d(&mut engine);
 
                     while engine.time.consume_fixed_step() {
                         if let Some(scene) = stack.last_mut() {
@@ -1066,13 +1384,7 @@ where
                         }
                     }
 
-                    if show_fps {
-                        let screen_size = engine.window_size();
-                        let atlas: *const text::FontAtlas = &engine.renderer.fonts[0];
-                        let mut fps_canvas = canvas::Canvas::new(screen_size, atlas);
-                        canvas::draw_fps(&mut fps_canvas, engine.time.fps());
-                        frame.canvases.push(fps_canvas);
-                    }
+                    push_builtin_2d_overlays(&mut frame, &engine, show_fps);
                     engine
                         .renderer
                         .render_frame(&mut frame, &engine.postfx_chain);
@@ -1152,6 +1464,7 @@ pub struct Engine3D {
     render_resolution: Option<(u32, u32)>,
     mouse_captured: bool,
     hot_reload_enabled: bool,
+    debug_ui: DebugUiState,
     actions: ActionMap,
     no_gamepad: crate::input::GamepadState,
     rng: RefCell<Rng>,
@@ -1196,6 +1509,30 @@ impl Engine3D {
         self.mouse_captured
     }
 
+    pub fn debug_overlay_visible(&self) -> bool {
+        self.debug_ui.overlay_visible()
+    }
+
+    pub fn set_debug_overlay_visible(&mut self, visible: bool) {
+        self.debug_ui.set_overlay_visible(visible);
+    }
+
+    pub fn toggle_debug_overlay(&mut self) {
+        self.debug_ui.toggle_overlay();
+    }
+
+    pub fn debug_console_open(&self) -> bool {
+        self.debug_ui.console_open()
+    }
+
+    pub fn set_debug_console_open(&mut self, open: bool) {
+        self.debug_ui.set_console_open(open);
+    }
+
+    pub fn toggle_debug_console(&mut self) {
+        self.debug_ui.toggle_console();
+    }
+
     pub fn actions(&self) -> &ActionMap {
         &self.actions
     }
@@ -1224,6 +1561,34 @@ impl Engine3D {
 
     pub fn axis(&self, name: &str) -> f32 {
         self.actions.axis(name, &self.input, &self.no_gamepad)
+    }
+
+    pub fn debug_logs(&self, limit: usize) -> Vec<crate::debug::DebugLogEntry> {
+        crate::debug::recent_logs(limit)
+    }
+
+    pub fn clear_debug_logs(&self) {
+        crate::debug::clear_logs();
+    }
+
+    pub fn log_trace(&self, target: &str, message: impl AsRef<str>) {
+        crate::debug::log_message(DebugLogLevel::Trace, target, message.as_ref());
+    }
+
+    pub fn log_debug(&self, target: &str, message: impl AsRef<str>) {
+        crate::debug::log_message(DebugLogLevel::Debug, target, message.as_ref());
+    }
+
+    pub fn log_info(&self, target: &str, message: impl AsRef<str>) {
+        crate::debug::log_message(DebugLogLevel::Info, target, message.as_ref());
+    }
+
+    pub fn log_warn(&self, target: &str, message: impl AsRef<str>) {
+        crate::debug::log_message(DebugLogLevel::Warn, target, message.as_ref());
+    }
+
+    pub fn log_error(&self, target: &str, message: impl AsRef<str>) {
+        crate::debug::log_message(DebugLogLevel::Error, target, message.as_ref());
     }
 
     pub fn asset_root(&self) -> &Path {
@@ -1606,7 +1971,7 @@ pub trait Game3D: 'static + Sized {
 }
 
 pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
+    debug::init_logging();
 
     let headless = config.headless;
     let show_fps = config.show_fps;
@@ -1654,6 +2019,7 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
         render_resolution: render_res,
         mouse_captured: false,
         hot_reload_enabled: config.hot_reload,
+        debug_ui: DebugUiState::new(config.show_debug_overlay),
         actions: ActionMap::new(),
         no_gamepad: crate::input::GamepadState::new(),
         rng: RefCell::new(Rng::from_time()),
@@ -1724,10 +2090,21 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                 }
 
                 WindowEvent::KeyboardInput { event, .. } => {
-                    handle_text_event(&mut engine.input, &event);
+                    let debug_consumed_text = if event.state == winit::event::ElementState::Pressed {
+                        event.text
+                            .as_deref()
+                            .is_some_and(|text| engine.debug_ui.handle_committed_text(text))
+                    } else {
+                        false
+                    };
+                    let debug_consumed = engine.debug_ui.handle_key_event(&event);
+                    if !debug_consumed_text {
+                        handle_text_event(&mut engine.input, &event);
+                    }
                     if let PhysicalKey::Code(key) = event.physical_key {
                         if key == winit::keyboard::KeyCode::Escape
                             && event.state == winit::event::ElementState::Pressed
+                            && !debug_consumed
                         {
                             if engine.mouse_captured {
                                 let _ = window.set_cursor_grab(CursorGrabMode::None);
@@ -1737,12 +2114,14 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                                 target.exit();
                             }
                         }
-                        engine.input.handle_key_event(key, event.state);
+                        if !debug_consumed {
+                            engine.input.handle_key_event(key, event.state);
+                        }
                     }
                 }
 
                 WindowEvent::Ime(event) => {
-                    handle_ime_event(&mut engine.input, event);
+                    route_debug_ime_event(&mut engine.input, &mut engine.debug_ui, event);
                 }
 
                 WindowEvent::MouseInput { button, state, .. } => {
@@ -1752,6 +2131,17 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                         MouseButton::Middle => 2,
                         _ => return,
                     };
+                    let window_size = engine.window_size();
+
+                    if route_debug_mouse_button_event(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        window_size,
+                        idx,
+                        state,
+                    ) {
+                        return;
+                    }
 
                     if !engine.mouse_captured && state == winit::event::ElementState::Pressed {
                         let _ = window
@@ -1760,7 +2150,6 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                         window.set_cursor_visible(false);
                         engine.mouse_captured = true;
                     }
-                    engine.input.handle_mouse_button(idx, state);
                 }
 
                 WindowEvent::MouseWheel { delta, .. } => {
@@ -1770,7 +2159,7 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                             (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
                         }
                     };
-                    engine.input.handle_scroll(dx, dy);
+                    route_debug_scroll_event(&mut engine.input, &mut engine.debug_ui, dx, dy);
                 }
 
                 WindowEvent::CursorMoved { position, .. } => {
@@ -1783,6 +2172,7 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                     engine.time.tick();
                     engine.reload_assets_if_changed();
                     engine.audio.update(engine.time.dt());
+                    drain_debug_commands_3d(&mut engine);
 
                     while engine.time.consume_fixed_step() {
                         game.fixed_update(&engine);
@@ -1797,13 +2187,7 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
 
                     game.render(&engine, &mut frame);
 
-                    if show_fps {
-                        let screen_size = engine.window_size();
-                        let atlas: *const text::FontAtlas = &engine.renderer.fonts[0];
-                        let mut fps_canvas = canvas::Canvas::new(screen_size, atlas);
-                        canvas::draw_fps(&mut fps_canvas, engine.time.fps());
-                        frame.canvases.push(fps_canvas);
-                    }
+                    push_builtin_3d_overlays(&mut frame, &engine, show_fps);
                     engine.renderer.render_frame(&mut frame);
 
                     engine.input.end_frame();
@@ -1827,7 +2211,7 @@ pub fn run3d_with_scenes<F>(config: EngineConfig, init: F) -> Result<(), Box<dyn
 where
     F: FnOnce(&mut Engine3D, &mut Globals) -> Box<dyn Scene3D>,
 {
-    env_logger::init();
+    debug::init_logging();
 
     let headless = config.headless;
     let show_fps = config.show_fps;
@@ -1875,6 +2259,7 @@ where
         render_resolution: render_res,
         mouse_captured: false,
         hot_reload_enabled: config.hot_reload,
+        debug_ui: DebugUiState::new(config.show_debug_overlay),
         actions: ActionMap::new(),
         no_gamepad: crate::input::GamepadState::new(),
         rng: RefCell::new(Rng::from_time()),
@@ -1962,10 +2347,21 @@ where
                 }
 
                 WindowEvent::KeyboardInput { event, .. } => {
-                    handle_text_event(&mut engine.input, &event);
+                    let debug_consumed_text = if event.state == winit::event::ElementState::Pressed {
+                        event.text
+                            .as_deref()
+                            .is_some_and(|text| engine.debug_ui.handle_committed_text(text))
+                    } else {
+                        false
+                    };
+                    let debug_consumed = engine.debug_ui.handle_key_event(&event);
+                    if !debug_consumed_text {
+                        handle_text_event(&mut engine.input, &event);
+                    }
                     if let PhysicalKey::Code(key) = event.physical_key {
                         if key == winit::keyboard::KeyCode::Escape
                             && event.state == winit::event::ElementState::Pressed
+                            && !debug_consumed
                         {
                             if engine.mouse_captured {
                                 let _ = window.set_cursor_grab(CursorGrabMode::None);
@@ -1975,12 +2371,14 @@ where
                                 target.exit();
                             }
                         }
-                        engine.input.handle_key_event(key, event.state);
+                        if !debug_consumed {
+                            engine.input.handle_key_event(key, event.state);
+                        }
                     }
                 }
 
                 WindowEvent::Ime(event) => {
-                    handle_ime_event(&mut engine.input, event);
+                    route_debug_ime_event(&mut engine.input, &mut engine.debug_ui, event);
                 }
 
                 WindowEvent::MouseInput { button, state, .. } => {
@@ -1990,6 +2388,17 @@ where
                         MouseButton::Middle => 2,
                         _ => return,
                     };
+                    let window_size = engine.window_size();
+
+                    if route_debug_mouse_button_event(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        window_size,
+                        idx,
+                        state,
+                    ) {
+                        return;
+                    }
 
                     if !engine.mouse_captured && state == winit::event::ElementState::Pressed {
                         let _ = window
@@ -1998,7 +2407,6 @@ where
                         window.set_cursor_visible(false);
                         engine.mouse_captured = true;
                     }
-                    engine.input.handle_mouse_button(idx, state);
                 }
 
                 WindowEvent::MouseWheel { delta, .. } => {
@@ -2008,7 +2416,7 @@ where
                             (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
                         }
                     };
-                    engine.input.handle_scroll(dx, dy);
+                    route_debug_scroll_event(&mut engine.input, &mut engine.debug_ui, dx, dy);
                 }
 
                 WindowEvent::CursorMoved { position, .. } => {
@@ -2021,6 +2429,7 @@ where
                     engine.time.tick();
                     engine.reload_assets_if_changed();
                     engine.audio.update(engine.time.dt());
+                    drain_debug_commands_3d(&mut engine);
 
                     while engine.time.consume_fixed_step() {
                         if let Some(scene) = stack.last_mut() {
@@ -2048,13 +2457,7 @@ where
                         scene.render(&engine, &globals, &mut frame);
                     }
 
-                    if show_fps {
-                        let screen_size = engine.window_size();
-                        let atlas: *const text::FontAtlas = &engine.renderer.fonts[0];
-                        let mut fps_canvas = canvas::Canvas::new(screen_size, atlas);
-                        canvas::draw_fps(&mut fps_canvas, engine.time.fps());
-                        frame.canvases.push(fps_canvas);
-                    }
+                    push_builtin_3d_overlays(&mut frame, &engine, show_fps);
                     engine.renderer.render_frame(&mut frame);
 
                     engine.input.end_frame();

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -65,8 +65,9 @@ fn route_debug_text_and_key_event(
     consumed_key
 }
 
-fn route_debug_keyboard_event(input: &mut InputState, debug_ui: &mut DebugUiState, event: &KeyEvent) {
-    let _ = route_debug_text_and_key_event(input, debug_ui, event);
+enum DebugEscapeHandling {
+    None,
+    ExitOrReleaseMouseCapture { mouse_captured: bool },
 }
 
 enum Debug3DKeyboardOutcome {
@@ -75,11 +76,11 @@ enum Debug3DKeyboardOutcome {
     Exit,
 }
 
-fn route_debug_keyboard_event_3d(
+fn route_debug_keyboard_event(
     input: &mut InputState,
     debug_ui: &mut DebugUiState,
-    mouse_captured: bool,
     event: &KeyEvent,
+    escape_handling: DebugEscapeHandling,
 ) -> Debug3DKeyboardOutcome {
     let consumed_key = route_debug_text_and_key_event(input, debug_ui, event);
 
@@ -90,10 +91,15 @@ fn route_debug_keyboard_event_3d(
             PhysicalKey::Code(winit::keyboard::KeyCode::Escape)
         )
     {
-        if mouse_captured {
-            Debug3DKeyboardOutcome::ReleaseMouseCapture
-        } else {
-            Debug3DKeyboardOutcome::Exit
+        match escape_handling {
+            DebugEscapeHandling::None => Debug3DKeyboardOutcome::None,
+            DebugEscapeHandling::ExitOrReleaseMouseCapture { mouse_captured } => {
+                if mouse_captured {
+                    Debug3DKeyboardOutcome::ReleaseMouseCapture
+                } else {
+                    Debug3DKeyboardOutcome::Exit
+                }
+            }
         }
     } else {
         Debug3DKeyboardOutcome::None
@@ -1131,7 +1137,12 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                 }
 
                 WindowEvent::KeyboardInput { event, .. } => {
-                    route_debug_keyboard_event(&mut engine.input, &mut engine.debug_ui, &event);
+                    let _ = route_debug_keyboard_event(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        &event,
+                        DebugEscapeHandling::None,
+                    );
                 }
 
                 WindowEvent::Ime(event) => {
@@ -1326,7 +1337,12 @@ where
                 }
 
                 WindowEvent::KeyboardInput { event, .. } => {
-                    route_debug_keyboard_event(&mut engine.input, &mut engine.debug_ui, &event);
+                    let _ = route_debug_keyboard_event(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        &event,
+                        DebugEscapeHandling::None,
+                    );
                 }
 
                 WindowEvent::Ime(event) => {
@@ -2164,12 +2180,13 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                 }
 
                 WindowEvent::KeyboardInput { event, .. } => {
-                    let mouse_captured = engine.mouse_captured;
-                    match route_debug_keyboard_event_3d(
+                    match route_debug_keyboard_event(
                         &mut engine.input,
                         &mut engine.debug_ui,
-                        mouse_captured,
                         &event,
+                        DebugEscapeHandling::ExitOrReleaseMouseCapture {
+                            mouse_captured: engine.mouse_captured,
+                        },
                     ) {
                         Debug3DKeyboardOutcome::None => {}
                         Debug3DKeyboardOutcome::ReleaseMouseCapture => {
@@ -2415,12 +2432,13 @@ where
                 }
 
                 WindowEvent::KeyboardInput { event, .. } => {
-                    let mouse_captured = engine.mouse_captured;
-                    match route_debug_keyboard_event_3d(
+                    match route_debug_keyboard_event(
                         &mut engine.input,
                         &mut engine.debug_ui,
-                        mouse_captured,
                         &event,
+                        DebugEscapeHandling::ExitOrReleaseMouseCapture {
+                            mouse_captured: engine.mouse_captured,
+                        },
                     ) {
                         Debug3DKeyboardOutcome::None => {}
                         Debug3DKeyboardOutcome::ReleaseMouseCapture => {

--- a/engine/src/app.rs
+++ b/engine/src/app.rs
@@ -38,7 +38,11 @@ fn handle_ime_event(input: &mut InputState, event: Ime) {
     input.handle_ime_event(event);
 }
 
-fn route_debug_keyboard_event(input: &mut InputState, debug_ui: &mut DebugUiState, event: &KeyEvent) {
+fn route_debug_text_and_key_event(
+    input: &mut InputState,
+    debug_ui: &mut DebugUiState,
+    event: &KeyEvent,
+) -> bool {
     let consumed_text = if event.state == winit::event::ElementState::Pressed {
         event.text
             .as_deref()
@@ -57,6 +61,43 @@ fn route_debug_keyboard_event(input: &mut InputState, debug_ui: &mut DebugUiStat
             input.handle_key_event(key, event.state);
         }
     }
+
+    consumed_key
+}
+
+fn route_debug_keyboard_event(input: &mut InputState, debug_ui: &mut DebugUiState, event: &KeyEvent) {
+    let _ = route_debug_text_and_key_event(input, debug_ui, event);
+}
+
+enum Debug3DKeyboardOutcome {
+    None,
+    ReleaseMouseCapture,
+    Exit,
+}
+
+fn route_debug_keyboard_event_3d(
+    input: &mut InputState,
+    debug_ui: &mut DebugUiState,
+    mouse_captured: bool,
+    event: &KeyEvent,
+) -> Debug3DKeyboardOutcome {
+    let consumed_key = route_debug_text_and_key_event(input, debug_ui, event);
+
+    if event.state == winit::event::ElementState::Pressed
+        && !consumed_key
+        && matches!(
+            event.physical_key,
+            PhysicalKey::Code(winit::keyboard::KeyCode::Escape)
+        )
+    {
+        if mouse_captured {
+            Debug3DKeyboardOutcome::ReleaseMouseCapture
+        } else {
+            Debug3DKeyboardOutcome::Exit
+        }
+    } else {
+        Debug3DKeyboardOutcome::None
+    }
 }
 
 fn route_debug_ime_event(input: &mut InputState, debug_ui: &mut DebugUiState, event: Ime) {
@@ -65,8 +106,15 @@ fn route_debug_ime_event(input: &mut InputState, debug_ui: &mut DebugUiState, ev
     }
 }
 
-fn route_debug_scroll_event(input: &mut InputState, debug_ui: &mut DebugUiState, dx: f32, dy: f32) {
-    if !debug_ui.handle_scroll(dy) {
+fn route_debug_scroll_event(
+    input: &mut InputState,
+    debug_ui: &mut DebugUiState,
+    window_size: (u32, u32),
+    dx: f32,
+    dy: f32,
+) {
+    let mouse_position = input.mouse_position();
+    if !debug_ui.handle_scroll(window_size, mouse_position, dy) {
         input.handle_scroll(dx, dy);
     }
 }
@@ -230,9 +278,8 @@ fn execute_debug_command(debug_ui: &mut DebugUiState, hot_reload_enabled: &mut b
             );
         }
         Ok(DebugCommand::Clear) => {
+            debug_ui.scroll_to_latest();
             debug::clear_logs();
-            log_console_line(DebugLogLevel::Debug, "> clear");
-            log_console_line(DebugLogLevel::Info, "log buffer cleared");
         }
         Ok(DebugCommand::Overlay(toggle)) => {
             log_console_line(DebugLogLevel::Debug, format!("> {command_text}"));
@@ -316,7 +363,8 @@ fn drain_debug_commands_3d(engine: &mut Engine3D) {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_asset_bundle_dependencies;
+    use super::{execute_debug_command, normalize_asset_bundle_dependencies};
+    use crate::debug::{self, DebugLogLevel, DebugUiState};
     use std::path::PathBuf;
 
     #[test]
@@ -338,6 +386,18 @@ mod tests {
                 PathBuf::from("z.txt"),
             ]
         );
+    }
+
+    #[test]
+    fn clear_command_empties_log_buffer() {
+        debug::clear_logs();
+        debug::log_message(DebugLogLevel::Info, "app-test", "before clear");
+
+        let mut debug_ui = DebugUiState::new(true);
+        let mut hot_reload_enabled = false;
+        execute_debug_command(&mut debug_ui, &mut hot_reload_enabled, "clear");
+
+        assert_eq!(debug::log_count(), 0);
     }
 }
 
@@ -1108,7 +1168,14 @@ pub fn run<G: Game>(config: EngineConfig) -> Result<(), Box<dyn std::error::Erro
                             (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
                         }
                     };
-                    route_debug_scroll_event(&mut engine.input, &mut engine.debug_ui, dx, dy);
+                    let window_size = engine.window_size();
+                    route_debug_scroll_event(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        window_size,
+                        dx,
+                        dy,
+                    );
                 }
 
                 WindowEvent::RedrawRequested => {
@@ -1296,7 +1363,14 @@ where
                             (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
                         }
                     };
-                    route_debug_scroll_event(&mut engine.input, &mut engine.debug_ui, dx, dy);
+                    let window_size = engine.window_size();
+                    route_debug_scroll_event(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        window_size,
+                        dx,
+                        dy,
+                    );
                 }
 
                 WindowEvent::RedrawRequested => {
@@ -2090,33 +2164,20 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                 }
 
                 WindowEvent::KeyboardInput { event, .. } => {
-                    let debug_consumed_text = if event.state == winit::event::ElementState::Pressed {
-                        event.text
-                            .as_deref()
-                            .is_some_and(|text| engine.debug_ui.handle_committed_text(text))
-                    } else {
-                        false
-                    };
-                    let debug_consumed = engine.debug_ui.handle_key_event(&event);
-                    if !debug_consumed_text {
-                        handle_text_event(&mut engine.input, &event);
-                    }
-                    if let PhysicalKey::Code(key) = event.physical_key {
-                        if key == winit::keyboard::KeyCode::Escape
-                            && event.state == winit::event::ElementState::Pressed
-                            && !debug_consumed
-                        {
-                            if engine.mouse_captured {
-                                let _ = window.set_cursor_grab(CursorGrabMode::None);
-                                window.set_cursor_visible(true);
-                                engine.mouse_captured = false;
-                            } else {
-                                target.exit();
-                            }
+                    let mouse_captured = engine.mouse_captured;
+                    match route_debug_keyboard_event_3d(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        mouse_captured,
+                        &event,
+                    ) {
+                        Debug3DKeyboardOutcome::None => {}
+                        Debug3DKeyboardOutcome::ReleaseMouseCapture => {
+                            let _ = window.set_cursor_grab(CursorGrabMode::None);
+                            window.set_cursor_visible(true);
+                            engine.mouse_captured = false;
                         }
-                        if !debug_consumed {
-                            engine.input.handle_key_event(key, event.state);
-                        }
+                        Debug3DKeyboardOutcome::Exit => target.exit(),
                     }
                 }
 
@@ -2159,7 +2220,14 @@ pub fn run3d<G: Game3D>(config: EngineConfig) -> Result<(), Box<dyn std::error::
                             (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
                         }
                     };
-                    route_debug_scroll_event(&mut engine.input, &mut engine.debug_ui, dx, dy);
+                    let window_size = engine.window_size();
+                    route_debug_scroll_event(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        window_size,
+                        dx,
+                        dy,
+                    );
                 }
 
                 WindowEvent::CursorMoved { position, .. } => {
@@ -2347,33 +2415,20 @@ where
                 }
 
                 WindowEvent::KeyboardInput { event, .. } => {
-                    let debug_consumed_text = if event.state == winit::event::ElementState::Pressed {
-                        event.text
-                            .as_deref()
-                            .is_some_and(|text| engine.debug_ui.handle_committed_text(text))
-                    } else {
-                        false
-                    };
-                    let debug_consumed = engine.debug_ui.handle_key_event(&event);
-                    if !debug_consumed_text {
-                        handle_text_event(&mut engine.input, &event);
-                    }
-                    if let PhysicalKey::Code(key) = event.physical_key {
-                        if key == winit::keyboard::KeyCode::Escape
-                            && event.state == winit::event::ElementState::Pressed
-                            && !debug_consumed
-                        {
-                            if engine.mouse_captured {
-                                let _ = window.set_cursor_grab(CursorGrabMode::None);
-                                window.set_cursor_visible(true);
-                                engine.mouse_captured = false;
-                            } else {
-                                target.exit();
-                            }
+                    let mouse_captured = engine.mouse_captured;
+                    match route_debug_keyboard_event_3d(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        mouse_captured,
+                        &event,
+                    ) {
+                        Debug3DKeyboardOutcome::None => {}
+                        Debug3DKeyboardOutcome::ReleaseMouseCapture => {
+                            let _ = window.set_cursor_grab(CursorGrabMode::None);
+                            window.set_cursor_visible(true);
+                            engine.mouse_captured = false;
                         }
-                        if !debug_consumed {
-                            engine.input.handle_key_event(key, event.state);
-                        }
+                        Debug3DKeyboardOutcome::Exit => target.exit(),
                     }
                 }
 
@@ -2416,7 +2471,14 @@ where
                             (pos.x as f32 / 40.0, pos.y as f32 / 40.0)
                         }
                     };
-                    route_debug_scroll_event(&mut engine.input, &mut engine.debug_ui, dx, dy);
+                    let window_size = engine.window_size();
+                    route_debug_scroll_event(
+                        &mut engine.input,
+                        &mut engine.debug_ui,
+                        window_size,
+                        dx,
+                        dy,
+                    );
                 }
 
                 WindowEvent::CursorMoved { position, .. } => {

--- a/engine/src/debug.rs
+++ b/engine/src/debug.rs
@@ -1,0 +1,1632 @@
+use std::collections::VecDeque;
+use std::sync::{Mutex, Once, OnceLock};
+use std::time::Instant;
+
+use crate::assets::Color;
+use crate::canvas::Canvas;
+use winit::event::{ElementState, Ime, KeyEvent};
+use winit::keyboard::{KeyCode, PhysicalKey};
+
+const DEFAULT_LOG_CAPACITY: usize = 256;
+const DEFAULT_OVERLAY_LOG_LIMIT: usize = 10;
+const DEFAULT_SCROLL_STEP: usize = 3;
+const MAX_COMMAND_HISTORY: usize = 64;
+const OVERLAY_TITLE_SIZE: f32 = 13.0;
+const OVERLAY_BODY_SIZE: f32 = 11.0;
+const OVERLAY_HINT_SIZE: f32 = 10.0;
+const OVERLAY_BUTTON_TEXT_SIZE: f32 = 10.0;
+const OVERLAY_BUTTON_HEIGHT: f32 = 20.0;
+const OVERLAY_BUTTON_GAP: f32 = 6.0;
+const OVERLAY_BUTTON_PADDING_X: f32 = 8.0;
+const OVERLAY_BUTTON_MIN_WIDTH: f32 = 54.0;
+const CONSOLE_PANEL_HEIGHT: f32 = 84.0;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DebugLogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl DebugLogLevel {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Trace => "TRACE",
+            Self::Debug => "DEBUG",
+            Self::Info => "INFO",
+            Self::Warn => "WARN",
+            Self::Error => "ERROR",
+        }
+    }
+
+    pub fn color(self) -> Color {
+        match self {
+            Self::Trace => Color::from_rgba8(150, 160, 180, 255),
+            Self::Debug => Color::from_rgba8(120, 180, 255, 255),
+            Self::Info => Color::from_rgba8(235, 238, 245, 255),
+            Self::Warn => Color::from_rgba8(255, 210, 96, 255),
+            Self::Error => Color::from_rgba8(255, 120, 120, 255),
+        }
+    }
+}
+
+impl From<log::Level> for DebugLogLevel {
+    fn from(value: log::Level) -> Self {
+        match value {
+            log::Level::Trace => Self::Trace,
+            log::Level::Debug => Self::Debug,
+            log::Level::Info => Self::Info,
+            log::Level::Warn => Self::Warn,
+            log::Level::Error => Self::Error,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DebugSeverityFilter {
+    All,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl DebugSeverityFilter {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Debug => "debug+",
+            Self::Info => "info+",
+            Self::Warn => "warn+",
+            Self::Error => "error",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::All => Self::Debug,
+            Self::Debug => Self::Info,
+            Self::Info => Self::Warn,
+            Self::Warn => Self::Error,
+            Self::Error => Self::All,
+        }
+    }
+
+    pub fn allows(self, level: DebugLogLevel) -> bool {
+        match self {
+            Self::All => true,
+            Self::Debug => !matches!(level, DebugLogLevel::Trace),
+            Self::Info => matches!(
+                level,
+                DebugLogLevel::Info | DebugLogLevel::Warn | DebugLogLevel::Error
+            ),
+            Self::Warn => matches!(level, DebugLogLevel::Warn | DebugLogLevel::Error),
+            Self::Error => level == DebugLogLevel::Error,
+        }
+    }
+
+    pub fn parse(text: &str) -> Option<Self> {
+        match text.trim().to_ascii_lowercase().as_str() {
+            "all" | "trace" => Some(Self::All),
+            "debug" => Some(Self::Debug),
+            "info" => Some(Self::Info),
+            "warn" | "warning" => Some(Self::Warn),
+            "error" | "errors" => Some(Self::Error),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DebugToggle {
+    On,
+    Off,
+    Toggle,
+}
+
+impl DebugToggle {
+    pub fn apply(self, current: bool) -> bool {
+        match self {
+            Self::On => true,
+            Self::Off => false,
+            Self::Toggle => !current,
+        }
+    }
+
+    pub fn parse(text: Option<&str>) -> Result<Self, String> {
+        match text.map(|value| value.trim().to_ascii_lowercase()) {
+            None => Ok(Self::Toggle),
+            Some(value) if value.is_empty() => Ok(Self::Toggle),
+            Some(value) if value == "toggle" => Ok(Self::Toggle),
+            Some(value) if matches!(value.as_str(), "on" | "true" | "1") => Ok(Self::On),
+            Some(value) if matches!(value.as_str(), "off" | "false" | "0") => Ok(Self::Off),
+            Some(value) => Err(format!("unknown toggle value '{value}'")),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DebugCommand {
+    Help,
+    State,
+    Clear,
+    Overlay(DebugToggle),
+    Console(DebugToggle),
+    Follow(DebugToggle),
+    Level(DebugSeverityFilter),
+    Target(Option<String>),
+    HotReload(DebugToggle),
+    Echo(DebugLogLevel, String),
+}
+
+#[derive(Clone, Debug)]
+pub struct DebugLogEntry {
+    pub index: u64,
+    pub seconds: f32,
+    pub level: DebugLogLevel,
+    pub target: String,
+    pub message: String,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct DebugOverlayInfo<'a> {
+    pub mode: &'a str,
+    pub fps: f32,
+    pub dt: f32,
+    pub frame_count: u64,
+    pub total_time: f32,
+    pub window_size: (u32, u32),
+    pub game_size: (u32, u32),
+    pub hot_reload_enabled: bool,
+    pub gamepads_connected: Option<usize>,
+    pub mouse_captured: Option<bool>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DebugTextInputMode {
+    None,
+    Console,
+    TargetFilter,
+}
+
+pub struct DebugUiState {
+    overlay_visible: bool,
+    console_open: bool,
+    follow_logs: bool,
+    severity_filter: DebugSeverityFilter,
+    target_filter: String,
+    target_filter_buffer: String,
+    console_buffer: String,
+    preedit: Option<(String, Option<(usize, usize)>)>,
+    scroll_offset: usize,
+    command_history: Vec<String>,
+    history_index: Option<usize>,
+    pending_commands: VecDeque<String>,
+    input_mode: DebugTextInputMode,
+    captured_mouse_buttons: [bool; 3],
+}
+
+impl DebugUiState {
+    pub fn new(overlay_visible: bool) -> Self {
+        Self {
+            overlay_visible,
+            console_open: false,
+            follow_logs: true,
+            severity_filter: DebugSeverityFilter::All,
+            target_filter: String::new(),
+            target_filter_buffer: String::new(),
+            console_buffer: String::new(),
+            preedit: None,
+            scroll_offset: 0,
+            command_history: Vec::new(),
+            history_index: None,
+            pending_commands: VecDeque::new(),
+            input_mode: DebugTextInputMode::None,
+            captured_mouse_buttons: [false; 3],
+        }
+    }
+
+    pub fn overlay_visible(&self) -> bool {
+        self.overlay_visible
+    }
+
+    pub fn set_overlay_visible(&mut self, visible: bool) {
+        self.overlay_visible = visible;
+        if !visible {
+            self.console_open = false;
+            self.input_mode = DebugTextInputMode::None;
+            self.preedit = None;
+            self.history_index = None;
+            self.captured_mouse_buttons = [false; 3];
+        }
+    }
+
+    pub fn toggle_overlay(&mut self) {
+        self.set_overlay_visible(!self.overlay_visible);
+    }
+
+    pub fn console_open(&self) -> bool {
+        self.console_open
+    }
+
+    pub fn set_console_open(&mut self, open: bool) {
+        if open {
+            self.overlay_visible = true;
+            self.console_open = true;
+            self.input_mode = DebugTextInputMode::Console;
+        } else {
+            self.console_open = false;
+            if self.input_mode == DebugTextInputMode::Console {
+                self.input_mode = DebugTextInputMode::None;
+            }
+        }
+        self.preedit = None;
+        self.history_index = None;
+    }
+
+    pub fn toggle_console(&mut self) {
+        self.set_console_open(!self.console_open);
+    }
+
+    pub fn follow_logs(&self) -> bool {
+        self.follow_logs
+    }
+
+    pub fn set_follow_logs(&mut self, follow: bool) {
+        self.follow_logs = follow;
+        if follow {
+            self.scroll_offset = 0;
+        }
+    }
+
+    pub fn toggle_follow_logs(&mut self) {
+        self.set_follow_logs(!self.follow_logs);
+    }
+
+    pub fn severity_filter(&self) -> DebugSeverityFilter {
+        self.severity_filter
+    }
+
+    pub fn set_severity_filter(&mut self, filter: DebugSeverityFilter) {
+        self.severity_filter = filter;
+        self.scroll_offset = self.scroll_offset.min(self.max_scroll_offset());
+    }
+
+    pub fn cycle_severity_filter(&mut self) {
+        self.set_severity_filter(self.severity_filter.next());
+    }
+
+    pub fn target_filter(&self) -> &str {
+        &self.target_filter
+    }
+
+    pub fn set_target_filter(&mut self, filter: impl Into<String>) {
+        self.target_filter = filter.into().trim().to_string();
+        self.target_filter_buffer = self.target_filter.clone();
+        self.scroll_offset = self.scroll_offset.min(self.max_scroll_offset());
+    }
+
+    pub fn clear_target_filter(&mut self) {
+        self.set_target_filter(String::new());
+    }
+
+    pub fn begin_target_filter_edit(&mut self) {
+        self.overlay_visible = true;
+        self.console_open = false;
+        self.input_mode = DebugTextInputMode::TargetFilter;
+        self.target_filter_buffer = self.target_filter.clone();
+        self.preedit = None;
+        self.history_index = None;
+    }
+
+    pub fn is_text_input_active(&self) -> bool {
+        self.input_mode != DebugTextInputMode::None
+    }
+
+    pub fn handle_key_event(&mut self, event: &KeyEvent) -> bool {
+        let key = match event.physical_key {
+            PhysicalKey::Code(code) => code,
+            _ => return self.is_text_input_active(),
+        };
+
+        if event.state == ElementState::Pressed {
+            if key == KeyCode::F3 {
+                self.toggle_overlay();
+                return true;
+            }
+            if key == KeyCode::F4 || key == KeyCode::Backquote {
+                self.toggle_console();
+                return true;
+            }
+        }
+
+        if self.is_text_input_active() {
+            if event.state == ElementState::Released {
+                return true;
+            }
+
+            return match key {
+                KeyCode::Enter | KeyCode::NumpadEnter => {
+                    self.submit_text_input();
+                    true
+                }
+                KeyCode::Escape => {
+                    self.cancel_text_input();
+                    true
+                }
+                KeyCode::Backspace => {
+                    self.active_buffer_backspace();
+                    true
+                }
+                KeyCode::ArrowUp if self.input_mode == DebugTextInputMode::Console => {
+                    self.console_history_up();
+                    true
+                }
+                KeyCode::ArrowDown if self.input_mode == DebugTextInputMode::Console => {
+                    self.console_history_down();
+                    true
+                }
+                _ => true,
+            };
+        }
+
+        if event.state != ElementState::Pressed || !self.overlay_visible {
+            return false;
+        }
+
+        match key {
+            KeyCode::F5 => {
+                clear_logs();
+                self.scroll_to_latest();
+                true
+            }
+            KeyCode::F6 => {
+                self.toggle_follow_logs();
+                true
+            }
+            KeyCode::F7 => {
+                self.cycle_severity_filter();
+                true
+            }
+            KeyCode::F8 => {
+                self.begin_target_filter_edit();
+                true
+            }
+            KeyCode::PageUp => {
+                self.scroll_up(DEFAULT_SCROLL_STEP);
+                true
+            }
+            KeyCode::PageDown => {
+                self.scroll_down(DEFAULT_SCROLL_STEP);
+                true
+            }
+            KeyCode::Home => {
+                self.scroll_to_oldest();
+                true
+            }
+            KeyCode::End => {
+                self.set_follow_logs(true);
+                self.scroll_to_latest();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub fn handle_committed_text(&mut self, text: &str) -> bool {
+        if !self.is_text_input_active() {
+            return false;
+        }
+
+        for ch in text.chars() {
+            if ch == '\u{7f}' || (ch.is_control() && ch != '\n' && ch != '\t') {
+                continue;
+            }
+            if ch == '\r' || ch == '\n' || ch == '\t' {
+                continue;
+            }
+            self.active_buffer_mut().push(ch);
+        }
+        true
+    }
+
+    pub fn handle_ime_event(&mut self, ime: &Ime) -> bool {
+        if !self.is_text_input_active() {
+            return false;
+        }
+
+        match ime {
+            Ime::Enabled => {}
+            Ime::Preedit(text, cursor) => {
+                if text.is_empty() {
+                    self.preedit = None;
+                } else {
+                    self.preedit = Some((text.clone(), *cursor));
+                }
+            }
+            Ime::Commit(text) => {
+                self.preedit = None;
+                self.handle_committed_text(text);
+            }
+            Ime::Disabled => {
+                self.preedit = None;
+            }
+        }
+
+        true
+    }
+
+    pub fn handle_scroll(&mut self, dy: f32) -> bool {
+        if !self.overlay_visible || self.is_text_input_active() || dy.abs() < f32::EPSILON {
+            return false;
+        }
+
+        let amount = dy.abs().ceil() as usize;
+        if dy > 0.0 {
+            self.scroll_up(amount.max(1));
+        } else {
+            self.scroll_down(amount.max(1));
+        }
+        true
+    }
+
+    pub fn handle_mouse_button(
+        &mut self,
+        screen_size: (u32, u32),
+        pointer: (f32, f32),
+        button: usize,
+        state: ElementState,
+    ) -> bool {
+        if button >= self.captured_mouse_buttons.len() {
+            return false;
+        }
+
+        match state {
+            ElementState::Pressed => {
+                let consume = self.is_text_input_active()
+                    || self.pointer_hits_overlay(screen_size, pointer)
+                    || self.pointer_hits_console(screen_size, pointer);
+
+                if consume {
+                    self.captured_mouse_buttons[button] = true;
+                    if button == 0 {
+                        self.handle_left_mouse_press(screen_size, pointer);
+                    }
+                }
+
+                consume
+            }
+            ElementState::Released => {
+                let consume = self.captured_mouse_buttons[button];
+                self.captured_mouse_buttons[button] = false;
+                consume
+            }
+        }
+    }
+
+    pub fn drain_pending_commands(&mut self) -> Vec<String> {
+        self.pending_commands.drain(..).collect()
+    }
+
+    pub fn filtered_logs(&self, limit: usize) -> (Vec<DebugLogEntry>, usize) {
+        let filtered = self.filtered_snapshot();
+        let total = filtered.len();
+        if total == 0 {
+            return (Vec::new(), 0);
+        }
+
+        let offset = if self.follow_logs {
+            0
+        } else {
+            self.scroll_offset.min(total.saturating_sub(1))
+        };
+        let end = total.saturating_sub(offset);
+        let start = end.saturating_sub(limit.max(1));
+        (filtered[start..end].to_vec(), total)
+    }
+
+    pub fn filtered_log_count(&self) -> usize {
+        self.filtered_snapshot().len()
+    }
+
+    pub fn visible_log_limit(&self) -> usize {
+        if self.console_open {
+            DEFAULT_OVERLAY_LOG_LIMIT.saturating_sub(2).max(4)
+        } else {
+            DEFAULT_OVERLAY_LOG_LIMIT
+        }
+    }
+
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    pub fn scroll_to_latest(&mut self) {
+        self.scroll_offset = 0;
+    }
+
+    pub fn scroll_to_oldest(&mut self) {
+        self.follow_logs = false;
+        self.scroll_offset = self.max_scroll_offset();
+    }
+
+    pub fn scroll_up(&mut self, amount: usize) {
+        self.follow_logs = false;
+        self.scroll_offset = (self.scroll_offset + amount).min(self.max_scroll_offset());
+    }
+
+    pub fn scroll_down(&mut self, amount: usize) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(amount);
+        if self.scroll_offset == 0 {
+            self.follow_logs = true;
+        }
+    }
+
+    pub fn console_buffer(&self) -> &str {
+        &self.console_buffer
+    }
+
+    pub fn target_filter_buffer(&self) -> &str {
+        &self.target_filter_buffer
+    }
+
+    pub fn preedit(&self) -> Option<(&str, Option<(usize, usize)>)> {
+        self.preedit
+            .as_ref()
+            .map(|(text, cursor)| (text.as_str(), *cursor))
+    }
+
+    fn active_buffer_mut(&mut self) -> &mut String {
+        match self.input_mode {
+            DebugTextInputMode::Console => &mut self.console_buffer,
+            DebugTextInputMode::TargetFilter => &mut self.target_filter_buffer,
+            DebugTextInputMode::None => unreachable!(),
+        }
+    }
+
+    fn active_buffer_backspace(&mut self) {
+        self.active_buffer_mut().pop();
+    }
+
+    fn cancel_text_input(&mut self) {
+        self.preedit = None;
+        self.history_index = None;
+        match self.input_mode {
+            DebugTextInputMode::Console => self.set_console_open(false),
+            DebugTextInputMode::TargetFilter => {
+                self.target_filter_buffer = self.target_filter.clone();
+                self.input_mode = DebugTextInputMode::None;
+            }
+            DebugTextInputMode::None => {}
+        }
+    }
+
+    fn submit_text_input(&mut self) {
+        self.preedit = None;
+        self.history_index = None;
+        match self.input_mode {
+            DebugTextInputMode::Console => {
+                let command = self.console_buffer.trim().to_string();
+                if !command.is_empty() {
+                    let should_push = match self.command_history.last() {
+                        Some(last) => last != &command,
+                        None => true,
+                    };
+                    if should_push {
+                        self.command_history.push(command.clone());
+                        if self.command_history.len() > MAX_COMMAND_HISTORY {
+                            self.command_history.remove(0);
+                        }
+                    }
+                    self.pending_commands.push_back(command);
+                }
+                self.console_buffer.clear();
+            }
+            DebugTextInputMode::TargetFilter => {
+                self.target_filter = self.target_filter_buffer.trim().to_string();
+                self.input_mode = DebugTextInputMode::None;
+            }
+            DebugTextInputMode::None => {}
+        }
+    }
+
+    fn console_history_up(&mut self) {
+        if self.command_history.is_empty() {
+            return;
+        }
+        let next_index = match self.history_index {
+            Some(index) if index > 0 => index - 1,
+            Some(index) => index,
+            None => self.command_history.len() - 1,
+        };
+        self.history_index = Some(next_index);
+        self.console_buffer = self.command_history[next_index].clone();
+    }
+
+    fn console_history_down(&mut self) {
+        if self.command_history.is_empty() {
+            return;
+        }
+        match self.history_index {
+            Some(index) if index + 1 < self.command_history.len() => {
+                let next_index = index + 1;
+                self.history_index = Some(next_index);
+                self.console_buffer = self.command_history[next_index].clone();
+            }
+            Some(_) => {
+                self.history_index = None;
+                self.console_buffer.clear();
+            }
+            None => {}
+        }
+    }
+
+    fn filtered_snapshot(&self) -> Vec<DebugLogEntry> {
+        let filter = self.target_filter.to_ascii_lowercase();
+        snapshot_logs()
+            .into_iter()
+            .filter(|entry| self.severity_filter.allows(entry.level))
+            .filter(|entry| {
+                if filter.is_empty() {
+                    return true;
+                }
+
+                entry.target.to_ascii_lowercase().contains(&filter)
+                    || entry.message.to_ascii_lowercase().contains(&filter)
+            })
+            .collect()
+    }
+
+    fn max_scroll_offset(&self) -> usize {
+        self.filtered_log_count()
+            .saturating_sub(self.visible_log_limit())
+    }
+
+    fn handle_left_mouse_press(&mut self, screen_size: (u32, u32), pointer: (f32, f32)) {
+        let layout = self.overlay_layout(screen_size);
+        for button in layout.buttons {
+            if button.rect.contains(pointer) {
+                match button.action {
+                    OverlayButtonAction::Clear => {
+                        clear_logs();
+                        self.scroll_to_latest();
+                    }
+                    OverlayButtonAction::ToggleConsole => self.toggle_console(),
+                    OverlayButtonAction::ToggleFollow => self.toggle_follow_logs(),
+                    OverlayButtonAction::CycleSeverity => self.cycle_severity_filter(),
+                    OverlayButtonAction::EditTargetFilter => {
+                        if self.input_mode == DebugTextInputMode::TargetFilter {
+                            self.submit_text_input();
+                        } else {
+                            self.begin_target_filter_edit();
+                        }
+                    }
+                }
+                return;
+            }
+        }
+    }
+
+    fn pointer_hits_overlay(&self, screen_size: (u32, u32), pointer: (f32, f32)) -> bool {
+        self.overlay_visible && self.overlay_layout(screen_size).panel.contains(pointer)
+    }
+
+    fn pointer_hits_console(&self, screen_size: (u32, u32), pointer: (f32, f32)) -> bool {
+        self.console_open && console_panel_rect(screen_size).contains(pointer)
+    }
+
+    fn overlay_layout(&self, screen_size: (u32, u32)) -> OverlayLayout {
+        let hw = screen_size.0 as f32 / 2.0;
+        let hh = screen_size.1 as f32 / 2.0;
+        let padding = 10.0;
+        let panel_x = -hw + 8.0;
+        let panel_top = hh - 8.0;
+        let panel_width = (screen_size.0 as f32 - 16.0).max(220.0).min(620.0);
+
+        let title_line_height = debug_line_height(OVERLAY_TITLE_SIZE);
+        let body_line_height = debug_line_height(OVERLAY_BODY_SIZE);
+        let hint_line_height = debug_line_height(OVERLAY_HINT_SIZE);
+        let visible_log_lines = self.filtered_logs(self.visible_log_limit()).0.len().max(1);
+
+        let buttons = build_overlay_buttons(
+            self,
+            panel_x + padding,
+            panel_x + panel_width - padding,
+            panel_top - padding - title_line_height - 6.0,
+        );
+        let button_rows = buttons
+            .iter()
+            .map(|button| button.row + 1)
+            .max()
+            .unwrap_or(0);
+        let button_block_height = if button_rows == 0 {
+            0.0
+        } else {
+            button_rows as f32 * OVERLAY_BUTTON_HEIGHT
+                + button_rows.saturating_sub(1) as f32 * OVERLAY_BUTTON_GAP
+                + 8.0
+        };
+        let input_line_height = if self.input_mode == DebugTextInputMode::TargetFilter {
+            body_line_height + 6.0
+        } else {
+            0.0
+        };
+        let panel_height = padding * 2.0
+            + title_line_height
+            + 6.0
+            + button_block_height
+            + 4.0 * body_line_height
+            + 8.0
+            + (visible_log_lines as f32 + 1.0) * body_line_height
+            + 8.0
+            + hint_line_height * 2.0
+            + input_line_height;
+
+        OverlayLayout {
+            panel: DebugRect {
+                x: panel_x,
+                y: panel_top - panel_height,
+                w: panel_width,
+                h: panel_height,
+            },
+            buttons,
+            stats_y: panel_top - padding - title_line_height - 6.0 - button_block_height,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct DebugRect {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+}
+
+impl DebugRect {
+    fn contains(self, point: (f32, f32)) -> bool {
+        point.0 >= self.x
+            && point.0 <= self.x + self.w
+            && point.1 >= self.y
+            && point.1 <= self.y + self.h
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OverlayButtonAction {
+    Clear,
+    ToggleConsole,
+    ToggleFollow,
+    CycleSeverity,
+    EditTargetFilter,
+}
+
+#[derive(Clone, Debug)]
+struct OverlayButtonLayout {
+    rect: DebugRect,
+    action: OverlayButtonAction,
+    label: String,
+    active: bool,
+    row: usize,
+}
+
+#[derive(Clone, Debug)]
+struct OverlayLayout {
+    panel: DebugRect,
+    buttons: Vec<OverlayButtonLayout>,
+    stats_y: f32,
+}
+
+#[derive(Debug)]
+struct DebugLogBuffer {
+    entries: VecDeque<DebugLogEntry>,
+    capacity: usize,
+    next_index: u64,
+}
+
+impl DebugLogBuffer {
+    fn new(capacity: usize) -> Self {
+        Self {
+            entries: VecDeque::with_capacity(capacity),
+            capacity: capacity.max(1),
+            next_index: 0,
+        }
+    }
+
+    fn push_entry(&mut self, mut entry: DebugLogEntry) {
+        entry.index = self.next_index;
+        self.next_index += 1;
+
+        if self.entries.len() >= self.capacity {
+            self.entries.pop_front();
+        }
+        self.entries.push_back(entry);
+    }
+
+    fn push_record(&mut self, elapsed_seconds: f32, record: &log::Record<'_>) {
+        self.push_entry(DebugLogEntry {
+            index: 0,
+            seconds: elapsed_seconds,
+            level: record.level().into(),
+            target: record.target().to_string(),
+            message: record.args().to_string(),
+        });
+    }
+
+    fn recent(&self, limit: usize) -> Vec<DebugLogEntry> {
+        let start = self.entries.len().saturating_sub(limit);
+        self.entries.iter().skip(start).cloned().collect()
+    }
+
+    fn snapshot(&self) -> Vec<DebugLogEntry> {
+        self.entries.iter().cloned().collect()
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    fn set_capacity(&mut self, capacity: usize) {
+        self.capacity = capacity.max(1);
+        while self.entries.len() > self.capacity {
+            self.entries.pop_front();
+        }
+    }
+}
+
+struct CombinedLogger {
+    inner: env_logger::Logger,
+    start: Instant,
+}
+
+impl log::Log for CombinedLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        log::Log::enabled(&self.inner, metadata)
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        log::Log::log(&self.inner, record);
+
+        let mut buffer = log_buffer()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        buffer.push_record(self.start.elapsed().as_secs_f32(), record);
+    }
+
+    fn flush(&self) {
+        log::Log::flush(&self.inner);
+    }
+}
+
+static LOGGER_INIT: Once = Once::new();
+static LOG_BUFFER: OnceLock<Mutex<DebugLogBuffer>> = OnceLock::new();
+
+fn log_buffer() -> &'static Mutex<DebugLogBuffer> {
+    LOG_BUFFER.get_or_init(|| Mutex::new(DebugLogBuffer::new(DEFAULT_LOG_CAPACITY)))
+}
+
+pub fn init_logging() {
+    log_buffer();
+
+    LOGGER_INIT.call_once(|| {
+        let mut builder = env_logger::Builder::from_default_env();
+        builder.format_timestamp_millis();
+
+        let inner = builder.build();
+        let max_level = inner.filter();
+        let logger = CombinedLogger {
+            inner,
+            start: Instant::now(),
+        };
+
+        let _ = log::set_boxed_logger(Box::new(logger));
+        log::set_max_level(max_level);
+    });
+}
+
+pub fn recent_logs(limit: usize) -> Vec<DebugLogEntry> {
+    let buffer = log_buffer()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    buffer.recent(limit)
+}
+
+pub fn snapshot_logs() -> Vec<DebugLogEntry> {
+    let buffer = log_buffer()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    buffer.snapshot()
+}
+
+pub fn clear_logs() {
+    let mut buffer = log_buffer()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    buffer.clear();
+}
+
+pub fn log_count() -> usize {
+    let buffer = log_buffer()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    buffer.len()
+}
+
+pub fn log_capacity() -> usize {
+    let buffer = log_buffer()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    buffer.capacity()
+}
+
+pub fn set_log_capacity(capacity: usize) {
+    let mut buffer = log_buffer()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    buffer.set_capacity(capacity);
+}
+
+pub fn log_message(level: DebugLogLevel, target: &str, message: &str) {
+    init_logging();
+
+    match level {
+        DebugLogLevel::Trace => log::trace!(target: target, "{message}"),
+        DebugLogLevel::Debug => log::debug!(target: target, "{message}"),
+        DebugLogLevel::Info => log::info!(target: target, "{message}"),
+        DebugLogLevel::Warn => log::warn!(target: target, "{message}"),
+        DebugLogLevel::Error => log::error!(target: target, "{message}"),
+    }
+}
+
+pub fn parse_command(text: &str) -> Result<DebugCommand, String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err("empty command".into());
+    }
+
+    let split_at = trimmed.find(char::is_whitespace);
+    let (command, rest) = match split_at {
+        Some(index) => (&trimmed[..index], trimmed[index..].trim()),
+        None => (trimmed, ""),
+    };
+    let command = command.to_ascii_lowercase();
+
+    match command.as_str() {
+        "help" | "?" => Ok(DebugCommand::Help),
+        "state" => Ok(DebugCommand::State),
+        "clear" => Ok(DebugCommand::Clear),
+        "overlay" => Ok(DebugCommand::Overlay(DebugToggle::parse(non_empty(rest))?)),
+        "console" => Ok(DebugCommand::Console(DebugToggle::parse(non_empty(rest))?)),
+        "follow" => Ok(DebugCommand::Follow(DebugToggle::parse(non_empty(rest))?)),
+        "level" | "severity" => {
+            let value = match non_empty(rest) {
+                Some(value) => value,
+                None => {
+                    return Err(
+                        "level command expects one of: all, debug, info, warn, error".into(),
+                    )
+                }
+            };
+            let filter = match DebugSeverityFilter::parse(value) {
+                Some(filter) => filter,
+                None => return Err(format!("unknown severity filter '{value}'")),
+            };
+            Ok(DebugCommand::Level(filter))
+        }
+        "target" => {
+            let value = rest.trim();
+            if value.is_empty() || value.eq_ignore_ascii_case("clear") {
+                Ok(DebugCommand::Target(None))
+            } else {
+                Ok(DebugCommand::Target(Some(value.to_string())))
+            }
+        }
+        "hot_reload" | "hotreload" => {
+            Ok(DebugCommand::HotReload(DebugToggle::parse(non_empty(rest))?))
+        }
+        "echo" => parse_echo_command(rest, DebugLogLevel::Info),
+        "debug" => parse_echo_command(rest, DebugLogLevel::Debug),
+        "info" => parse_echo_command(rest, DebugLogLevel::Info),
+        "warn" | "warning" => parse_echo_command(rest, DebugLogLevel::Warn),
+        "error" => parse_echo_command(rest, DebugLogLevel::Error),
+        _ => Err(format!("unknown debug command '{command}'")),
+    }
+}
+
+pub fn command_help_lines() -> &'static [&'static str] {
+    &[
+        "help | state | clear",
+        "overlay [on|off|toggle] | console [on|off|toggle] | follow [on|off|toggle]",
+        "level <all|debug|info|warn|error> | target <text> | target clear",
+        "hot_reload [on|off|toggle]",
+        "echo <msg> | debug <msg> | info <msg> | warn <msg> | error <msg>",
+    ]
+}
+
+pub fn draw_overlay(
+    canvas: &mut Canvas,
+    info: &DebugOverlayInfo<'_>,
+    state: &DebugUiState,
+    mouse_position: Option<(f32, f32)>,
+) {
+    let visible_limit = state.visible_log_limit();
+    let (logs, filtered_count) = state.filtered_logs(visible_limit);
+    let screen_size = canvas.screen_size();
+    let padding = 10.0;
+    let body_line_height = debug_line_height(OVERLAY_BODY_SIZE);
+    let hint_line_height = debug_line_height(OVERLAY_HINT_SIZE);
+    let layout = state.overlay_layout(screen_size);
+    let panel_x = layout.panel.x;
+    let panel_y = layout.panel.y;
+    let panel_width = layout.panel.w;
+    let panel_top = panel_y + layout.panel.h;
+    let stats = overlay_stats(info, state, filtered_count);
+
+    canvas.rect(
+        panel_x,
+        panel_y,
+        panel_width,
+        layout.panel.h,
+        Color::from_rgba8(8, 12, 18, 220),
+    );
+    canvas.rect(
+        panel_x,
+        panel_top - 30.0,
+        panel_width,
+        30.0,
+        Color::from_rgba8(18, 28, 42, 240),
+    );
+
+    let title_y = panel_top - padding;
+    canvas.text(
+        panel_x + padding,
+        title_y,
+        "DEBUG OVERLAY",
+        OVERLAY_TITLE_SIZE,
+        Color::from_rgba8(122, 214, 255, 255),
+    );
+    canvas.text(
+        panel_x + panel_width - 210.0,
+        title_y,
+        "click chips | F4 console | F5 clear",
+        OVERLAY_HINT_SIZE,
+        Color::from_rgba8(146, 163, 186, 255),
+    );
+
+    for button in &layout.buttons {
+        let hovered = mouse_position.is_some_and(|pointer| button.rect.contains(pointer));
+        let fill = overlay_button_fill(button, hovered);
+        let text_color = overlay_button_text_color(button, hovered);
+        canvas.rect(button.rect.x, button.rect.y, button.rect.w, button.rect.h, fill);
+        canvas.text(
+            button.rect.x + OVERLAY_BUTTON_PADDING_X,
+            button.rect.y + OVERLAY_BUTTON_HEIGHT - 5.0,
+            &button.label,
+            OVERLAY_BUTTON_TEXT_SIZE,
+            text_color,
+        );
+    }
+
+    let mut y = layout.stats_y;
+    for stat in stats {
+        canvas.text(
+            panel_x + padding,
+            y,
+            &stat,
+            OVERLAY_BODY_SIZE,
+            Color::from_rgba8(218, 224, 236, 255),
+        );
+        y -= body_line_height;
+    }
+
+    if state.input_mode == DebugTextInputMode::TargetFilter {
+        y -= 4.0;
+        canvas.text(
+            panel_x + padding,
+            y,
+            &format!(
+                "Target filter> {}_{}",
+                state.target_filter_buffer(),
+                format_preedit_suffix(state.preedit())
+            ),
+            OVERLAY_BODY_SIZE,
+            Color::from_rgba8(188, 222, 255, 255),
+        );
+        y -= body_line_height;
+    }
+
+    y -= 4.0;
+    canvas.text(
+        panel_x + padding,
+        y,
+        &format!(
+            "Recent logs ({filtered_count} filtered / {} total / {} capacity)",
+            log_count(),
+            log_capacity()
+        ),
+        OVERLAY_BODY_SIZE,
+        Color::from_rgba8(146, 163, 186, 255),
+    );
+
+    y -= body_line_height;
+    if logs.is_empty() {
+        canvas.text(
+            panel_x + padding,
+            y,
+            "No log entries captured for the current filters.",
+            OVERLAY_BODY_SIZE,
+            Color::from_rgba8(146, 163, 186, 255),
+        );
+        y -= body_line_height + 6.0;
+    } else {
+        let max_chars = (((panel_width - padding * 2.0) / 6.1).floor() as usize).max(24);
+        for entry in logs.iter().rev() {
+            let line = truncate_chars(&format_overlay_entry(entry), max_chars);
+            canvas.text(
+                panel_x + padding,
+                y,
+                &line,
+                OVERLAY_BODY_SIZE,
+                entry.level.color(),
+            );
+            y -= body_line_height;
+        }
+    }
+
+    y -= 2.0;
+    canvas.text(
+        panel_x + padding,
+        y,
+        "Mouse wheel scrolls logs | F6 follow | F7 severity | F8 target",
+        OVERLAY_HINT_SIZE,
+        Color::from_rgba8(146, 163, 186, 255),
+    );
+    y -= hint_line_height;
+    canvas.text(
+        panel_x + padding,
+        y,
+        "PgUp/PgDn/Home/End still work. Console commands feed back into this log buffer.",
+        OVERLAY_HINT_SIZE,
+        Color::from_rgba8(122, 132, 148, 255),
+    );
+}
+
+pub fn draw_console(canvas: &mut Canvas, state: &DebugUiState) {
+    if !state.console_open() {
+        return;
+    }
+
+    let panel = console_panel_rect(canvas.screen_size());
+    let padding = 10.0;
+    let body_size = 12.0;
+    let hint_size = 10.0;
+    let line_height = debug_line_height(body_size);
+
+    canvas.rect(
+        panel.x,
+        panel.y,
+        panel.w,
+        panel.h,
+        Color::from_rgba8(10, 14, 22, 238),
+    );
+    canvas.rect(
+        panel.x,
+        panel.y + panel.h - 26.0,
+        panel.w,
+        26.0,
+        Color::from_rgba8(20, 30, 46, 244),
+    );
+
+    canvas.text(
+        panel.x + padding,
+        panel.y + 18.0,
+        "Developer Console",
+        13.0,
+        Color::from_rgba8(122, 214, 255, 255),
+    );
+    canvas.text(
+        panel.x + padding,
+        panel.y + 32.0,
+        "Examples: state | level warn | target renderer | hot_reload toggle | clear",
+        hint_size,
+        Color::from_rgba8(146, 163, 186, 255),
+    );
+
+    let prompt = format!(
+        "> {}_{}",
+        state.console_buffer(),
+        format_preedit_suffix(state.preedit())
+    );
+    canvas.text(
+        panel.x + padding,
+        panel.y + panel.h - 8.0,
+        &prompt,
+        body_size,
+        Color::from_rgba8(230, 236, 245, 255),
+    );
+    canvas.text(
+        panel.x + padding,
+        panel.y + panel.h - 8.0 - line_height - 4.0,
+        "Enter run | Up/Down history | Esc close | click overlay chips for mouse controls",
+        hint_size,
+        Color::from_rgba8(156, 168, 188, 255),
+    );
+}
+
+fn build_overlay_buttons(
+    state: &DebugUiState,
+    left: f32,
+    right: f32,
+    top: f32,
+) -> Vec<OverlayButtonLayout> {
+    let specs = overlay_button_specs(state);
+    let mut buttons = Vec::with_capacity(specs.len());
+    let mut cursor_x = left;
+    let mut row = 0usize;
+
+    for (action, label, active) in specs {
+        let width = overlay_button_width(&label);
+        if cursor_x > left && cursor_x + width > right {
+            row += 1;
+            cursor_x = left;
+        }
+
+        let rect = DebugRect {
+            x: cursor_x,
+            y: top - OVERLAY_BUTTON_HEIGHT - row as f32 * (OVERLAY_BUTTON_HEIGHT + OVERLAY_BUTTON_GAP),
+            w: width,
+            h: OVERLAY_BUTTON_HEIGHT,
+        };
+        buttons.push(OverlayButtonLayout {
+            rect,
+            action,
+            label,
+            active,
+            row,
+        });
+        cursor_x += width + OVERLAY_BUTTON_GAP;
+    }
+
+    buttons
+}
+
+fn overlay_button_specs(state: &DebugUiState) -> Vec<(OverlayButtonAction, String, bool)> {
+    let target_label = if state.input_mode == DebugTextInputMode::TargetFilter {
+        "target: apply".to_string()
+    } else if state.target_filter().is_empty() {
+        "target: *".to_string()
+    } else {
+        format!("target: {}", truncate_chars(state.target_filter(), 12))
+    };
+
+    vec![
+        (OverlayButtonAction::Clear, "clear logs".to_string(), false),
+        (
+            OverlayButtonAction::ToggleConsole,
+            format!("console: {}", if state.console_open() { "open" } else { "closed" }),
+            state.console_open(),
+        ),
+        (
+            OverlayButtonAction::ToggleFollow,
+            format!("follow: {}", if state.follow_logs() { "live" } else { "paused" }),
+            state.follow_logs(),
+        ),
+        (
+            OverlayButtonAction::CycleSeverity,
+            format!("level: {}", state.severity_filter().label()),
+            state.severity_filter() != DebugSeverityFilter::All,
+        ),
+        (
+            OverlayButtonAction::EditTargetFilter,
+            target_label,
+            state.input_mode == DebugTextInputMode::TargetFilter || !state.target_filter().is_empty(),
+        ),
+    ]
+}
+
+fn overlay_button_width(label: &str) -> f32 {
+    (approx_text_width(label, OVERLAY_BUTTON_TEXT_SIZE) + OVERLAY_BUTTON_PADDING_X * 2.0)
+        .max(OVERLAY_BUTTON_MIN_WIDTH)
+}
+
+fn overlay_button_fill(button: &OverlayButtonLayout, hovered: bool) -> Color {
+    match button.action {
+        OverlayButtonAction::Clear => {
+            if hovered {
+                Color::from_rgba8(98, 36, 42, 244)
+            } else {
+                Color::from_rgba8(74, 28, 34, 232)
+            }
+        }
+        _ if button.active && hovered => Color::from_rgba8(44, 84, 122, 244),
+        _ if button.active => Color::from_rgba8(34, 66, 98, 236),
+        _ if hovered => Color::from_rgba8(34, 42, 58, 236),
+        _ => Color::from_rgba8(22, 28, 38, 228),
+    }
+}
+
+fn overlay_button_text_color(button: &OverlayButtonLayout, hovered: bool) -> Color {
+    match button.action {
+        OverlayButtonAction::Clear => {
+            if hovered {
+                Color::from_rgba8(255, 220, 220, 255)
+            } else {
+                Color::from_rgba8(248, 196, 196, 255)
+            }
+        }
+        _ if button.active => Color::from_rgba8(236, 242, 250, 255),
+        _ if hovered => Color::from_rgba8(220, 228, 240, 255),
+        _ => Color::from_rgba8(176, 188, 206, 255),
+    }
+}
+
+fn console_panel_rect(screen_size: (u32, u32)) -> DebugRect {
+    let hw = screen_size.0 as f32 / 2.0;
+    let hh = screen_size.1 as f32 / 2.0;
+    DebugRect {
+        x: -hw + 8.0,
+        y: -hh + 8.0,
+        w: screen_size.0 as f32 - 16.0,
+        h: CONSOLE_PANEL_HEIGHT,
+    }
+}
+
+fn debug_line_height(size: f32) -> f32 {
+    size * 1.35
+}
+
+fn approx_text_width(text: &str, size: f32) -> f32 {
+    text.chars().count() as f32 * size * 0.58
+}
+
+fn overlay_stats(
+    info: &DebugOverlayInfo<'_>,
+    state: &DebugUiState,
+    filtered_count: usize,
+) -> Vec<String> {
+    let mut lines = Vec::with_capacity(5);
+    lines.push(format!(
+        "{} | {:.0} FPS | {:.2} ms | frame {} | {:.1}s",
+        info.mode,
+        info.fps,
+        info.dt * 1000.0,
+        info.frame_count,
+        info.total_time,
+    ));
+    lines.push(format!(
+        "window {}x{} | game {}x{} | hot reload {}",
+        info.window_size.0,
+        info.window_size.1,
+        info.game_size.0,
+        info.game_size.1,
+        if info.hot_reload_enabled { "on" } else { "off" },
+    ));
+    lines.push(format!(
+        "level {} | target {} | follow {} | scroll {} | visible {}",
+        state.severity_filter().label(),
+        if state.target_filter().is_empty() {
+            "*"
+        } else {
+            state.target_filter()
+        },
+        if state.follow_logs() { "live" } else { "paused" },
+        state.scroll_offset(),
+        filtered_count,
+    ));
+
+    if let Some(gamepads) = info.gamepads_connected {
+        lines.push(format!("gamepads connected {} | F3 toggles overlay", gamepads));
+    } else if let Some(mouse_captured) = info.mouse_captured {
+        lines.push(format!(
+            "mouse captured {} | F3 toggles overlay",
+            if mouse_captured { "yes" } else { "no" }
+        ));
+    } else {
+        lines.push("F3 toggles overlay".to_string());
+    }
+
+    lines
+}
+
+fn format_overlay_entry(entry: &DebugLogEntry) -> String {
+    format!(
+        "{:>5.1}s {:<5} {:<18} {}",
+        entry.seconds,
+        entry.level.label(),
+        compact_target(&entry.target),
+        entry.message,
+    )
+}
+
+fn compact_target(target: &str) -> String {
+    let mut parts = target.rsplit("::");
+    match (parts.next(), parts.next()) {
+        (Some(last), Some(prev)) => format!("{}::{}", prev, last),
+        (Some(last), None) => last.to_string(),
+        _ => "log".to_string(),
+    }
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+
+    let mut out: String = text.chars().take(max_chars.saturating_sub(3)).collect();
+    out.push_str("...");
+    out
+}
+
+fn non_empty(text: &str) -> Option<&str> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn parse_echo_command(rest: &str, level: DebugLogLevel) -> Result<DebugCommand, String> {
+    let message = rest.trim();
+    if message.is_empty() {
+        Err("message cannot be empty".into())
+    } else {
+        Ok(DebugCommand::Echo(level, message.to_string()))
+    }
+}
+
+fn format_preedit_suffix(preedit: Option<(&str, Option<(usize, usize)>)>) -> String {
+    match preedit {
+        Some((text, _)) => format!(" [{text}]"),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_discards_oldest_entries() {
+        let mut buffer = DebugLogBuffer::new(2);
+        buffer.push_entry(DebugLogEntry {
+            index: 0,
+            seconds: 0.1,
+            level: DebugLogLevel::Info,
+            target: "alpha".into(),
+            message: "one".into(),
+        });
+        buffer.push_entry(DebugLogEntry {
+            index: 0,
+            seconds: 0.2,
+            level: DebugLogLevel::Warn,
+            target: "beta".into(),
+            message: "two".into(),
+        });
+        buffer.push_entry(DebugLogEntry {
+            index: 0,
+            seconds: 0.3,
+            level: DebugLogLevel::Error,
+            target: "gamma".into(),
+            message: "three".into(),
+        });
+
+        let recent = buffer.recent(10);
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].message, "two");
+        assert_eq!(recent[1].message, "three");
+        assert_eq!(recent[0].index, 1);
+        assert_eq!(recent[1].index, 2);
+    }
+
+    #[test]
+    fn compact_target_keeps_last_segments() {
+        assert_eq!(compact_target("rengine::renderer::mod"), "renderer::mod");
+        assert_eq!(compact_target("gameplay"), "gameplay");
+    }
+
+    #[test]
+    fn truncate_chars_adds_ellipsis() {
+        assert_eq!(truncate_chars("abcdef", 6), "abcdef");
+        assert_eq!(truncate_chars("abcdefgh", 6), "abc...");
+    }
+
+    #[test]
+    fn parse_debug_commands() {
+        assert_eq!(parse_command("help").unwrap(), DebugCommand::Help);
+        assert_eq!(
+            parse_command("level warn").unwrap(),
+            DebugCommand::Level(DebugSeverityFilter::Warn)
+        );
+        assert_eq!(
+            parse_command("target renderer").unwrap(),
+            DebugCommand::Target(Some("renderer".into()))
+        );
+        assert_eq!(parse_command("target clear").unwrap(), DebugCommand::Target(None));
+    }
+
+    #[test]
+    fn severity_filter_blocks_lower_levels() {
+        assert!(DebugSeverityFilter::Warn.allows(DebugLogLevel::Warn));
+        assert!(DebugSeverityFilter::Warn.allows(DebugLogLevel::Error));
+        assert!(!DebugSeverityFilter::Warn.allows(DebugLogLevel::Info));
+    }
+
+    #[test]
+    fn console_submit_queues_command() {
+        let mut state = DebugUiState::new(true);
+        state.set_console_open(true);
+        state.handle_committed_text("state");
+        state.submit_text_input();
+
+        let commands = state.drain_pending_commands();
+        assert_eq!(commands, vec!["state"]);
+    }
+
+    #[test]
+    fn mouse_click_clear_button_clears_logs() {
+        {
+            let mut buffer = log_buffer()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            buffer.clear();
+            buffer.push_entry(DebugLogEntry {
+                index: 0,
+                seconds: 0.1,
+                level: DebugLogLevel::Info,
+                target: "debug".into(),
+                message: "entry".into(),
+            });
+        }
+
+        let mut state = DebugUiState::new(true);
+        let clear_button = state
+            .overlay_layout((800, 600))
+            .buttons
+            .into_iter()
+            .find(|button| button.action == OverlayButtonAction::Clear)
+            .unwrap();
+        let pointer = (
+            clear_button.rect.x + clear_button.rect.w * 0.5,
+            clear_button.rect.y + clear_button.rect.h * 0.5,
+        );
+
+        assert!(state.handle_mouse_button((800, 600), pointer, 0, ElementState::Pressed));
+        assert!(state.handle_mouse_button((800, 600), pointer, 0, ElementState::Released));
+        assert_eq!(log_count(), 0);
+    }
+
+    #[test]
+    fn mouse_click_level_button_cycles_severity() {
+        let mut state = DebugUiState::new(true);
+        let level_button = state
+            .overlay_layout((800, 600))
+            .buttons
+            .into_iter()
+            .find(|button| button.action == OverlayButtonAction::CycleSeverity)
+            .unwrap();
+        let pointer = (
+            level_button.rect.x + level_button.rect.w * 0.5,
+            level_button.rect.y + level_button.rect.h * 0.5,
+        );
+
+        assert_eq!(state.severity_filter(), DebugSeverityFilter::All);
+        assert!(state.handle_mouse_button((800, 600), pointer, 0, ElementState::Pressed));
+        assert!(state.handle_mouse_button((800, 600), pointer, 0, ElementState::Released));
+        assert_eq!(state.severity_filter(), DebugSeverityFilter::Debug);
+    }
+}

--- a/engine/src/debug.rs
+++ b/engine/src/debug.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, Once, OnceLock};
 use std::time::Instant;
 
@@ -455,9 +456,23 @@ impl DebugUiState {
         true
     }
 
-    pub fn handle_scroll(&mut self, dy: f32) -> bool {
-        if !self.overlay_visible || self.is_text_input_active() || dy.abs() < f32::EPSILON {
+    pub fn handle_scroll(
+        &mut self,
+        screen_size: (u32, u32),
+        pointer: (f32, f32),
+        dy: f32,
+    ) -> bool {
+        if !self.overlay_visible || dy.abs() < f32::EPSILON {
             return false;
+        }
+
+        let pointer_over_debug = self.pointer_hits_overlay(screen_size, pointer)
+            || self.pointer_hits_console(screen_size, pointer);
+        if !pointer_over_debug {
+            return self.is_text_input_active();
+        }
+        if self.is_text_input_active() {
+            return true;
         }
 
         let amount = dy.abs().ceil() as usize;
@@ -661,7 +676,7 @@ impl DebugUiState {
     }
 
     fn filtered_snapshot(&self) -> Vec<DebugLogEntry> {
-        let filter = self.target_filter.to_ascii_lowercase();
+        let filter = self.target_filter.trim();
         snapshot_logs()
             .into_iter()
             .filter(|entry| self.severity_filter.allows(entry.level))
@@ -670,8 +685,8 @@ impl DebugUiState {
                     return true;
                 }
 
-                entry.target.to_ascii_lowercase().contains(&filter)
-                    || entry.message.to_ascii_lowercase().contains(&filter)
+                contains_ascii_case_insensitive(&entry.target, filter)
+                    || contains_ascii_case_insensitive(&entry.message, filter)
             })
             .collect()
     }
@@ -883,7 +898,6 @@ impl DebugLogBuffer {
 
 struct CombinedLogger {
     inner: env_logger::Logger,
-    start: Instant,
 }
 
 impl log::Log for CombinedLogger {
@@ -901,7 +915,7 @@ impl log::Log for CombinedLogger {
         let mut buffer = log_buffer()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        buffer.push_record(self.start.elapsed().as_secs_f32(), record);
+        buffer.push_record(log_start().elapsed().as_secs_f32(), record);
     }
 
     fn flush(&self) {
@@ -910,14 +924,21 @@ impl log::Log for CombinedLogger {
 }
 
 static LOGGER_INIT: Once = Once::new();
+static LOGGER_CAPTURE_ACTIVE: AtomicBool = AtomicBool::new(false);
 static LOG_BUFFER: OnceLock<Mutex<DebugLogBuffer>> = OnceLock::new();
+static LOG_START: OnceLock<Instant> = OnceLock::new();
 
 fn log_buffer() -> &'static Mutex<DebugLogBuffer> {
     LOG_BUFFER.get_or_init(|| Mutex::new(DebugLogBuffer::new(DEFAULT_LOG_CAPACITY)))
 }
 
+fn log_start() -> &'static Instant {
+    LOG_START.get_or_init(Instant::now)
+}
+
 pub fn init_logging() {
     log_buffer();
+    log_start();
 
     LOGGER_INIT.call_once(|| {
         let mut builder = env_logger::Builder::from_default_env();
@@ -925,13 +946,17 @@ pub fn init_logging() {
 
         let inner = builder.build();
         let max_level = inner.filter();
-        let logger = CombinedLogger {
-            inner,
-            start: Instant::now(),
-        };
+        let logger = CombinedLogger { inner };
 
-        let _ = log::set_boxed_logger(Box::new(logger));
-        log::set_max_level(max_level);
+        match log::set_boxed_logger(Box::new(logger)) {
+            Ok(()) => {
+                LOGGER_CAPTURE_ACTIVE.store(true, Ordering::Relaxed);
+                log::set_max_level(max_level);
+            }
+            Err(err) => {
+                eprintln!("failed to initialize debug logger: {err}");
+            }
+        }
     });
 }
 
@@ -979,6 +1004,19 @@ pub fn set_log_capacity(capacity: usize) {
 
 pub fn log_message(level: DebugLogLevel, target: &str, message: &str) {
     init_logging();
+
+    if !LOGGER_CAPTURE_ACTIVE.load(Ordering::Relaxed) {
+        let mut buffer = log_buffer()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        buffer.push_entry(DebugLogEntry {
+            index: 0,
+            seconds: log_start().elapsed().as_secs_f32(),
+            level,
+            target: target.to_string(),
+            message: message.to_string(),
+        });
+    }
 
     match level {
         DebugLogLevel::Trace => log::trace!(target: target, "{message}"),
@@ -1390,6 +1428,18 @@ fn approx_text_width(text: &str, size: f32) -> f32 {
     text.chars().count() as f32 * size * 0.58
 }
 
+fn contains_ascii_case_insensitive(haystack: &str, needle: &str) -> bool {
+    let needle_bytes = needle.as_bytes();
+    if needle_bytes.is_empty() {
+        return true;
+    }
+
+    haystack
+        .as_bytes()
+        .windows(needle_bytes.len())
+        .any(|window| window.eq_ignore_ascii_case(needle_bytes))
+}
+
 fn overlay_stats(
     info: &DebugOverlayInfo<'_>,
     state: &DebugUiState,
@@ -1625,5 +1675,44 @@ mod tests {
         assert!(state.handle_mouse_button((800, 600), pointer, 0, ElementState::Pressed));
         assert!(state.handle_mouse_button((800, 600), pointer, 0, ElementState::Released));
         assert_eq!(state.severity_filter(), DebugSeverityFilter::Debug);
+    }
+
+    #[test]
+    fn target_filter_matches_case_insensitively_without_lowercasing_entries() {
+        {
+            let mut buffer = log_buffer()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            buffer.clear();
+            buffer.push_entry(DebugLogEntry {
+                index: 0,
+                seconds: 0.1,
+                level: DebugLogLevel::Info,
+                target: "Renderer::Mesh".into(),
+                message: "Frame Presented".into(),
+            });
+        }
+
+        let mut state = DebugUiState::new(true);
+        state.set_target_filter("renderER");
+
+        let (logs, filtered_count) = state.filtered_logs(10);
+        assert_eq!(filtered_count, 1);
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].target, "Renderer::Mesh");
+    }
+
+    #[test]
+    fn scroll_only_consumes_when_pointer_is_over_debug_ui_or_text_input_is_active() {
+        let mut state = DebugUiState::new(true);
+        let layout = state.overlay_layout((800, 600));
+        let inside_overlay = (layout.panel.x + 12.0, layout.panel.y + 12.0);
+        let outside_overlay = (380.0, -280.0);
+
+        assert!(!state.handle_scroll((800, 600), outside_overlay, 1.0));
+        assert!(state.handle_scroll((800, 600), inside_overlay, 1.0));
+
+        state.begin_target_filter_edit();
+        assert!(state.handle_scroll((800, 600), outside_overlay, 1.0));
     }
 }

--- a/engine/src/debug.rs
+++ b/engine/src/debug.rs
@@ -697,7 +697,7 @@ impl DebugUiState {
     }
 
     fn handle_left_mouse_press(&mut self, screen_size: (u32, u32), pointer: (f32, f32)) {
-        let layout = self.overlay_layout(screen_size);
+        let layout = self.overlay_layout(screen_size, self.filtered_log_count());
         for button in layout.buttons {
             if button.rect.contains(pointer) {
                 match button.action {
@@ -722,14 +722,18 @@ impl DebugUiState {
     }
 
     fn pointer_hits_overlay(&self, screen_size: (u32, u32), pointer: (f32, f32)) -> bool {
-        self.overlay_visible && self.overlay_layout(screen_size).panel.contains(pointer)
+        self.overlay_visible
+            && self
+                .overlay_layout(screen_size, self.filtered_log_count())
+                .panel
+                .contains(pointer)
     }
 
     fn pointer_hits_console(&self, screen_size: (u32, u32), pointer: (f32, f32)) -> bool {
         self.console_open && console_panel_rect(screen_size).contains(pointer)
     }
 
-    fn overlay_layout(&self, screen_size: (u32, u32)) -> OverlayLayout {
+    fn overlay_layout(&self, screen_size: (u32, u32), visible_log_count: usize) -> OverlayLayout {
         let hw = screen_size.0 as f32 / 2.0;
         let hh = screen_size.1 as f32 / 2.0;
         let padding = 10.0;
@@ -740,7 +744,7 @@ impl DebugUiState {
         let title_line_height = debug_line_height(OVERLAY_TITLE_SIZE);
         let body_line_height = debug_line_height(OVERLAY_BODY_SIZE);
         let hint_line_height = debug_line_height(OVERLAY_HINT_SIZE);
-        let visible_log_lines = self.filtered_logs(self.visible_log_limit()).0.len().max(1);
+        let visible_log_lines = visible_log_count.max(1);
 
         let buttons = build_overlay_buttons(
             self,
@@ -1104,7 +1108,7 @@ pub fn draw_overlay(
     let padding = 10.0;
     let body_line_height = debug_line_height(OVERLAY_BODY_SIZE);
     let hint_line_height = debug_line_height(OVERLAY_HINT_SIZE);
-    let layout = state.overlay_layout(screen_size);
+    let layout = state.overlay_layout(screen_size, logs.len());
     let panel_x = layout.panel.x;
     let panel_y = layout.panel.y;
     let panel_width = layout.panel.w;
@@ -1642,7 +1646,7 @@ mod tests {
 
         let mut state = DebugUiState::new(true);
         let clear_button = state
-            .overlay_layout((800, 600))
+            .overlay_layout((800, 600), state.filtered_log_count())
             .buttons
             .into_iter()
             .find(|button| button.action == OverlayButtonAction::Clear)
@@ -1661,7 +1665,7 @@ mod tests {
     fn mouse_click_level_button_cycles_severity() {
         let mut state = DebugUiState::new(true);
         let level_button = state
-            .overlay_layout((800, 600))
+            .overlay_layout((800, 600), state.filtered_log_count())
             .buttons
             .into_iter()
             .find(|button| button.action == OverlayButtonAction::CycleSeverity)
@@ -1705,7 +1709,7 @@ mod tests {
     #[test]
     fn scroll_only_consumes_when_pointer_is_over_debug_ui_or_text_input_is_active() {
         let mut state = DebugUiState::new(true);
-        let layout = state.overlay_layout((800, 600));
+        let layout = state.overlay_layout((800, 600), state.filtered_log_count());
         let inside_overlay = (layout.panel.x + 12.0, layout.panel.y + 12.0);
         let outside_overlay = (380.0, -280.0);
 

--- a/engine/src/debug.rs
+++ b/engine/src/debug.rs
@@ -201,7 +201,7 @@ pub struct DebugUiState {
     console_buffer: String,
     preedit: Option<(String, Option<(usize, usize)>)>,
     scroll_offset: usize,
-    command_history: Vec<String>,
+    command_history: VecDeque<String>,
     history_index: Option<usize>,
     pending_commands: VecDeque<String>,
     input_mode: DebugTextInputMode,
@@ -220,7 +220,7 @@ impl DebugUiState {
             console_buffer: String::new(),
             preedit: None,
             scroll_offset: 0,
-            command_history: Vec::new(),
+            command_history: VecDeque::new(),
             history_index: None,
             pending_commands: VecDeque::new(),
             input_mode: DebugTextInputMode::None,
@@ -421,10 +421,7 @@ impl DebugUiState {
         }
 
         for ch in text.chars() {
-            if ch == '\u{7f}' || (ch.is_control() && ch != '\n' && ch != '\t') {
-                continue;
-            }
-            if ch == '\r' || ch == '\n' || ch == '\t' {
+            if ch.is_control() {
                 continue;
             }
             self.active_buffer_mut().push(ch);
@@ -610,14 +607,14 @@ impl DebugUiState {
             DebugTextInputMode::Console => {
                 let command = self.console_buffer.trim().to_string();
                 if !command.is_empty() {
-                    let should_push = match self.command_history.last() {
+                    let should_push = match self.command_history.back() {
                         Some(last) => last != &command,
                         None => true,
                     };
                     if should_push {
-                        self.command_history.push(command.clone());
+                        self.command_history.push_back(command.clone());
                         if self.command_history.len() > MAX_COMMAND_HISTORY {
-                            self.command_history.remove(0);
+                            self.command_history.pop_front();
                         }
                     }
                     self.pending_commands.push_back(command);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -4,6 +4,7 @@ pub mod math;
 pub mod input;
 
 pub mod canvas;
+pub mod debug;
 pub mod particle;
 pub mod renderer;
 pub mod renderer3d;
@@ -23,6 +24,7 @@ pub use app::run;
 pub use app::run_with_scenes;
 pub use app::{Engine, EngineConfig, Game, ScaleMode};
 pub use assets::Color;
+pub use debug::{DebugLogEntry, DebugLogLevel};
 pub use input::InputState;
 pub use input::{ActionMap, AxisMapping, Binding, GamepadAxis};
 pub use math::Rect;


### PR DESCRIPTION
## Summary
Add a shared in-game debugging surface for the engine, including a log-backed overlay, developer console, and mouse-accessible overlay controls.

## What changed
- add a new `engine::debug` module with a ring-buffer logger, overlay rendering, console rendering, command parsing, and focused tests
- wire `Engine` and `Engine3D` to a shared `DebugUiState` and route keyboard, IME, wheel, and mouse input through it before gameplay input
- expose engine-level helpers for showing the overlay, clearing logs, and writing trace/debug/info/warn/error messages
- support runtime controls for follow mode, severity filtering, target filtering, hot reload toggling, and console commands
- add mouse-clickable overlay chips so the debug controls are usable without keyboard-only shortcuts

## Validation
- `cargo test -p rengine`
- `cargo check --workspace`
