### PR TITLE
Runtime scene world (SceneWorld2D)

### DIFF
--- a/ROADMAP_ENGINE.md
+++ b/ROADMAP_ENGINE.md
@@ -33,6 +33,7 @@ What still matters most on the engine side is closing the remaining runtime gaps
 - scene-script host scaffolding now includes targeted dispatch helpers (by script path/editor name) and binding lookups for scene-authored event routing
 - Scene2D now exposes typed scalar/tag parsing helpers plus direct lookup helpers by editor node id, editor name, and conventional tags
 - headless 2D runs can now render their final frame and optionally capture it to an RGBA screenshot artifact for smoke coverage
+- a mutable runtime scene graph (`SceneWorld2D`) now sits over the immutable `Scene2D` render data: live nodes addressed by stable generational `NodeHandle2D`s, built from a loaded scene with hierarchy reconstructed from editor node/parent ids, with spawn/despawn/reparent, name/id/tag/prefab lookups, composed parent transforms, and visibility-aware drawing
 
 ## Runtime Priorities
 
@@ -103,6 +104,7 @@ What still matters most on the engine side is closing the remaining runtime gaps
    - Status: In progress (scene binding helpers, SceneScript2D registry/host scaffolding, targeted event routing, binding lookups, and Scene2D editor-name/id/tag lookup helpers are landed; remaining work is broader runtime ergonomics and higher-level scripting workflows).
 1. Stabilize runtime serialization, IDs, and dependency tracking so the editor has trustworthy data contracts.
 2. Add a stronger object or component model that scenes and scripts can target consistently.
+   - Status: In progress (`SceneWorld2D` runtime graph with generational node handles is landed; next is giving scripts a context that hands them `&mut SceneWorld2D` so behavior can mutate live nodes, then engine-owned hit-testing/input routing).
 3. Finish the missing 3D transform and material basics so imported content stops being fragile.
 4. Deepen 2D content workflows with better physics and tilemap authoring support.
 5. Add async asset loading and stronger diagnostics so larger projects do not stall on the main thread.

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -52,10 +52,10 @@ pub use assets::{
 
 pub use canvas::{screen_to_ndc, wrap_text, Canvas, CanvasVertex, TextAlign};
 pub use scene::{
-    Globals, Prefab2D, Prefab2DDef, PrefabSprite2D, PrefabSprite2DDef, Scene, Scene2D, Scene2DDef,
-    SceneInstance2D, SceneInstance2DDef, SceneOp, SceneScript2D, SceneScriptBinding2D,
-    SceneScriptEvent2D, SceneScriptHost2D, SceneScriptInputEvent2D, SceneScriptRegistry2D,
-    Transition,
+    Globals, NodeHandle2D, Prefab2D, Prefab2DDef, PrefabSprite2D, PrefabSprite2DDef, Scene,
+    Scene2D, Scene2DDef, SceneInstance2D, SceneInstance2DDef, SceneNode2D, SceneOp, SceneScript2D,
+    SceneScriptBinding2D, SceneScriptEvent2D, SceneScriptHost2D, SceneScriptInputEvent2D,
+    SceneScriptRegistry2D, SceneWorld2D, Transform2D, Transition,
 };
 pub use text::FontAtlas;
 pub use text::FontId;

--- a/engine/src/scene/data2d.rs
+++ b/engine/src/scene/data2d.rs
@@ -137,6 +137,14 @@ impl SceneInstance2D {
             .filter(|value| !value.is_empty())
     }
 
+    /// Compiled sprite layers for this instance.
+    ///
+    /// Exposed to sibling scene modules (such as the runtime [`SceneWorld2D`])
+    /// so live nodes can reuse the same render data the static scene draws.
+    pub(crate) fn sprite_layers(&self) -> &[PrefabSprite2D] {
+        &self.sprites
+    }
+
     pub fn draw(&self, frame: &mut Frame) {
         for sprite in &self.sprites {
             frame.draw_sprite(
@@ -321,7 +329,7 @@ fn default_scale() -> [f32; 2] {
     [1.0, 1.0]
 }
 
-fn parse_bool_property(value: &str) -> Option<bool> {
+pub(crate) fn parse_bool_property(value: &str) -> Option<bool> {
     match value.trim().to_ascii_lowercase().as_str() {
         "true" | "1" | "yes" | "on" => Some(true),
         "false" | "0" | "no" | "off" => Some(false),

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -1,6 +1,7 @@
 mod data2d;
 mod globals;
 mod script2d;
+mod world2d;
 
 pub use data2d::{
     Prefab2D, Prefab2DDef, PrefabSprite2D, PrefabSprite2DDef, Scene2D, Scene2DDef, SceneInstance2D,
@@ -12,6 +13,7 @@ pub use script2d::{
     SceneScript2D, SceneScriptEvent2D, SceneScriptHost2D, SceneScriptInputEvent2D,
     SceneScriptRegistry2D,
 };
+pub use world2d::{NodeHandle2D, SceneNode2D, SceneWorld2D, Transform2D};
 
 use crate::app::{Engine, Engine3D};
 use crate::assets::Color;

--- a/engine/src/scene/world2d.rs
+++ b/engine/src/scene/world2d.rs
@@ -1,0 +1,824 @@
+//! Mutable runtime scene graph for 2D games.
+//!
+//! [`Scene2D`] is intentionally immutable render data: it is what the asset
+//! pipeline loads and what the static [`Scene2D::draw`] path renders. That is
+//! the right contract for passive content, but it cannot express *gameplay* —
+//! scripts have no way to move, hide, retag, spawn, or despawn nodes at runtime.
+//!
+//! [`SceneWorld2D`] closes that gap. It is built from a loaded [`Scene2D`] and
+//! owns a live, mutable node graph addressed through stable generational
+//! [`NodeHandle2D`]s. Handles survive despawns safely: once a node is removed,
+//! any handle pointing at its slot is permanently invalidated, so stale handles
+//! resolve to `None` instead of silently aliasing a different node.
+//!
+//! This is the foundation the script host builds on: a script can hold a
+//! handle across frames and mutate the node it refers to without re-parsing
+//! string property maps every tick.
+
+use std::collections::HashMap;
+
+use crate::renderer::{DrawParams, Frame};
+use crate::Vec2;
+
+use super::data2d::{parse_bool_property, PrefabSprite2D, Scene2D};
+
+/// A stable reference to a node inside a [`SceneWorld2D`].
+///
+/// Handles are generational: each slot tracks a generation counter that is
+/// bumped on despawn, so a handle from a previous occupant never resolves to a
+/// newer node that reused the same slot. Handles are cheap `Copy` values safe
+/// to store in script state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NodeHandle2D {
+    index: u32,
+    generation: u32,
+}
+
+/// Local transform of a node: position, rotation (radians), and scale.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Transform2D {
+    pub position: Vec2,
+    pub rotation: f32,
+    pub scale: Vec2,
+}
+
+impl Default for Transform2D {
+    fn default() -> Self {
+        Self {
+            position: Vec2::ZERO,
+            rotation: 0.0,
+            scale: Vec2::ONE,
+        }
+    }
+}
+
+impl Transform2D {
+    pub fn from_position(position: Vec2) -> Self {
+        Self {
+            position,
+            ..Self::default()
+        }
+    }
+
+    /// Compose `self` (parent) with a child's local transform, producing the
+    /// child's transform in the parent's space.
+    fn compose(&self, child: &Transform2D) -> Transform2D {
+        Transform2D {
+            position: self.position + rotate_vec(child.position * self.scale, self.rotation),
+            rotation: self.rotation + child.rotation,
+            scale: self.scale * child.scale,
+        }
+    }
+}
+
+/// A single live node in the runtime scene graph.
+///
+/// A node carries authoring identity (name, source prefab, script path, editor
+/// ids), mutable runtime state (transform, visibility, tags, properties),
+/// optional sprite layers used for rendering, and hierarchy links.
+#[derive(Debug, Clone)]
+pub struct SceneNode2D {
+    name: Option<String>,
+    prefab: String,
+    script_path: Option<String>,
+    editor_node_id: Option<u64>,
+    transform: Transform2D,
+    visible: bool,
+    tags: Vec<String>,
+    properties: HashMap<String, String>,
+    sprites: Vec<PrefabSprite2D>,
+    parent: Option<NodeHandle2D>,
+    children: Vec<NodeHandle2D>,
+}
+
+impl SceneNode2D {
+    /// Create a bare logical node with no sprites, useful for spawn points,
+    /// markers, and script-driven entities.
+    pub fn new(prefab: impl Into<String>) -> Self {
+        Self {
+            name: None,
+            prefab: prefab.into(),
+            script_path: None,
+            editor_node_id: None,
+            transform: Transform2D::default(),
+            visible: true,
+            tags: Vec::new(),
+            properties: HashMap::new(),
+            sprites: Vec::new(),
+            parent: None,
+            children: Vec::new(),
+        }
+    }
+
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub fn with_transform(mut self, transform: Transform2D) -> Self {
+        self.transform = transform;
+        self
+    }
+
+    pub fn with_position(mut self, position: Vec2) -> Self {
+        self.transform.position = position;
+        self
+    }
+
+    pub fn with_sprites(mut self, sprites: Vec<PrefabSprite2D>) -> Self {
+        self.sprites = sprites;
+        self
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    pub fn prefab(&self) -> &str {
+        &self.prefab
+    }
+
+    pub fn script_path(&self) -> Option<&str> {
+        self.script_path.as_deref()
+    }
+
+    pub fn editor_node_id(&self) -> Option<u64> {
+        self.editor_node_id
+    }
+
+    pub fn transform(&self) -> Transform2D {
+        self.transform
+    }
+
+    pub fn transform_mut(&mut self) -> &mut Transform2D {
+        &mut self.transform
+    }
+
+    pub fn position(&self) -> Vec2 {
+        self.transform.position
+    }
+
+    pub fn set_position(&mut self, position: Vec2) {
+        self.transform.position = position;
+    }
+
+    pub fn translate(&mut self, delta: Vec2) {
+        self.transform.position += delta;
+    }
+
+    pub fn rotation(&self) -> f32 {
+        self.transform.rotation
+    }
+
+    pub fn set_rotation(&mut self, radians: f32) {
+        self.transform.rotation = radians;
+    }
+
+    pub fn scale(&self) -> Vec2 {
+        self.transform.scale
+    }
+
+    pub fn set_scale(&mut self, scale: Vec2) {
+        self.transform.scale = scale;
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    pub fn set_visible(&mut self, visible: bool) {
+        self.visible = visible;
+    }
+
+    pub fn tags(&self) -> &[String] {
+        &self.tags
+    }
+
+    pub fn has_tag(&self, tag: &str) -> bool {
+        self.tags.iter().any(|item| item == tag)
+    }
+
+    pub fn add_tag(&mut self, tag: impl Into<String>) {
+        let tag = tag.into();
+        if !self.tags.iter().any(|item| item == &tag) {
+            self.tags.push(tag);
+        }
+    }
+
+    pub fn remove_tag(&mut self, tag: &str) -> bool {
+        let before = self.tags.len();
+        self.tags.retain(|item| item != tag);
+        self.tags.len() != before
+    }
+
+    pub fn sprites(&self) -> &[PrefabSprite2D] {
+        &self.sprites
+    }
+
+    pub fn set_sprites(&mut self, sprites: Vec<PrefabSprite2D>) {
+        self.sprites = sprites;
+    }
+
+    pub fn parent(&self) -> Option<NodeHandle2D> {
+        self.parent
+    }
+
+    pub fn children(&self) -> &[NodeHandle2D] {
+        &self.children
+    }
+
+    pub fn property(&self, name: &str) -> Option<&str> {
+        self.properties.get(name).map(String::as_str)
+    }
+
+    pub fn property_bool(&self, name: &str) -> Option<bool> {
+        self.property(name).and_then(parse_bool_property)
+    }
+
+    pub fn property_i64(&self, name: &str) -> Option<i64> {
+        self.property(name).and_then(|value| value.parse().ok())
+    }
+
+    pub fn property_u64(&self, name: &str) -> Option<u64> {
+        self.property(name).and_then(|value| value.parse().ok())
+    }
+
+    pub fn property_f32(&self, name: &str) -> Option<f32> {
+        self.property(name).and_then(|value| value.parse().ok())
+    }
+
+    pub fn set_property(&mut self, name: impl Into<String>, value: impl Into<String>) {
+        self.properties.insert(name.into(), value.into());
+    }
+
+    pub fn remove_property(&mut self, name: &str) -> Option<String> {
+        self.properties.remove(name)
+    }
+
+    pub fn properties(&self) -> &HashMap<String, String> {
+        &self.properties
+    }
+}
+
+struct Slot {
+    generation: u32,
+    node: Option<SceneNode2D>,
+}
+
+/// A mutable, hierarchical runtime scene graph addressed by [`NodeHandle2D`].
+///
+/// Build one from a loaded scene with [`SceneWorld2D::from_scene`], then look
+/// nodes up by handle, name, editor id, tag, or prefab and mutate them in
+/// place. Spawning and despawning preserve handle safety through generational
+/// slots, and [`SceneWorld2D::draw`] renders the live state (respecting
+/// visibility and composed parent transforms).
+#[derive(Default)]
+pub struct SceneWorld2D {
+    slots: Vec<Slot>,
+    free: Vec<u32>,
+    roots: Vec<NodeHandle2D>,
+    by_name: HashMap<String, NodeHandle2D>,
+    by_editor_id: HashMap<u64, NodeHandle2D>,
+}
+
+impl SceneWorld2D {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a live world from a loaded [`Scene2D`].
+    ///
+    /// Hierarchy is reconstructed from each instance's editor node/parent ids:
+    /// an instance whose `editor_parent_id` resolves to another instance in the
+    /// scene becomes that node's child, otherwise it is a root. Instances
+    /// without an editor id are always roots (nothing can reference them as a
+    /// parent). Transform, visibility, tags, and sprite layers are seeded from
+    /// the instance so the world renders identically to the static scene until
+    /// gameplay mutates it.
+    pub fn from_scene(scene: &Scene2D) -> Self {
+        let instances = scene.instances();
+        let mut world = SceneWorld2D::new();
+
+        // First pass: spawn every instance as a detached node and remember the
+        // handle for each editor node id so the second pass can wire parents.
+        let mut handles = Vec::with_capacity(instances.len());
+        let mut handle_by_editor_id: HashMap<u64, NodeHandle2D> = HashMap::new();
+
+        for instance in instances {
+            let mut node = SceneNode2D::new(instance.prefab.clone());
+            node.name = instance.editor_name().map(str::to_string);
+            node.script_path = instance.script_path().map(str::to_string);
+            node.editor_node_id = instance.editor_node_id();
+            node.transform = Transform2D {
+                position: instance.position,
+                rotation: instance.property_f32("rotation").unwrap_or(0.0),
+                scale: instance.scale,
+            };
+            node.visible = instance.editor_visible().unwrap_or(true);
+            node.tags = instance
+                .property_tags("tags")
+                .into_iter()
+                .map(str::to_string)
+                .collect();
+            node.properties = instance.properties.clone();
+            node.sprites = instance.sprite_layers().to_vec();
+
+            let handle = world.insert_detached(node);
+            handles.push(handle);
+            if let Some(editor_id) = instance.editor_node_id() {
+                handle_by_editor_id.insert(editor_id, handle);
+            }
+        }
+
+        // Second pass: attach each node to its parent (if present) or to the
+        // root set, and populate the name/editor-id lookup tables.
+        for (instance, handle) in instances.iter().zip(handles.iter().copied()) {
+            let parent = instance
+                .editor_parent_id()
+                .and_then(|parent_id| handle_by_editor_id.get(&parent_id).copied());
+
+            match parent {
+                Some(parent_handle) if parent_handle != handle => {
+                    world.set_parent_link(handle, Some(parent_handle));
+                }
+                _ => world.roots.push(handle),
+            }
+
+            let name = world
+                .get(handle)
+                .and_then(|node| node.name().map(str::to_string));
+            let editor_id = world.get(handle).and_then(|node| node.editor_node_id());
+            if let Some(name) = name {
+                world.by_name.entry(name).or_insert(handle);
+            }
+            if let Some(editor_id) = editor_id {
+                world.by_editor_id.entry(editor_id).or_insert(handle);
+            }
+        }
+
+        world
+    }
+
+    /// Spawn a new node as a root and return its handle.
+    pub fn spawn(&mut self, node: SceneNode2D) -> NodeHandle2D {
+        let name = node.name().map(str::to_string);
+        let editor_id = node.editor_node_id();
+        let handle = self.insert_detached(node);
+        self.roots.push(handle);
+        if let Some(name) = name {
+            self.by_name.entry(name).or_insert(handle);
+        }
+        if let Some(editor_id) = editor_id {
+            self.by_editor_id.entry(editor_id).or_insert(handle);
+        }
+        handle
+    }
+
+    /// Spawn a new node as a child of `parent` and return its handle. If
+    /// `parent` is stale the node is spawned as a root instead.
+    pub fn spawn_child(&mut self, parent: NodeHandle2D, node: SceneNode2D) -> NodeHandle2D {
+        let handle = self.spawn(node);
+        self.reparent(handle, Some(parent));
+        handle
+    }
+
+    /// Remove a node and its entire subtree. All handles into the removed
+    /// subtree become permanently invalid.
+    pub fn despawn(&mut self, handle: NodeHandle2D) -> bool {
+        if !self.contains(handle) {
+            return false;
+        }
+
+        // Detach from parent / root set first so we do not leave dangling links.
+        self.unlink_from_parent(handle);
+        self.roots.retain(|root| *root != handle);
+
+        self.despawn_subtree(handle);
+        true
+    }
+
+    fn despawn_subtree(&mut self, handle: NodeHandle2D) {
+        let children = match self.get(handle) {
+            Some(node) => node.children.clone(),
+            None => return,
+        };
+        for child in children {
+            self.despawn_subtree(child);
+        }
+
+        if let Some(slot) = self.slots.get_mut(handle.index as usize) {
+            if slot.generation == handle.generation {
+                if let Some(node) = slot.node.take() {
+                    if let Some(name) = node.name {
+                        if self.by_name.get(&name) == Some(&handle) {
+                            self.by_name.remove(&name);
+                        }
+                    }
+                    if let Some(editor_id) = node.editor_node_id {
+                        if self.by_editor_id.get(&editor_id) == Some(&handle) {
+                            self.by_editor_id.remove(&editor_id);
+                        }
+                    }
+                }
+                slot.generation = slot.generation.wrapping_add(1);
+                self.free.push(handle.index);
+            }
+        }
+    }
+
+    pub fn contains(&self, handle: NodeHandle2D) -> bool {
+        self.slots
+            .get(handle.index as usize)
+            .is_some_and(|slot| slot.generation == handle.generation && slot.node.is_some())
+    }
+
+    pub fn get(&self, handle: NodeHandle2D) -> Option<&SceneNode2D> {
+        let slot = self.slots.get(handle.index as usize)?;
+        if slot.generation != handle.generation {
+            return None;
+        }
+        slot.node.as_ref()
+    }
+
+    pub fn get_mut(&mut self, handle: NodeHandle2D) -> Option<&mut SceneNode2D> {
+        let slot = self.slots.get_mut(handle.index as usize)?;
+        if slot.generation != handle.generation {
+            return None;
+        }
+        slot.node.as_mut()
+    }
+
+    pub fn len(&self) -> usize {
+        self.slots.iter().filter(|slot| slot.node.is_some()).count()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn roots(&self) -> &[NodeHandle2D] {
+        &self.roots
+    }
+
+    pub fn parent(&self, handle: NodeHandle2D) -> Option<NodeHandle2D> {
+        self.get(handle).and_then(|node| node.parent)
+    }
+
+    pub fn children(&self, handle: NodeHandle2D) -> Vec<NodeHandle2D> {
+        self.get(handle)
+            .map(|node| node.children.clone())
+            .unwrap_or_default()
+    }
+
+    /// Iterate over every live node handle in the world (unordered).
+    pub fn handles(&self) -> impl Iterator<Item = NodeHandle2D> + '_ {
+        self.slots.iter().enumerate().filter_map(|(index, slot)| {
+            slot.node.as_ref().map(|_| NodeHandle2D {
+                index: index as u32,
+                generation: slot.generation,
+            })
+        })
+    }
+
+    pub fn find_by_name(&self, name: &str) -> Option<NodeHandle2D> {
+        self.by_name.get(name).copied()
+    }
+
+    pub fn find_by_editor_id(&self, editor_node_id: u64) -> Option<NodeHandle2D> {
+        self.by_editor_id.get(&editor_node_id).copied()
+    }
+
+    pub fn by_tag(&self, tag: &str) -> Vec<NodeHandle2D> {
+        self.handles()
+            .filter(|handle| self.get(*handle).is_some_and(|node| node.has_tag(tag)))
+            .collect()
+    }
+
+    pub fn by_prefab(&self, prefab: &str) -> Vec<NodeHandle2D> {
+        self.handles()
+            .filter(|handle| {
+                self.get(*handle)
+                    .is_some_and(|node| node.prefab() == prefab)
+            })
+            .collect()
+    }
+
+    /// Move a node under a new parent (or to the root set when `new_parent` is
+    /// `None`). No-ops if either handle is stale, if the move is a self-parent,
+    /// or if it would create a cycle (parenting a node under its own descendant).
+    pub fn reparent(&mut self, handle: NodeHandle2D, new_parent: Option<NodeHandle2D>) -> bool {
+        if !self.contains(handle) {
+            return false;
+        }
+        if let Some(parent) = new_parent {
+            if parent == handle || !self.contains(parent) || self.is_descendant(parent, handle) {
+                return false;
+            }
+        }
+
+        self.unlink_from_parent(handle);
+        self.roots.retain(|root| *root != handle);
+
+        match new_parent {
+            Some(parent) => self.set_parent_link(handle, Some(parent)),
+            None => {
+                self.set_parent_link(handle, None);
+                self.roots.push(handle);
+            }
+        }
+        true
+    }
+
+    /// The fully composed world transform of a node, folding in every ancestor.
+    pub fn world_transform(&self, handle: NodeHandle2D) -> Option<Transform2D> {
+        let node = self.get(handle)?;
+        match node.parent {
+            Some(parent) => {
+                let parent_transform = self.world_transform(parent)?;
+                Some(parent_transform.compose(&node.transform))
+            }
+            None => Some(node.transform),
+        }
+    }
+
+    /// Draw every visible node, parents before children, composing parent
+    /// transforms. An invisible node hides its whole subtree.
+    pub fn draw(&self, frame: &mut Frame) {
+        let roots = self.roots.clone();
+        for root in roots {
+            self.draw_node(root, &Transform2D::default(), frame);
+        }
+    }
+
+    fn draw_node(&self, handle: NodeHandle2D, parent_world: &Transform2D, frame: &mut Frame) {
+        let Some(node) = self.get(handle) else {
+            return;
+        };
+        if !node.visible {
+            return;
+        }
+
+        let world = parent_world.compose(&node.transform);
+        for sprite in &node.sprites {
+            let offset = rotate_vec(sprite.offset * world.scale, world.rotation);
+            frame.draw_sprite(
+                DrawParams::new(
+                    sprite.texture,
+                    world.position + offset,
+                    sprite.size * world.scale,
+                )
+                .with_color(sprite.color)
+                .with_uv_rect(sprite.uv_rect)
+                .with_flip_x(sprite.flip_x)
+                .with_flip_y(sprite.flip_y)
+                .with_rotation(world.rotation),
+            );
+        }
+
+        let children = node.children.clone();
+        for child in children {
+            self.draw_node(child, &world, frame);
+        }
+    }
+
+    // --- internal helpers -------------------------------------------------
+
+    fn insert_detached(&mut self, node: SceneNode2D) -> NodeHandle2D {
+        if let Some(index) = self.free.pop() {
+            let slot = &mut self.slots[index as usize];
+            slot.node = Some(node);
+            NodeHandle2D {
+                index,
+                generation: slot.generation,
+            }
+        } else {
+            let index = self.slots.len() as u32;
+            self.slots.push(Slot {
+                generation: 0,
+                node: Some(node),
+            });
+            NodeHandle2D {
+                index,
+                generation: 0,
+            }
+        }
+    }
+
+    /// Set a node's parent link and add it to the parent's child list. Does not
+    /// touch the root set; callers manage that around the link change.
+    fn set_parent_link(&mut self, handle: NodeHandle2D, parent: Option<NodeHandle2D>) {
+        if let Some(node) = self.get_mut(handle) {
+            node.parent = parent;
+        }
+        if let Some(parent) = parent {
+            if let Some(parent_node) = self.get_mut(parent) {
+                if !parent_node.children.contains(&handle) {
+                    parent_node.children.push(handle);
+                }
+            }
+        }
+    }
+
+    fn unlink_from_parent(&mut self, handle: NodeHandle2D) {
+        let parent = self.get(handle).and_then(|node| node.parent);
+        if let Some(parent) = parent {
+            if let Some(parent_node) = self.get_mut(parent) {
+                parent_node.children.retain(|child| *child != handle);
+            }
+        }
+        if let Some(node) = self.get_mut(handle) {
+            node.parent = None;
+        }
+    }
+
+    fn is_descendant(&self, maybe_descendant: NodeHandle2D, ancestor: NodeHandle2D) -> bool {
+        let mut current = self.parent(maybe_descendant);
+        while let Some(node) = current {
+            if node == ancestor {
+                return true;
+            }
+            current = self.parent(node);
+        }
+        false
+    }
+}
+
+fn rotate_vec(v: Vec2, radians: f32) -> Vec2 {
+    if radians == 0.0 {
+        return v;
+    }
+    let (sin, cos) = radians.sin_cos();
+    Vec2::new(v.x * cos - v.y * sin, v.x * sin + v.y * cos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assets::AssetPack;
+    use crate::scene::{Prefab2DDef, Scene2D, Scene2DDef, SceneInstance2DDef};
+    use std::path::Path;
+
+    fn props(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn spawn_get_and_mutate_roundtrip() {
+        let mut world = SceneWorld2D::new();
+        let handle = world.spawn(
+            SceneNode2D::new("player")
+                .with_name("hero")
+                .with_position(Vec2::new(10.0, 20.0)),
+        );
+
+        assert_eq!(world.len(), 1);
+        assert_eq!(world.get(handle).unwrap().position(), Vec2::new(10.0, 20.0));
+
+        world
+            .get_mut(handle)
+            .unwrap()
+            .translate(Vec2::new(5.0, -5.0));
+        assert_eq!(world.get(handle).unwrap().position(), Vec2::new(15.0, 15.0));
+
+        assert_eq!(world.find_by_name("hero"), Some(handle));
+    }
+
+    #[test]
+    fn despawn_invalidates_handle_and_reuses_slot_safely() {
+        let mut world = SceneWorld2D::new();
+        let first = world.spawn(SceneNode2D::new("a"));
+        assert!(world.contains(first));
+
+        assert!(world.despawn(first));
+        assert!(!world.contains(first));
+        assert!(world.get(first).is_none());
+
+        // The freed slot is reused, but the new handle's generation differs so
+        // the old handle stays invalid (no aliasing).
+        let second = world.spawn(SceneNode2D::new("b"));
+        assert_eq!(first.index, second.index);
+        assert_ne!(first.generation, second.generation);
+        assert!(world.contains(second));
+        assert!(!world.contains(first));
+    }
+
+    #[test]
+    fn despawn_removes_entire_subtree() {
+        let mut world = SceneWorld2D::new();
+        let root = world.spawn(SceneNode2D::new("root"));
+        let child = world.spawn_child(root, SceneNode2D::new("child"));
+        let grandchild = world.spawn_child(child, SceneNode2D::new("grandchild"));
+
+        assert_eq!(world.len(), 3);
+        assert!(world.despawn(root));
+        assert_eq!(world.len(), 0);
+        assert!(!world.contains(child));
+        assert!(!world.contains(grandchild));
+        assert!(world.roots().is_empty());
+    }
+
+    #[test]
+    fn reparent_updates_links_and_rejects_cycles() {
+        let mut world = SceneWorld2D::new();
+        let a = world.spawn(SceneNode2D::new("a"));
+        let b = world.spawn(SceneNode2D::new("b"));
+
+        assert!(world.reparent(b, Some(a)));
+        assert_eq!(world.parent(b), Some(a));
+        assert_eq!(world.children(a), vec![b]);
+        assert_eq!(world.roots(), &[a]);
+
+        // Parenting an ancestor under its descendant must be rejected.
+        assert!(!world.reparent(a, Some(b)));
+        // Self-parenting must be rejected.
+        assert!(!world.reparent(a, Some(a)));
+
+        // Moving back to root restores the root set.
+        assert!(world.reparent(b, None));
+        assert_eq!(world.parent(b), None);
+        assert!(world.children(a).is_empty());
+    }
+
+    #[test]
+    fn world_transform_composes_parent_chain() {
+        let mut world = SceneWorld2D::new();
+        let parent = world.spawn(SceneNode2D::new("parent").with_transform(Transform2D {
+            position: Vec2::new(100.0, 0.0),
+            rotation: std::f32::consts::FRAC_PI_2,
+            scale: Vec2::splat(2.0),
+        }));
+        let child = world.spawn_child(
+            parent,
+            SceneNode2D::new("child").with_position(Vec2::new(10.0, 0.0)),
+        );
+
+        let world_t = world.world_transform(child).unwrap();
+        // Child local (10,0) scaled by 2 -> (20,0), rotated 90deg -> (0,20),
+        // offset by parent position (100,0) -> (100,20).
+        assert!((world_t.position.x - 100.0).abs() < 1e-3);
+        assert!((world_t.position.y - 20.0).abs() < 1e-3);
+        assert!((world_t.scale.x - 2.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn from_scene_reconstructs_hierarchy_and_lookups() {
+        let definition = Scene2DDef {
+            // An empty sprite list keeps this a pure data test: no texture
+            // assets are required, so the world's hierarchy/lookup logic can be
+            // exercised without standing up the GPU asset pipeline.
+            prefabs: vec![Prefab2DDef {
+                name: "marker".to_string(),
+                sprites: vec![],
+            }],
+            instances: vec![
+                SceneInstance2DDef {
+                    prefab: "marker".to_string(),
+                    position: [0.0, 0.0],
+                    scale: [1.0, 1.0],
+                    properties: props(&[
+                        ("editor_node_id", "1"),
+                        ("editor_name", "root_node"),
+                        ("tags", "spawn, team_a"),
+                    ]),
+                },
+                SceneInstance2DDef {
+                    prefab: "marker".to_string(),
+                    position: [5.0, 5.0],
+                    scale: [1.0, 1.0],
+                    properties: props(&[
+                        ("editor_node_id", "2"),
+                        ("editor_parent_id", "1"),
+                        ("editor_name", "child_node"),
+                        ("script_path", "scripts/child.rs"),
+                    ]),
+                },
+            ],
+        };
+
+        let assets = AssetPack::default();
+        let scene =
+            Scene2D::from_definition(Path::new("test.scene.json"), definition, &assets).unwrap();
+        let world = SceneWorld2D::from_scene(&scene);
+
+        assert_eq!(world.len(), 2);
+        let root = world.find_by_editor_id(1).unwrap();
+        let child = world.find_by_editor_id(2).unwrap();
+
+        assert_eq!(world.roots(), &[root]);
+        assert_eq!(world.parent(child), Some(root));
+        assert_eq!(world.children(root), vec![child]);
+
+        assert_eq!(world.find_by_name("child_node"), Some(child));
+        assert_eq!(
+            world.get(child).unwrap().script_path(),
+            Some("scripts/child.rs")
+        );
+
+        let tagged = world.by_tag("spawn");
+        assert_eq!(tagged, vec![root]);
+        assert!(world.get(root).unwrap().has_tag("team_a"));
+    }
+}


### PR DESCRIPTION
## What

Adds a **mutable runtime scene graph** layered over the immutable `Scene2D` render data — item #1 of the combined backlog and the foundation for all scripted gameplay.

`Scene2D` is intentionally read-only render data, which is right for passive content but means scripts have no way to move, hide, retag, spawn, or despawn nodes at runtime. `SceneWorld2D` closes that gap.

## Highlights

- **`NodeHandle2D`** — stable *generational* handles. Despawn bumps the slot generation, so a stale handle resolves to `None` instead of silently aliasing a recycled node (the safety property scripts need to hold references across frames).
- **`SceneNode2D` / `Transform2D`** — per-node transform (position/rotation/scale), visibility, tags, typed property get/set, and sprite layers.
- **`SceneWorld2D::from_scene`** — rebuilds the hierarchy from editor node/parent ids and seeds transforms/tags/sprites so the live world renders identically to the static scene until gameplay mutates it.
- Operations: `spawn`/`spawn_child`/`despawn` (recursive subtree), `reparent` (rejects self-parent + cycles), lookups by handle/name/editor-id/tag/prefab, composed `world_transform`, and visibility-aware `draw`.
- Small enablers in `data2d.rs`: a `pub(crate)` sprite-layer accessor and exposing the existing bool parser to the sibling module.

## Testing

- 6 new unit tests (handle invalidation/slot reuse, recursive despawn, reparent + cycle rejection, transform composition, `from_scene` hierarchy/lookups).
- Engine suite **82 → 88** passing; `cargo check --workspace` clean; Formula R crate still compiles against the new API.

## Next

Follow-up slice (item #1 → #2): give `SceneScript2D` a context that hands it `&mut SceneWorld2D` so scripts can call this API, then engine-owned hit-testing/input routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)