### PR TITLE
Engine-owned pointer hit-testing and click routing

### DIFF
--- a/ROADMAP_ENGINE.md
+++ b/ROADMAP_ENGINE.md
@@ -35,6 +35,7 @@ What still matters most on the engine side is closing the remaining runtime gaps
 - headless 2D runs can now render their final frame and optionally capture it to an RGBA screenshot artifact for smoke coverage
 - a mutable runtime scene graph (`SceneWorld2D`) now sits over the immutable `Scene2D` render data: live nodes addressed by stable generational `NodeHandle2D`s, built from a loaded scene with hierarchy reconstructed from editor node/parent ids, with spawn/despawn/reparent, name/id/tag/prefab lookups, composed parent transforms, and visibility-aware drawing
 - scene scripts can now mutate that live world: a `SceneScriptContext2D` threads `&mut SceneWorld2D` (plus the script's own node, resolved by editor id/name) through world-aware host dispatch (`enter/update/fixed_update/input/event_world`), with default delegation from the new hooks to the existing binding-only hooks so shipping scripts keep working unchanged
+- the engine now owns pointer hit-testing and input routing: `SceneWorld2D` exposes `node_bounds`/`hit_test`/`hit_test_all` (topmost-first, visibility-aware, bounds from `w`/`h` props or sprite union), and the host can route pointer events to the script on the node under the cursor (`route_input_world`) and turn press/release over the same node into an `activate` event (`route_pointer_click`), removing the duplicated render-vs-input hitbox math games hand-write
 
 ## Runtime Priorities
 
@@ -105,7 +106,7 @@ What still matters most on the engine side is closing the remaining runtime gaps
    - Status: In progress (scene binding helpers, SceneScript2D registry/host scaffolding, targeted event routing, binding lookups, and Scene2D editor-name/id/tag lookup helpers are landed; remaining work is broader runtime ergonomics and higher-level scripting workflows).
 1. Stabilize runtime serialization, IDs, and dependency tracking so the editor has trustworthy data contracts.
 2. Add a stronger object or component model that scenes and scripts can target consistently.
-   - Status: In progress (`SceneWorld2D` runtime graph with generational node handles is landed, and `SceneScriptContext2D` now hands scripts `&mut SceneWorld2D` so behavior can mutate live nodes; next is engine-owned hit-testing/input routing so pointer events resolve to scene/UI nodes without per-game hitbox math).
+   - Status: In progress (`SceneWorld2D` runtime graph with generational node handles, `SceneScriptContext2D` for live-node mutation, and engine-owned pointer hit-testing/click routing are all landed; next is stable IDs + versioned scene/prefab schemas + project-wide validation so the editor has trustworthy data contracts, then richer component/property typing).
 3. Finish the missing 3D transform and material basics so imported content stops being fragile.
 4. Deepen 2D content workflows with better physics and tilemap authoring support.
 5. Add async asset loading and stronger diagnostics so larger projects do not stall on the main thread.

--- a/engine/src/scene/script2d.rs
+++ b/engine/src/scene/script2d.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::{NodeHandle2D, Scene2D, SceneNode2D, SceneScriptBinding2D, SceneWorld2D};
+use crate::Vec2;
 
 pub trait SceneScript2D: Send {
     fn on_attach(&mut self, _binding: &SceneScriptBinding2D) {}
@@ -180,6 +181,7 @@ struct SceneScriptInstance2D {
 pub struct SceneScriptHost2D {
     instances: Vec<SceneScriptInstance2D>,
     warnings: Vec<String>,
+    pressed_node: Option<NodeHandle2D>,
 }
 
 impl SceneScriptHost2D {
@@ -396,6 +398,109 @@ impl SceneScriptHost2D {
                 payload,
             },
         );
+    }
+
+    // --- Pointer hit-test routing -----------------------------------------
+    //
+    // These let the engine own picking: the host resolves the node under the
+    // pointer via `SceneWorld2D::hit_test` and delivers the event only to the
+    // script bound to that node, instead of every game hand-coding hitboxes.
+
+    /// Route a pointer event to the script on the topmost node under the
+    /// pointer. Positional events (`PointerMove`/`PointerButton`) reach only the
+    /// hit node's script; non-positional events fall back to a broadcast.
+    /// Returns the hit node handle, if any.
+    pub fn route_input_world(
+        &mut self,
+        world: &mut SceneWorld2D,
+        event: &SceneScriptInputEvent2D,
+    ) -> Option<NodeHandle2D> {
+        let position = match event {
+            SceneScriptInputEvent2D::PointerMove { position } => *position,
+            SceneScriptInputEvent2D::PointerButton { position, .. } => *position,
+            _ => {
+                self.input_world(world, event);
+                return None;
+            }
+        };
+        let hit = world.hit_test(Vec2::new(position[0], position[1]))?;
+        self.dispatch_input_to_node(world, hit, event);
+        Some(hit)
+    }
+
+    /// Route a pointer button as a click: remember the topmost hit node on
+    /// press, and on release over that same node emit an `activate` event to its
+    /// script (payload `target` = the node's script path, matching
+    /// [`SceneScriptHost2D::emit_activate_script_path`]). Returns the activated
+    /// node handle, if any.
+    pub fn route_pointer_click(
+        &mut self,
+        world: &mut SceneWorld2D,
+        position: [f32; 2],
+        pressed: bool,
+    ) -> Option<NodeHandle2D> {
+        let hit = world.hit_test(Vec2::new(position[0], position[1]));
+        if pressed {
+            self.pressed_node = hit;
+            return None;
+        }
+
+        let pressed_node = self.pressed_node.take();
+        match (pressed_node, hit) {
+            (Some(down), Some(up)) if down == up => {
+                let mut payload = HashMap::new();
+                if let Some(target) = world.get(up).and_then(|node| node.script_path()) {
+                    payload.insert("target".to_string(), target.to_string());
+                }
+                let event = SceneScriptEvent2D::Custom {
+                    topic: "activate".to_string(),
+                    payload,
+                };
+                self.dispatch_event_to_node(world, up, &event);
+                Some(up)
+            }
+            _ => None,
+        }
+    }
+
+    fn dispatch_input_to_node(
+        &mut self,
+        world: &mut SceneWorld2D,
+        handle: NodeHandle2D,
+        event: &SceneScriptInputEvent2D,
+    ) {
+        let Some(editor_id) = world.get(handle).and_then(|node| node.editor_node_id()) else {
+            return;
+        };
+        for instance in &mut self.instances {
+            if instance.binding.editor_node_id != Some(editor_id) {
+                continue;
+            }
+            let binding = &instance.binding;
+            let script = &mut instance.script;
+            let mut ctx = SceneScriptContext2D::new(&mut *world, binding);
+            script.on_input_world(&mut ctx, event);
+        }
+    }
+
+    fn dispatch_event_to_node(
+        &mut self,
+        world: &mut SceneWorld2D,
+        handle: NodeHandle2D,
+        event: &SceneScriptEvent2D,
+    ) {
+        let Some(editor_id) = world.get(handle).and_then(|node| node.editor_node_id()) else {
+            return;
+        };
+        for instance in &mut self.instances {
+            if instance.binding.editor_node_id != Some(editor_id) {
+                continue;
+            }
+            let binding = &instance.binding;
+            let script = &mut instance.script;
+            let mut ctx = SceneScriptContext2D::new(&mut *world, binding);
+            script.on_event_world(&mut ctx, event);
+        }
     }
 
     pub fn detach_all(&mut self) {
@@ -636,5 +741,98 @@ mod tests {
         );
 
         assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn pointer_click_routes_activate_to_clicked_node_only() {
+        use crate::scene::{Prefab2DDef, Scene2DDef, SceneInstance2DDef};
+        use std::sync::Mutex;
+
+        struct ClickScript {
+            log: Arc<Mutex<Vec<String>>>,
+        }
+        impl SceneScript2D for ClickScript {
+            fn on_event_world(
+                &mut self,
+                ctx: &mut SceneScriptContext2D,
+                event: &SceneScriptEvent2D,
+            ) {
+                let SceneScriptEvent2D::Custom { topic, .. } = event;
+                if topic == "activate" {
+                    if let Some(name) = ctx.binding().editor_name.clone() {
+                        self.log.lock().unwrap().push(name);
+                    }
+                }
+            }
+        }
+
+        fn button(name: &str, id: u64, x: f32) -> SceneInstance2DDef {
+            SceneInstance2DDef {
+                prefab: "btn".to_string(),
+                position: [x, 0.0],
+                scale: [1.0, 1.0],
+                properties: [
+                    ("editor_node_id", id.to_string()),
+                    ("editor_name", name.to_string()),
+                    ("script_path", "scripts/btn.rs".to_string()),
+                    ("w", "100".to_string()),
+                    ("h", "100".to_string()),
+                ]
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+            }
+        }
+
+        let definition = Scene2DDef {
+            prefabs: vec![Prefab2DDef {
+                name: "btn".to_string(),
+                sprites: vec![],
+            }],
+            instances: vec![button("start_btn", 1, 0.0), button("quit_btn", 2, 200.0)],
+        };
+        let scene = Scene2D::from_definition(
+            std::path::Path::new("t.scene.json"),
+            definition,
+            &crate::assets::AssetPack::default(),
+        )
+        .unwrap();
+        let mut world = SceneWorld2D::from_scene(&scene);
+
+        let log = Arc::new(Mutex::new(Vec::<String>::new()));
+        let factory_log = log.clone();
+        let mut registry = SceneScriptRegistry2D::new();
+        registry.register("scripts/btn.rs", move || {
+            Box::new(ClickScript {
+                log: factory_log.clone(),
+            })
+        });
+        let mut host = SceneScriptHost2D::new();
+        host.attach_scene(&scene, &registry);
+
+        // Press + release over start_btn activates it.
+        assert_eq!(
+            host.route_pointer_click(&mut world, [50.0, 50.0], true),
+            None
+        );
+        let activated = host.route_pointer_click(&mut world, [50.0, 50.0], false);
+        assert_eq!(
+            activated.and_then(|h| world.get(h)?.editor_node_id()),
+            Some(1)
+        );
+
+        // Press + release over quit_btn activates it.
+        host.route_pointer_click(&mut world, [250.0, 50.0], true);
+        host.route_pointer_click(&mut world, [250.0, 50.0], false);
+
+        // Press on start but release on quit activates neither.
+        host.route_pointer_click(&mut world, [50.0, 50.0], true);
+        assert_eq!(
+            host.route_pointer_click(&mut world, [250.0, 50.0], false),
+            None
+        );
+
+        let log = log.lock().unwrap();
+        assert_eq!(*log, vec!["start_btn".to_string(), "quit_btn".to_string()]);
     }
 }

--- a/engine/src/scene/world2d.rs
+++ b/engine/src/scene/world2d.rs
@@ -18,7 +18,7 @@
 use std::collections::HashMap;
 
 use crate::renderer::{DrawParams, Frame};
-use crate::Vec2;
+use crate::{Rect, Vec2};
 
 use super::data2d::{parse_bool_property, PrefabSprite2D, Scene2D};
 
@@ -541,6 +541,81 @@ impl SceneWorld2D {
         }
     }
 
+    /// Axis-aligned world-space bounds used for pointer hit-testing.
+    ///
+    /// Prefers an explicit interactive size from the node's `w`/`h` properties
+    /// (how editor-authored UI/markers carry their box), falling back to the
+    /// union of the node's sprite layers. Returns `None` for nodes with no
+    /// pickable area. Rotation is not yet folded into the hit rect — the bounds
+    /// are the node's axis-aligned extent at its composed world position/scale.
+    pub fn node_bounds(&self, handle: NodeHandle2D) -> Option<Rect> {
+        let node = self.get(handle)?;
+        let world = self.world_transform(handle)?;
+
+        if let (Some(w), Some(h)) = (node.property_f32("w"), node.property_f32("h")) {
+            let size = Vec2::new(w, h) * world.scale;
+            return Some(Rect::from_pos_size(world.position, size));
+        }
+
+        let sprites = node.sprites();
+        if sprites.is_empty() {
+            return None;
+        }
+        let mut min = Vec2::splat(f32::MAX);
+        let mut max = Vec2::splat(f32::MIN);
+        for sprite in sprites {
+            let a = sprite.offset * world.scale;
+            let b = (sprite.offset + sprite.size) * world.scale;
+            min = min.min(a).min(b);
+            max = max.max(a).max(b);
+        }
+        Some(Rect::from_pos_size(world.position + min, max - min))
+    }
+
+    /// Visible nodes in draw order (parents before children, siblings in order),
+    /// skipping invisible subtrees — the same set [`SceneWorld2D::draw`] emits.
+    pub fn visible_draw_order(&self) -> Vec<NodeHandle2D> {
+        let mut out = Vec::new();
+        for root in self.roots.clone() {
+            self.collect_visible(root, &mut out);
+        }
+        out
+    }
+
+    fn collect_visible(&self, handle: NodeHandle2D, out: &mut Vec<NodeHandle2D>) {
+        let Some(node) = self.get(handle) else {
+            return;
+        };
+        if !node.is_visible() {
+            return;
+        }
+        out.push(handle);
+        for child in node.children().to_vec() {
+            self.collect_visible(child, out);
+        }
+    }
+
+    /// Topmost visible node whose bounds contain `point` (in world space).
+    ///
+    /// "Topmost" means last-drawn: children sit above parents and later
+    /// siblings above earlier ones, matching what the player sees.
+    pub fn hit_test(&self, point: Vec2) -> Option<NodeHandle2D> {
+        self.hit_test_all(point).into_iter().next()
+    }
+
+    /// Every visible node whose bounds contain `point`, topmost first.
+    pub fn hit_test_all(&self, point: Vec2) -> Vec<NodeHandle2D> {
+        let mut order = self.visible_draw_order();
+        order.reverse();
+        order
+            .into_iter()
+            .filter(|handle| {
+                self.node_bounds(*handle)
+                    .is_some_and(|rect| rect.contains_point(point))
+            })
+            .collect()
+    }
+
     /// Draw every visible node, parents before children, composing parent
     /// transforms. An invisible node hides its whole subtree.
     pub fn draw(&self, frame: &mut Frame) {
@@ -761,6 +836,40 @@ mod tests {
         assert!((world_t.position.x - 100.0).abs() < 1e-3);
         assert!((world_t.position.y - 20.0).abs() < 1e-3);
         assert!((world_t.scale.x - 2.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn hit_test_picks_topmost_visible_node_in_bounds() {
+        let mut world = SceneWorld2D::new();
+
+        let a = world.spawn(SceneNode2D::new("a").with_position(Vec2::ZERO));
+        {
+            let node = world.get_mut(a).unwrap();
+            node.set_property("w", "100");
+            node.set_property("h", "100");
+        }
+        // `b` is spawned later, so it draws on top of `a` where they overlap.
+        let b = world.spawn(SceneNode2D::new("b").with_position(Vec2::new(50.0, 50.0)));
+        {
+            let node = world.get_mut(b).unwrap();
+            node.set_property("w", "100");
+            node.set_property("h", "100");
+        }
+
+        // Overlap region resolves to the topmost node.
+        assert_eq!(world.hit_test(Vec2::new(75.0, 75.0)), Some(b));
+        // Region only covered by `a`.
+        assert_eq!(world.hit_test(Vec2::new(10.0, 10.0)), Some(a));
+        // Outside everything.
+        assert_eq!(world.hit_test(Vec2::new(500.0, 500.0)), None);
+
+        // Hiding the topmost node falls through to the one beneath it.
+        world.get_mut(b).unwrap().set_visible(false);
+        assert_eq!(world.hit_test(Vec2::new(75.0, 75.0)), Some(a));
+
+        // A node with no sprites and no w/h has no pickable bounds.
+        let empty = world.spawn(SceneNode2D::new("empty").with_position(Vec2::ZERO));
+        assert_eq!(world.node_bounds(empty), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Completes backlog **item #2** (the second half of "engine-owned hit-testing + input/event routing"). Builds on #66 (`SceneWorld2D`) and #67 (`SceneScriptContext2D`).

The engine now resolves the node under the pointer itself, so games stop hand-writing the render-vs-input hitbox math that litters Formula R today.

## `SceneWorld2D`

- **`node_bounds`** — axis-aligned world-space bounds from explicit `w`/`h` properties (how editor-authored UI/markers carry their box) or the union of the node's sprite layers; `None` when there's no pickable area.
- **`visible_draw_order`** — the same visible node set `draw()` emits, in draw order.
- **`hit_test` / `hit_test_all`** — topmost-first picking (children over parents, later siblings over earlier), visibility-aware.

## `SceneScriptHost2D`

- **`route_input_world`** — deliver a pointer event only to the script on the topmost hit node; non-positional events still broadcast.
- **`route_pointer_click`** — press remembers the hit node; release over the *same* node emits an `activate` event (payload `target` = the node's script path, matching `emit_activate_script_path`) to that node's script. This is the zero-hitbox path for scene buttons.

## Testing

- `hit_test_picks_topmost_visible_node_in_bounds` — overlap/topmost, fall-through when the top node is hidden, and empty-bounds nodes.
- `pointer_click_routes_activate_to_clicked_node_only` — clicking start vs quit activates exactly one; press-on-one/release-on-other activates neither.
- Engine suite **90 → 92** passing; clippy clean on the new code; **Formula R compiles unchanged**.

## Notes / next

Rotation isn't folded into hit rects yet (bounds are the axis-aligned extent at world position/scale) — fine for the unrotated UI/marker picking this targets; documented in `node_bounds`. Hover-enter/leave and focus state are a deliberate follow-up. Next backlog item: stable IDs + versioned scene/prefab schemas + project-wide validation (item #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)