### PR TITLE
Project-wide scene validation sweeps

### DIFF
--- a/ROADMAP_ENGINE.md
+++ b/ROADMAP_ENGINE.md
@@ -106,7 +106,7 @@ What still matters most on the engine side is closing the remaining runtime gaps
 0. Land scene binding helpers and script host scaffolding so scene-authored behavior can run without game-specific glue.
    - Status: In progress (scene binding helpers, SceneScript2D registry/host scaffolding, targeted event routing, binding lookups, and Scene2D editor-name/id/tag lookup helpers are landed; remaining work is broader runtime ergonomics and higher-level scripting workflows).
 1. Stabilize runtime serialization, IDs, and dependency tracking so the editor has trustworthy data contracts.
-   - Status: In progress (non-fatal `validate_editor_scene` report + `CURRENT_EDITOR_SCENE_VERSION` schema-version hook are landed; remaining work is wiring validation into the editor panel/pre-boot checks and dependency ("used-by") tracking).
+   - Status: In progress (non-fatal `validate_editor_scene` report, `CURRENT_EDITOR_SCENE_VERSION` schema-version hook, and project-wide `validate_scene_file`/`validate_scene_dir` sweeps are landed; remaining work is surfacing reports in the editor panel and dependency ("used-by") tracking).
 2. Add a stronger object or component model that scenes and scripts can target consistently.
    - Status: In progress (`SceneWorld2D` runtime graph with generational node handles, `SceneScriptContext2D` for live-node mutation, and engine-owned pointer hit-testing/click routing are all landed; next is stable IDs + versioned scene/prefab schemas + project-wide validation so the editor has trustworthy data contracts, then richer component/property typing).
 3. Finish the missing 3D transform and material basics so imported content stops being fragile.

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -52,12 +52,12 @@ pub use assets::{
 
 pub use canvas::{screen_to_ndc, wrap_text, Canvas, CanvasVertex, TextAlign};
 pub use scene::{
-    validate_editor_scene, Globals, NodeHandle2D, Prefab2D, Prefab2DDef, PrefabSprite2D,
-    PrefabSprite2DDef, Scene, Scene2D, Scene2DDef, SceneInstance2D, SceneInstance2DDef,
-    SceneIssueSeverity, SceneNode2D, SceneOp, SceneScript2D, SceneScriptBinding2D,
-    SceneScriptContext2D, SceneScriptEvent2D, SceneScriptHost2D, SceneScriptInputEvent2D,
-    SceneScriptRegistry2D, SceneValidationIssue, SceneValidationReport, SceneWorld2D, Transform2D,
-    Transition, CURRENT_EDITOR_SCENE_VERSION,
+    validate_editor_scene, validate_scene_dir, validate_scene_file, Globals, NodeHandle2D,
+    Prefab2D, Prefab2DDef, PrefabSprite2D, PrefabSprite2DDef, Scene, Scene2D, Scene2DDef,
+    SceneInstance2D, SceneInstance2DDef, SceneIssueSeverity, SceneNode2D, SceneOp, SceneScript2D,
+    SceneScriptBinding2D, SceneScriptContext2D, SceneScriptEvent2D, SceneScriptHost2D,
+    SceneScriptInputEvent2D, SceneScriptRegistry2D, SceneValidationIssue, SceneValidationReport,
+    SceneWorld2D, Transform2D, Transition, CURRENT_EDITOR_SCENE_VERSION,
 };
 pub use text::FontAtlas;
 pub use text::FontId;

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -15,8 +15,8 @@ pub use script2d::{
     SceneScriptInputEvent2D, SceneScriptRegistry2D,
 };
 pub use validation::{
-    validate_editor_scene, SceneIssueSeverity, SceneValidationIssue, SceneValidationReport,
-    CURRENT_EDITOR_SCENE_VERSION,
+    validate_editor_scene, validate_scene_dir, validate_scene_file, SceneIssueSeverity,
+    SceneValidationIssue, SceneValidationReport, CURRENT_EDITOR_SCENE_VERSION,
 };
 pub use world2d::{NodeHandle2D, SceneNode2D, SceneWorld2D, Transform2D};
 

--- a/engine/src/scene/validation.rs
+++ b/engine/src/scene/validation.rs
@@ -16,6 +16,7 @@
 //! [`SceneScriptRegistry2D`] run when those are supplied.
 
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
@@ -240,6 +241,83 @@ pub fn validate_editor_scene(
     report
 }
 
+/// Validate a single scene file on disk, reading and parsing it first.
+///
+/// IO and JSON parse failures are reported as error issues (with no node id)
+/// rather than returned as `Err`, so a project-wide pass can keep going and
+/// report every bad file in one sweep instead of stopping at the first.
+pub fn validate_scene_file(
+    path: &Path,
+    assets: Option<&AssetPack>,
+    registry: Option<&SceneScriptRegistry2D>,
+) -> SceneValidationReport {
+    let mut report = SceneValidationReport::default();
+
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) => {
+            report.push(SceneValidationIssue::error(
+                None,
+                format!("failed to read '{}': {error}", path.display()),
+            ));
+            return report;
+        }
+    };
+
+    let value: serde_json::Value = match serde_json::from_str(&text) {
+        Ok(value) => value,
+        Err(error) => {
+            report.push(SceneValidationIssue::error(
+                None,
+                format!("failed to parse '{}': {error}", path.display()),
+            ));
+            return report;
+        }
+    };
+
+    validate_editor_scene(&value, assets, registry)
+}
+
+/// Validate every `*.scene.json` file under `dir` (recursively), returning one
+/// report per file in sorted path order for stable, diff-friendly output.
+pub fn validate_scene_dir(
+    dir: &Path,
+    assets: Option<&AssetPack>,
+    registry: Option<&SceneScriptRegistry2D>,
+) -> Vec<(PathBuf, SceneValidationReport)> {
+    let mut files = Vec::new();
+    collect_scene_files(dir, &mut files);
+    files.sort();
+    files
+        .into_iter()
+        .map(|path| {
+            let report = validate_scene_file(&path, assets, registry);
+            (path, report)
+        })
+        .collect()
+}
+
+fn collect_scene_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_scene_files(&path, out);
+        } else if is_scene_file(&path) {
+            out.push(path);
+        }
+    }
+}
+
+fn is_scene_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.ends_with(".scene.json"))
+        .unwrap_or(false)
+}
+
 fn validate_parent(
     node: &EditorNode,
     id_to_parent: &HashMap<u64, Option<u64>>,
@@ -400,6 +478,65 @@ mod tests {
         assert!(report
             .warnings()
             .any(|issue| issue.message.contains("has no 'kind'")));
+    }
+
+    #[test]
+    fn validate_missing_scene_file_is_an_error() {
+        let report = validate_scene_file(
+            Path::new("definitely/does/not/exist.scene.json"),
+            None,
+            None,
+        );
+        assert!(report.has_errors());
+    }
+
+    #[test]
+    fn validate_scene_dir_reports_each_scene_file() {
+        use std::fs;
+
+        let base = std::env::temp_dir().join(format!(
+            "rengine_scene_validation_{}_{}",
+            std::process::id(),
+            CURRENT_EDITOR_SCENE_VERSION
+        ));
+        let _ = fs::remove_dir_all(&base);
+        let nested = base.join("ui");
+        fs::create_dir_all(&nested).unwrap();
+
+        let good = base.join("good.scene.json");
+        let bad = nested.join("bad.scene.json");
+        fs::write(
+            &good,
+            serde_json::to_string(&json!({ "nodes": [sprite_node(1, None, "hero")] })).unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &bad,
+            serde_json::to_string(
+                &json!({ "nodes": [sprite_node(1, None, "hero"), sprite_node(1, None, "hero")] }),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        // A non-scene file must be ignored.
+        fs::write(base.join("notes.txt"), "ignore me").unwrap();
+
+        let reports = validate_scene_dir(&base, None, None);
+        assert_eq!(reports.len(), 2, "should find exactly the two scene files");
+
+        let by_name: HashMap<String, &SceneValidationReport> = reports
+            .iter()
+            .map(|(path, report)| {
+                (
+                    path.file_name().unwrap().to_str().unwrap().to_string(),
+                    report,
+                )
+            })
+            .collect();
+        assert!(by_name["good.scene.json"].is_ok());
+        assert!(by_name["bad.scene.json"].has_errors());
+
+        let _ = fs::remove_dir_all(&base);
     }
 
     #[test]


### PR DESCRIPTION
## What

Completes the runtime side of backlog **item #3**. Builds on #69's per-document validator with the "project-wide" half.

- **`validate_scene_file(path, assets, registry)`** — read + parse + validate one scene; IO and JSON parse failures are reported as **error issues** (not `Err`) so a sweep never aborts on a single bad file.
- **`validate_scene_dir(dir, assets, registry)`** — recursively validate every `*.scene.json` under a directory, returning one `(path, report)` per file in **sorted path order** for stable, diff-friendly output. Non-scene files are ignored.

This is the pre-boot / CI / editor "validate the whole project" entry point.

## Testing

- `validate_missing_scene_file_is_an_error`
- `validate_scene_dir_reports_each_scene_file` — writes a clean scene, a nested duplicate-id scene, and a `.txt` to ignore; asserts exactly two reports with the right pass/fail.
- Engine suite **100 → 102**; clippy clean; **Formula R compiles unchanged**.

## Item #3 status

Runtime validation is now complete: per-document report + schema-version hook (#69) and project-wide file/dir sweeps (this PR). Remaining item #3 work is editor-side (surface reports in a validation panel) and dependency ("used-by") tracking — both deferred to their natural homes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)