### PR TITLE
2D AABB mover + kinematic body (first real 2D physics)

### DIFF
--- a/ROADMAP_ENGINE.md
+++ b/ROADMAP_ENGINE.md
@@ -40,6 +40,7 @@ What still matters most on the engine side is closing the remaining runtime gaps
 - a `feature-scene-scripts` sample now demonstrates the scene-driven stack end to end with no hand-coded hitboxes: menu buttons authored as `SceneWorld2D` nodes, picked by `hit_test`, clicked via `route_pointer_click`, with scripts mutating the live world (spawn/despawn) through `SceneScriptContext2D` — and a headless test drives the same wiring as an integration check
 - runtime scene reuse: `SceneWorld2D::instantiate_scene` composes a loaded `Scene2D` into an existing world as a subtree (under an optional parent, with a placement offset, first-wins name/id lookups), and `from_scene` is now a thin wrapper over it — the primitive behind nested scenes and prefab instances
 - data-driven nested scenes: a `SceneLibrary` of named scenes plus `SceneWorld2D::instantiate_scene_tree` recursively expands any node carrying a `nested_scene` alias into that referenced scene as a child subtree, with a per-path cycle guard and a depth cap so reference loops terminate and unknown aliases are skipped
+- first real 2D physics beyond overlap tests: `move_and_collide` resolves an AABB against static solids axis-by-axis (flush, seam-safe contacts) reporting which faces hit, and `KinematicBody2D` integrates gravity + velocity into that mover for a minimal platformer/top-down character controller with ground/wall/ceiling detection
 
 ## Runtime Priorities
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -39,8 +39,9 @@ pub use renderer::{
 
 pub use world::tilemap;
 pub use world::{
-    aabb_overlap, aabb_overlap_layered, iso_to_screen, screen_to_iso, BodyId, CollisionLayer,
-    OverlapEvent, TileDef, TileMap, TriggerSystem, TriggerZone, TriggerZoneId,
+    aabb_overlap, aabb_overlap_layered, iso_to_screen, move_and_collide, screen_to_iso, BodyId,
+    CollisionLayer, Contacts2D, KinematicBody2D, MoveResult2D, OverlapEvent, TileDef, TileMap,
+    TriggerSystem, TriggerZone, TriggerZoneId,
 };
 
 pub use assets::pixelart;

--- a/engine/src/world/mod.rs
+++ b/engine/src/world/mod.rs
@@ -4,6 +4,9 @@ pub mod tilemap;
 pub mod trigger;
 
 pub use iso::{iso_to_screen, screen_to_iso};
-pub use physics::{aabb_overlap, aabb_overlap_layered, CollisionLayer};
+pub use physics::{
+    aabb_overlap, aabb_overlap_layered, move_and_collide, CollisionLayer, Contacts2D,
+    KinematicBody2D, MoveResult2D,
+};
 pub use tilemap::{TileDef, TileMap};
 pub use trigger::{BodyId, OverlapEvent, TriggerSystem, TriggerZone, TriggerZoneId};

--- a/engine/src/world/physics.rs
+++ b/engine/src/world/physics.rs
@@ -72,3 +72,203 @@ pub fn aabb_overlap(a: &Rect, b: &Rect) -> Option<Vec2> {
         Some(Vec2::new(0.0, sign * overlap_y))
     }
 }
+
+/// The faces of a moving body that came into contact with a solid during a
+/// [`move_and_collide`] resolution. Coordinates follow [`Rect`]'s y-up
+/// convention, so `bottom` is a floor/ground contact and `top` a ceiling.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Contacts2D {
+    pub left: bool,
+    pub right: bool,
+    pub top: bool,
+    pub bottom: bool,
+}
+
+impl Contacts2D {
+    pub fn any(&self) -> bool {
+        self.left || self.right || self.top || self.bottom
+    }
+}
+
+/// Result of moving an AABB against a set of static solids.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MoveResult2D {
+    /// The resolved bottom-left position of the body after collision response.
+    pub position: Vec2,
+    pub contacts: Contacts2D,
+}
+
+/// Move an axis-aligned `body` by `motion` against static `solids`, resolving
+/// overlaps axis-by-axis (X then Y) and reporting which faces made contact.
+///
+/// Resolution snaps the body flush against blocking solids using the strict
+/// touching semantics of [`Rect::overlaps`], so sliding along a row of tiles
+/// does not snag on the seams between them. This is the classic AABB platformer
+/// mover; it does not perform swept (time-of-impact) tests, so motion larger
+/// than a solid in a single step can tunnel through it — keep per-step motion
+/// below your smallest solid (or substep) for very fast bodies.
+pub fn move_and_collide(body: Rect, motion: Vec2, solids: &[Rect]) -> MoveResult2D {
+    let mut rect = body;
+    let mut contacts = Contacts2D::default();
+
+    // X axis first.
+    rect.x += motion.x;
+    if motion.x != 0.0 {
+        for solid in solids {
+            if rect.overlaps(solid) {
+                if motion.x > 0.0 {
+                    rect.x = solid.left() - rect.width;
+                    contacts.right = true;
+                } else {
+                    rect.x = solid.right();
+                    contacts.left = true;
+                }
+            }
+        }
+    }
+
+    // Then Y axis (y-up: positive motion moves upward toward ceilings).
+    rect.y += motion.y;
+    if motion.y != 0.0 {
+        for solid in solids {
+            if rect.overlaps(solid) {
+                if motion.y > 0.0 {
+                    rect.y = solid.bottom() - rect.height;
+                    contacts.top = true;
+                } else {
+                    rect.y = solid.top();
+                    contacts.bottom = true;
+                }
+            }
+        }
+    }
+
+    MoveResult2D {
+        position: Vec2::new(rect.x, rect.y),
+        contacts,
+    }
+}
+
+/// A simple kinematic AABB body with gravity, integrated against static solids.
+///
+/// This is the minimal "character controller" primitive for platformers and
+/// top-down games: set [`KinematicBody2D::velocity`] each frame (jump impulses,
+/// horizontal input) and call [`KinematicBody2D::step`] to integrate, resolve
+/// collisions, and learn about ground/wall/ceiling contacts.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KinematicBody2D {
+    pub bounds: Rect,
+    pub velocity: Vec2,
+    pub gravity: Vec2,
+    pub contacts: Contacts2D,
+}
+
+impl KinematicBody2D {
+    /// A body with a default downward gravity (y-up world).
+    pub fn new(bounds: Rect) -> Self {
+        Self {
+            bounds,
+            velocity: Vec2::ZERO,
+            gravity: Vec2::new(0.0, -980.0),
+            contacts: Contacts2D::default(),
+        }
+    }
+
+    pub fn with_gravity(mut self, gravity: Vec2) -> Self {
+        self.gravity = gravity;
+        self
+    }
+
+    pub fn with_velocity(mut self, velocity: Vec2) -> Self {
+        self.velocity = velocity;
+        self
+    }
+
+    /// True when the body's last [`KinematicBody2D::step`] landed on a floor.
+    pub fn on_ground(&self) -> bool {
+        self.contacts.bottom
+    }
+
+    /// Advance one timestep: apply gravity, integrate velocity, resolve against
+    /// `solids`, and zero the velocity components that ran into a solid so the
+    /// body rests (rather than accumulating force) against contacts.
+    pub fn step(&mut self, dt: f32, solids: &[Rect]) {
+        self.velocity += self.gravity * dt;
+        let motion = self.velocity * dt;
+        let result = move_and_collide(self.bounds, motion, solids);
+
+        self.bounds.x = result.position.x;
+        self.bounds.y = result.position.y;
+        self.contacts = result.contacts;
+
+        if result.contacts.left || result.contacts.right {
+            self.velocity.x = 0.0;
+        }
+        if result.contacts.top || result.contacts.bottom {
+            self.velocity.y = 0.0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x: f32, y: f32, w: f32, h: f32) -> Rect {
+        Rect::new(x, y, w, h)
+    }
+
+    #[test]
+    fn move_into_wall_stops_flush_and_reports_contact() {
+        let body = rect(0.0, 0.0, 10.0, 10.0);
+        let wall = rect(15.0, 0.0, 10.0, 100.0);
+
+        let result = move_and_collide(body, Vec2::new(20.0, 0.0), &[wall]);
+
+        assert!(result.contacts.right);
+        assert!(!result.contacts.left);
+        // The body's right edge rests flush against the wall's left edge.
+        assert!((result.position.x + 10.0 - wall.left()).abs() < 1e-3);
+    }
+
+    #[test]
+    fn falling_body_lands_and_rests_on_floor() {
+        let floor = rect(-100.0, 0.0, 200.0, 10.0); // top at y = 10
+        let mut body = KinematicBody2D::new(rect(0.0, 50.0, 10.0, 10.0));
+
+        for _ in 0..240 {
+            body.step(1.0 / 60.0, &[floor]);
+        }
+
+        assert!(body.on_ground());
+        assert!((body.bounds.y - floor.top()).abs() < 1e-2);
+        assert!(body.velocity.y.abs() < 1e-3);
+    }
+
+    #[test]
+    fn rising_body_stops_under_ceiling() {
+        let ceiling = rect(-100.0, 15.0, 200.0, 10.0); // bottom at y = 15
+        let mut body = KinematicBody2D::new(rect(0.0, 0.0, 10.0, 10.0))
+            .with_gravity(Vec2::ZERO)
+            .with_velocity(Vec2::new(0.0, 600.0)); // 10px of motion at 1/60s
+
+        body.step(1.0 / 60.0, &[ceiling]);
+
+        assert!(body.contacts.top);
+        // The body's top edge rests flush against the ceiling's bottom edge.
+        assert!((body.bounds.y + 10.0 - ceiling.bottom()).abs() < 1e-3);
+        assert!(body.velocity.y.abs() < 1e-3);
+    }
+
+    #[test]
+    fn free_fall_without_solids_accelerates_downward() {
+        let mut body = KinematicBody2D::new(rect(0.0, 0.0, 10.0, 10.0));
+        let start_y = body.bounds.y;
+
+        body.step(1.0 / 60.0, &[]);
+
+        assert!(body.bounds.y < start_y);
+        assert!(!body.on_ground());
+        assert!(body.velocity.y < 0.0);
+    }
+}


### PR DESCRIPTION
## What

The engine's 2D physics was just overlap tests (`aabb_overlap`). This adds the platformer/top-down foundation — actually *moving* a body against solids and resting on them — a "2D Production Path" roadmap priority.

- **`move_and_collide(body, motion, solids)`** — axis-by-axis (X then Y) AABB resolution that snaps the body flush against blocking solids using `Rect`'s strict touching semantics (so sliding along a row of tiles doesn't snag on seams), returning **`Contacts2D`** (`left`/`right`/`top`/`bottom`).
- **`KinematicBody2D`** — gravity + velocity integration over that mover; zeroes velocity components on contact so the body rests rather than accumulating force, with `on_ground()` and ceiling/wall detection. The minimal character-controller primitive.

## Notes
- y-up throughout (matches `Rect`): `bottom` contact = floor, `top` = ceiling.
- Documented limitation: not swept (no time-of-impact), so keep per-step motion below the smallest solid — or substep — for very fast bodies.

## Testing

4 tests: move into wall stops flush + reports contact; falling body lands and rests on a floor (velocity zeroed, `on_ground`); rising body stops flush under a ceiling; free fall accelerates downward with no solids.

Engine suite **107 → 111**; clippy clean; **Formula R compiles unchanged**.

## Why this, now

Picked as a headlessly-verifiable engine slice: the game repo currently has uncommitted WIP (so I'm not branching there), and the remaining editor items (play-in-editor, UI docs) aren't autonomously verifiable without a human at a window. This is pure, tested logic that advances "viable usable engine" for action genres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)